### PR TITLE
Try converting Array values to same type in constructor

### DIFF
--- a/spinedb_api/parameter_value.py
+++ b/spinedb_api/parameter_value.py
@@ -905,7 +905,10 @@ class Array(IndexedValue):
                     raise ParameterValueFormatError("Cannot convert array's values to float.")
                 value_type = float
         if any(not isinstance(x, value_type) for x in values):
-            raise ParameterValueFormatError("Not all array's values are of the same type.")
+            try:
+                values = [value_type(x) for x in values]
+            except ValueError:
+                raise ParameterValueFormatError("Not all array's values are of the same type.")
         self.indexes = range(len(values))
         self.values = list(values)
         self._value_type = value_type

--- a/spinedb_api/spine_io/importers/excel_reader.py
+++ b/spinedb_api/spine_io/importers/excel_reader.py
@@ -133,7 +133,7 @@ class ExcelConnector(SourceConnection):
         else:
             header = []
             rows = chain((first_row,), rows)
-        # iterator for selected columns and and skipped rows
+        # iterator for selected columns and skipped rows
         data_iterator = (list(cell.value for cell in islice(row, skip_columns, read_to_col)) for row in rows)
         if stop_at_empty_row:
             # add condition to iterator

--- a/tests/test_parameter_value.py
+++ b/tests/test_parameter_value.py
@@ -828,6 +828,11 @@ class TestParameterValue(unittest.TestCase):
         self.assertEqual(array.indexes, [0])
         self.assertEqual(array.index_name, "index")
 
+    def test_Array_constructor_converts_ints_to_floats(self):
+        array = Array([9, 5])
+        self.assertIs(array.value_type, float)
+        self.assertEqual(array.values, [9.0, 5.0])
+
     def test_DateTime_copy_construction(self):
         date_time = DateTime("2019-07-03T09:09:09")
         copied = DateTime(date_time)


### PR DESCRIPTION
This PR makes `Array.__init__()` try to convert all values to the same type if the types are not consistent before raising an exception.

Re spine-tools/Spine-Toolbox#2017

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
