### PR TITLE
Don't validate cache items more than once

### DIFF
--- a/spinedb_api/db_cache.py
+++ b/spinedb_api/db_cache.py
@@ -126,6 +126,7 @@ class CacheItem(dict):
         self._to_remove = False
         self._removed = False
         self._corrupted = False
+        self._valid = None
 
     @property
     def item_type(self):
@@ -185,6 +186,8 @@ class CacheItem(dict):
         return type(self)(self._db_cache, self._item_type, **self)
 
     def is_valid(self):
+        if self._valid is not None:
+            return self._valid
         if self._removed or self._corrupted:
             return False
         self._to_remove = False
@@ -193,7 +196,8 @@ class CacheItem(dict):
             _ = self[key]
         if self._to_remove:
             self.cascade_remove()
-        return not self._removed and not self._corrupted
+        self._valid = not self._removed and not self._corrupted
+        return self._valid
 
     def is_removed(self):
         return self._removed
@@ -228,6 +232,7 @@ class CacheItem(dict):
             return
         self._removed = True
         self._to_remove = False
+        self._valid = None
         obsolete = set()
         for callback in self.remove_callbacks:
             if not callback(self):


### PR DESCRIPTION
Cache items need to be validated to check if their references are still there. For example, a user can remove an object class and *later* fetch the objects of that class. So as these objects are fetched, we need to check that they are actually invalid. This is done and working, but this PR caches the results of the validation to speedup things like the purge.

## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes in Toolbox repo have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black
- [ ] Unit tests pass
