### PR TITLE
Support for more SQL dialects in SqlWriter

### DIFF
--- a/spinedb_api/spine_io/exporters/sql_writer.py
+++ b/spinedb_api/spine_io/exporters/sql_writer.py
@@ -21,13 +21,17 @@ from .writer import Writer, WriterException
 
 
 class SqlWriter(Writer):
-    def __init__(self, file_path):
+    """Export writer that targets SQL databases."""
+
+    def __init__(self, database):
         """
         Args:
-            file_path (str): path to output .sqlite file
+            database (str): URL or path to output .sqlite file
         """
         super().__init__()
-        self._engine = create_engine("sqlite:///" + file_path)
+        if database.find("://") < 0:
+            database = "sqlite:///" + database
+        self._engine = create_engine(database)
         self._connection = self._engine.connect()
         self._metadata = MetaData()
         self._metadata.reflect(bind=self._engine)


### PR DESCRIPTION
This makes it possible to provide `SqlWriter` a database URL instead of SQLite file name which should enable writing to MySQL etc. Other dialects remain untested though as I don't have access to remote databases.

Re #spine-tools/Spine-Toolbox#1668

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
