### PR TITLE
Handle booleans case insensitively

### DIFF
--- a/spinedb_api/check_functions.py
+++ b/spinedb_api/check_functions.py
@@ -16,7 +16,7 @@ to the violation of integrity constraints.
 :date:   4.6.2019
 """
 
-from .parameter_value import from_database, ParameterValueFormatError
+from .parameter_value import dump_db_value, from_database, ParameterValueFormatError
 from .exception import SpineIntegrityError
 
 # NOTE: We parse each parameter value or default value before accepting it. Is it too much?
@@ -435,7 +435,7 @@ def _replace_values_with_list_references(item_type, item, parameter_value_list_i
         return False
     list_value_id = next((id_ for id_ in value_id_list if list_values.get(id_) == parsed_value), None)
     if list_value_id is None:
-        valid_values = ", ".join([f"'{list_values.get(id_)}'" for id_ in value_id_list])
+        valid_values = ", ".join(f"{dump_db_value(list_values.get(id_))[0].decode('utf8')!r}" for id_ in value_id_list)
         raise SpineIntegrityError(
             f"Invalid {value_key} '{parsed_value}' - it should be one from the parameter value list: {valid_values}."
         )

--- a/spinedb_api/parameter_value.py
+++ b/spinedb_api/parameter_value.py
@@ -121,6 +121,15 @@ def relativedelta_to_duration(delta):
     return "0h"
 
 
+def lower_if_bool(value: str | bytes) -> str | bytes:
+    """Check if string or bytes object is a boolean, if yes lowercase, noop otherwise"""
+    value_lower = value.lower()
+    if value_lower in ['true', 'false', b'true', b'false']:
+        return value_lower
+    else:
+        return value
+
+
 def load_db_value(db_value, value_type=None):
     """
     Loads a database parameter value into a Python object using JSON.
@@ -136,7 +145,7 @@ def load_db_value(db_value, value_type=None):
     if db_value is None:
         return None
     try:
-        parsed = json.loads(db_value)
+        parsed = json.loads(lower_if_bool(db_value))
     except JSONDecodeError as err:
         raise ParameterValueFormatError(f"Could not decode the value: {err}") from err
     if isinstance(parsed, dict):

--- a/tests/test_check_functions.py
+++ b/tests/test_check_functions.py
@@ -10,6 +10,7 @@
 ######################################################################################################################
 
 import json
+from numbers import Number
 import unittest
 
 from spinedb_api.db_cache import DBCache, ParameterValueItem
@@ -22,17 +23,17 @@ class TestCheckFunctions(unittest.TestCase):
     def setUp(self):
         self.data = [
             (bool, (b'"TRUE"', b'"FALSE"', b'"T"', b'"True"', b'"False"'), (b'true', b'false')),
-            (int, (b'32',), (b'42', b'-2')),
+            (int, (b'32', b'3.14'), (b'42', b'-2')),
             (str, (b'"FOO"', b'"bar"'), (b'"foo"', b'"Bar"', b'"BAZ"')),
         ]
