### PR TITLE
Quote alternative names in alternative filter shorthand

### DIFF
--- a/spinedb_api/filters/alternative_filter.py
+++ b/spinedb_api/filters/alternative_filter.py
@@ -72,7 +72,7 @@ def alternative_filter_config_to_shorthand(config):
     """
     shorthand = ""
     for alternative in config["alternatives"]:
-        shorthand = shorthand + ":" + alternative
+        shorthand = shorthand + f":'{alternative}'"
     return ALTERNATIVE_FILTER_SHORTHAND_TAG + shorthand
 
 
@@ -101,8 +101,10 @@ def alternative_filter_shorthand_to_config(shorthand):
     Returns:
         dict: alternative filter configuration
     """
-    alternatives = shorthand.split(":")
-    return alternative_filter_config(alternatives[1:])
+    filter_type, separator, tokens = shorthand.partition(":'")
+    alternatives = tokens.split("':'")
+    alternatives[-1] = alternatives[-1][:-1]
+    return alternative_filter_config(alternatives)
 
 
 class _AlternativeFilterState:


### PR DESCRIPTION
Alternative names may have time stamps that contain colons ':' that mess up the shorthand version unless we quote the names.

Fixes #220

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
