### PR TITLE
Remove parameter components from object group mappings

### DIFF
--- a/spinedb_api/export_mapping/__init__.py
+++ b/spinedb_api/export_mapping/__init__.py
@@ -21,7 +21,6 @@ from .settings import (
     feature_export,
     object_export,
     object_group_export,
-    object_group_parameter_export,
     object_parameter_default_value_export,
     object_parameter_export,
     parameter_value_list_export,

--- a/spinedb_api/export_mapping/settings.py
+++ b/spinedb_api/export_mapping/settings.py
@@ -151,52 +151,6 @@ def object_parameter_export(
     return class_
 
 
-def object_group_parameter_export(
-    class_position=Position.hidden,
-    definition_position=Position.hidden,
-    value_list_position=Position.hidden,
-    group_position=Position.hidden,
-    object_position=Position.hidden,
-    alternative_position=Position.hidden,
-    value_type_position=Position.hidden,
-    value_position=Position.hidden,
-    index_name_positions=None,
-    index_positions=None,
-):
-    """
-    Sets up export mappings for exporting object groups and object parameters.
-
-    Args:
-        class_position (int or Position): position of object classes
-        definition_position (int or Position): position of parameter names in a table
-        value_list_position (int or Position): position of parameter value lists
-        group_position (int or Position): position of groups
-        object_position (int or Position): position of objects
-        alternative_position (int or position): position of alternatives in a table
-        value_type_position (int or Position): position of parameter value types in a table
-        value_position (int or Position): position of parameter values in a table
-        index_name_positions (list of int, optional): positions of index names
-        index_positions (list of int, optional): positions of parameter indexes in a table
-
-    Returns:
-        ExportMapping: root mapping
-    """
-    class_ = ObjectClassMapping(class_position)
-    definition = ParameterDefinitionMapping(definition_position)
-    value_list = ParameterValueListMapping(value_list_position)
-    value_list.set_ignorable(True)
-    group = ObjectGroupMapping(group_position)
-    object_ = ObjectGroupObjectMapping(object_position)
-    group.child = object_
-    _generate_parameter_value_mappings(
-        object_, alternative_position, value_type_position, value_position, index_name_positions, index_positions
-    )
-    value_list.child = group
-    definition.child = value_list
-    class_.child = definition
-    return class_
-
-
 def object_group_export(
     class_position=Position.hidden, group_position=Position.hidden, object_position=Position.hidden
 ):

--- a/spinedb_api/import_mapping/import_mapping.py
+++ b/spinedb_api/import_mapping/import_mapping.py
@@ -1105,6 +1105,9 @@ def from_dict(serialized):
                 position, value, skip_columns, read_start_row, filter_re, mapping_dict
             )
         )
+        if mapping_dict["map_type"] == "ObjectGroup":
+            # Legacy: dropping parameter mappings from object groups
+            break
     return unflatten(flattened)
 
 

--- a/spinedb_api/import_mapping/import_mapping_compat.py
+++ b/spinedb_api/import_mapping/import_mapping_compat.py
@@ -216,14 +216,12 @@ def _object_group_mapping_from_dict(map_dict):
     name = map_dict.get("name")
     groups = map_dict.get("groups")
     members = map_dict.get("members")
-    parameters = map_dict.get("parameters")
     import_objects = map_dict.get("import_objects", False)
     skip_columns = map_dict.get("skip_columns", [])
     read_start_row = map_dict.get("read_start_row", 0)
     root_mapping = ObjectClassMapping(*_pos_and_val(name), skip_columns=skip_columns, read_start_row=read_start_row)
     object_mapping = root_mapping.child = ObjectMapping(*_pos_and_val(groups))
-    group_mapping = object_mapping.child = ObjectGroupMapping(*_pos_and_val(members), import_objects=import_objects)
-    group_mapping.child = parameter_mapping_from_dict(parameters)
+    object_mapping.child = ObjectGroupMapping(*_pos_and_val(members), import_objects=import_objects)
     return root_mapping
 
 

--- a/tests/export_mapping/test_settings.py
+++ b/tests/export_mapping/test_settings.py
@@ -29,10 +29,8 @@ from spinedb_api import (
     import_relationships,
     TimeSeriesFixedResolution,
 )