-        self.par_defns = {
+        self.parameter_definitions = {
             1: {'name': 'par1', 'entity_class_id': 1, 'parameter_value_list_id': 1},
             2: {'name': 'par2', 'entity_class_id': 1, 'parameter_value_list_id': 2},
             3: {'name': 'par2', 'entity_class_id': 1, 'parameter_value_list_id': 3},
         }
         self.value_type = {bool: 1, int: 2, str: 3}
-        self.par_val_lists = {1: (1, 2), 2: (3, 4), 3: (5, 6, 7)}
-        self.list_vals = {1: True, 2: False, 3: 42, 4: -2, 5: 'foo', 6: 'Bar', 7: 'BAZ'}
+        self.parameter_value_lists = {1: (1, 2), 2: (3, 4), 3: (5, 6, 7)}
+        self.list_values = {1: True, 2: False, 3: 42, 4: -2, 5: 'foo', 6: 'Bar', 7: 'BAZ'}
 
     def get_item(self, _type: type, val: bytes):
         _id = self.value_type[_type]  # setup: param defn/value list ids are equal
@@ -56,22 +57,26 @@ class TestCheckFunctions(unittest.TestCase):
         for _type, _fail, _pass in self.data:
             for data in _fail:
                 with self.subTest(_type=_type, data=data):
-                    # expect_in = f"{json.loads(data.decode('utf8'))}"
                     expect_in = json.loads(data.decode('utf8'))
-                    ref = [self.list_vals[i] for i in self.par_val_lists[self.value_type[_type]]]
+                    if isinstance(expect_in, Number):
+                        expect_in = float(expect_in)
+                    ref = [self.list_values[i] for i in self.parameter_value_lists[self.value_type[_type]]]
                     expect_ref = ", ".join(f"{json.dumps(i)!r}" for i in ref)
                     self.assertRaisesRegex(
                         SpineIntegrityError,
                         fr"{expect_in!r}.+{expect_ref}",
                         replace_parameter_values_with_list_references,
                         self.get_item(_type, data),
-                        self.par_defns,
-                        self.par_val_lists,
-                        self.list_vals,
+                        self.parameter_definitions,
+                        self.parameter_value_lists,
+                        self.list_values,
                     )
 
             for data in _pass:
                 with self.subTest(_type=_type, data=data):
                     replace_parameter_values_with_list_references(
-                        self.get_item(_type, data), self.par_defns, self.par_val_lists, self.list_vals
+                        self.get_item(_type, data),
+                        self.parameter_definitions,
+                        self.parameter_value_lists,
+                        self.list_values,
                     )

--- a/tests/test_check_functions.py
+++ b/tests/test_check_functions.py
@@ -1,0 +1,66 @@
+import json
+import unittest
+
+from spinedb_api.db_cache import DBCache, ParameterValueItem
+from spinedb_api.exception import SpineIntegrityError
+
+from spinedb_api.check_functions import replace_parameter_values_with_list_references
+
+
+class TestCheckFunctions(unittest.TestCase):
+    def setUp(self):
+        self.data = [
+            (bool, (b'"TRUE"', b'"FALSE"', b'"T"', b'"True"', b'"False"'), (b'true', b'false')),
+            (int, (b'32',), (b'42', b'-2')),
+            (str, (b'"FOO"', b'"bar"'), (b'"foo"', b'"Bar"', b'"BAZ"')),
+        ]
+        self.par_defns = {
+            1: {'name': 'par1', 'entity_class_id': 1, 'parameter_value_list_id': 1},
+            2: {'name': 'par2', 'entity_class_id': 1, 'parameter_value_list_id': 2},
+            3: {'name': 'par2', 'entity_class_id': 1, 'parameter_value_list_id': 3},
+        }
+        self.value_type = {bool: 1, int: 2, str: 3}
+        self.par_val_lists = {1: (1, 2), 2: (3, 4), 3: (5, 6, 7)}
+        self.list_vals = {1: True, 2: False, 3: 42, 4: -2, 5: 'foo', 6: 'Bar', 7: 'BAZ'}
+
+    def get_item(self, _type: type, val: bytes):
+        _id = self.value_type[_type]  # setup: param defn/value list ids are equal
+        kwargs = {
+            'id': 1,
+            'parameter_definition_id': _id,
+            'entity_class_id': 1,
+            'entity_id': 1,
+            'object_class_id': 1,
+            'object_id': 1,
+            'value': val,
+            'commit_id': 3,
+            'alternative_id': 1,
+            'object_class_name': 'test_objcls',
+            'alternative_name': 'Base',
+            'object_name': 'obj1',
+        }
+        return ParameterValueItem(DBCache(lambda *_, **__: None), item_type="value", **kwargs)
+
+    def test_replace_parameter_or_default_values_with_list_references(self):
+        for _type, _fail, _pass in self.data:
+            for data in _fail:
+                with self.subTest(_type=_type, data=data):
+                    # expect_in = f"{json.loads(data.decode('utf8'))}"
+                    expect_in = json.loads(data.decode('utf8'))
+                    ref = [self.list_vals[i] for i in self.par_val_lists[self.value_type[_type]]]
+                    expect_ref = ", ".join(f"{json.dumps(i)!r}" for i in ref)
+                    self.assertRaisesRegex(
+                        SpineIntegrityError,
+                        fr"{expect_in!r}.+{expect_ref}",
+                        replace_parameter_values_with_list_references,
+                        self.get_item(_type, data),
+                        self.par_defns,
+                        self.par_val_lists,
+                        self.list_vals,
+                    )
+
+            for data in _pass:
+                with self.subTest(_type=_type, data=data):
+                    replace_parameter_values_with_list_references(
+                        self.get_item(_type, data), self.par_defns, self.par_val_lists, self.list_vals
+                    )

--- a/tests/test_check_functions.py
+++ b/tests/test_check_functions.py
@@ -36,7 +36,7 @@ class TestCheckFunctions(unittest.TestCase):
         self.list_values = {1: True, 2: False, 3: 42, 4: -2, 5: 'foo', 6: 'Bar', 7: 'BAZ'}
 
     def get_item(self, _type: type, val: bytes):
-        _id = self.value_type[_type]  # setup: param defn/value list ids are equal
+        _id = self.value_type[_type]  # setup: parameter definition/value list ids are equal
         kwargs = {
             'id': 1,
             'parameter_definition_id': _id,
@@ -54,6 +54,7 @@ class TestCheckFunctions(unittest.TestCase):
         return ParameterValueItem(DBCache(lambda *_, **__: None), item_type="value", **kwargs)
 
     def test_replace_parameter_or_default_values_with_list_references(self):
+        # regression test for spine-tools/Spine-Toolbox#1878
         for _type, _fail, _pass in self.data:
             for data in _fail:
                 with self.subTest(_type=_type, data=data):

--- a/tests/test_check_functions.py
+++ b/tests/test_check_functions.py
@@ -1,3 +1,14 @@
+######################################################################################################################
+# Copyright (C) 2017-2022 Spine project consortium
+# This file is part of Spine Database API.
+# Spine Database API is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+# General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+# Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+######################################################################################################################
+
 import json
 import unittest
 

--- a/tests/test_parameter_value.py
+++ b/tests/test_parameter_value.py
@@ -150,10 +150,12 @@ class TestParameterValue(unittest.TestCase):
         self.assertEqual(value, 23.0)
 
     def test_from_database_boolean(self):
-        database_value = b"true"
-        value = from_database(database_value, value_type=None)
-        self.assertTrue(isinstance(value, bool))
-        self.assertEqual(value, True)
+        values = [(b"true", True), (b"false", False)]
+        for _value, expected in values:
+            for database_value in [call(_value) for call in (bytes, bytes.capitalize, bytes.upper)]:
+                value = from_database(database_value, value_type=None)
+                self.assertTrue(isinstance(value, bool))
+                self.assertEqual(value, expected)
 
     def test_to_database_plain_number(self):
         value = 23.0


### PR DESCRIPTION
Currently only `'true'` & `'false'` (case sensitive) are accepted as valid booleans (as per the JSON spec).  This PR adds a preprocessing step that case insensitively checks if the string/bytes value matches a boolean, if it does, it down cases the value before parsing it to a Python object.

- `'TRUE'`, `'true'`, `'True'` -> `True`
- `'FALSE'`, `'false'`, `'False'` -> `False`

This should be merged after #235, new commits only touch `parameter_value.py` & `tests/test_parameter_value.py`

## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