-from spinedb_api.import_functions import import_object_groups
 from spinedb_api.export_mapping import rows
 from spinedb_api.export_mapping.settings import (
-    object_group_parameter_export,
     relationship_export,
     set_relationship_dimensions,
     object_parameter_export,
@@ -99,35 +97,6 @@ class TestRelationshipParameterExport(unittest.TestCase):
             [numpy.datetime64("2022-06-22T12:00:00"), -2.2, -4.4],
         ]
         self.assertEqual(list(rows(root_mapping, db_map)), expected)
-        db_map.connection.close()
-
-
-class TestObjectGroupParameterExport(unittest.TestCase):
-    def test_export_with_parameter_values(self):
-        db_map = DatabaseMapping("sqlite://", create=True)
-        import_object_classes(db_map, ("oc",))
-        import_object_parameters(db_map, (("oc", "param"),))
-        import_objects(
-            db_map, (("oc", "o1"), ("oc", "o2"), ("oc", "o3"), ("oc", "g1"), ("oc", "g2"), ("oc", "no_group"))
-        )
-        import_object_parameter_values(
-            db_map,
-            (
-                ("oc", "o1", "param", -11.0),
-                ("oc", "o2", "param", -22.0),
-                ("oc", "o3", "param", -33.0),
-                ("oc", "no_group", "param", -44.0),
-            ),
-        )
-        import_object_groups(db_map, (("oc", "g1", "o1"), ("oc", "g1", "o2"), ("oc", "g2", "o3")))
-        db_map.commit_session("Add test data.")
-        mapping = object_group_parameter_export(0, 1, 2, 3, 4, 5, 6, 7, None)
-        expected = [
-            ["oc", "param", None, "g1", "o1", "Base", "single_value", -11.0],
-            ["oc", "param", None, "g1", "o2", "Base", "single_value", -22.0],
-            ["oc", "param", None, "g2", "o3", "Base", "single_value", -33.0],
-        ]
-        self.assertEqual(list(rows(mapping, db_map)), expected)
         db_map.connection.close()
 
 

--- a/tests/import_mapping/test_import_mapping.py
+++ b/tests/import_mapping/test_import_mapping.py
@@ -395,10 +395,6 @@ class TestImportMappingLegacy(unittest.TestCase):
             {'map_type': 'ObjectClass', 'position': 0},
             {'map_type': 'Object', 'position': 1},
             {'map_type': 'ObjectGroup', 'position': 2},
-            {'map_type': 'ParameterDefinition', 'position': 'hidden', 'value': 'pname'},
-            {'map_type': 'Alternative', 'position': 'hidden'},
-            {'map_type': 'ParameterValueMetadata', 'position': 'hidden'},
-            {'map_type': 'ParameterValue', 'position': 2},
         ]
         self.assertEqual(out, expected)
 
@@ -1838,39 +1834,6 @@ class TestMappingIntegration(unittest.TestCase):
             ("class_A", "group2"),
             ("class_A", "object3"),
         }
-        self.assertFalse(errors)
-        self.assertEqual(out, expected)
-
-    def test_read_object_group_with_parameters(self):
-        input_data = [
-            ["Object Class", "Group", "Object", "Speed"],
-            ["class_A", "group1", "object1", 23.0],
-            ["class_A", "group1", "object2", 42.0],
-            ["class_A", "group2", "object3", 5.0],
-        ]
-        data = iter(input_data)
-        data_header = next(data)
-        mapping = {
-            "map_type": "ObjectGroup",
-            "name": 0,
-            "groups": 1,
-            "members": 2,
-            "parameters": {"name": "speed", "parameter_type": "single value", "value": 3},
-        }
-        out, errors = get_mapped_data(data, [mapping], data_header)
-        expected = dict()
-        expected["object_groups"] = {
-            ("class_A", "group1", "object1"),
-            ("class_A", "group1", "object2"),
-            ("class_A", "group2", "object3"),
-        }
-        expected["object_classes"] = {"class_A"}
-        expected["object_parameters"] = [("class_A", "speed")]
-        expected["object_parameter_values"] = [
-            ["class_A", "group1", "speed", 23.0],
-            ["class_A", "group1", "speed", 42.0],
-            ["class_A", "group2", "speed", 5.0],
-        ]
         self.assertFalse(errors)
         self.assertEqual(out, expected)
 


### PR DESCRIPTION
This PR removes the option to create object group mappings (import or export) with parameter components.

Re spine-tools/Spine-Toolbox#1324

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
