### PR TITLE
Fix JSONConnector

### DIFF
--- a/spinedb_api/spine_io/importers/csv_reader.py
+++ b/spinedb_api/spine_io/importers/csv_reader.py
@@ -158,13 +158,11 @@ class CSVConnector(SourceConnection):
             yield from csv_reader
 
     def get_data_iterator(self, table, options, max_rows=-1):
-        """Creates an iterator for the file in self.filename
+        """Creates an iterator for the file in self.filename.
 
         Arguments:
             table (string): ignored, used in abstract IOWorker class
             options (dict): dict with options
-
-        Keyword Arguments:
             max_rows (int): how many rows of data to read, if -1 read all rows (default: {-1})
 
         Returns:

--- a/spinedb_api/spine_io/importers/json_reader.py
+++ b/spinedb_api/spine_io/importers/json_reader.py
@@ -40,15 +40,14 @@ class JSONConnector(SourceConnection):
     def connect_to_source(self, source):
         """saves filepath
 
-        Arguments:
-            source {str} -- filepath
+        Args:
+            source (str): filepath
         """
         self._filename = source
         self._root_prefix = os.path.splitext(os.path.basename(source))[0]
 
     def disconnect(self):
-        """Disconnect from connected source.
-        """
+        """Disconnect from connected source."""
 
     def get_tables(self):
         prefixes = dict()
@@ -61,9 +60,9 @@ class JSONConnector(SourceConnection):
     def file_iterator(self, table, options, max_rows=-1):
         if max_rows == -1:
             max_rows = sys.maxsize
-        max_depth = options["max_depth"]
+        max_depth = options.get("max_depth", self.OPTIONS["max_depth"]["default"])
         prefix = ".".join(table.split(".")[1:])
-        with open(self._filename) as f:
+        with open(self._filename, "rb") as f:
             row = 0
             for obj in ijson.items(f, prefix):
                 for x in _tabulize_json(obj):
@@ -74,7 +73,7 @@ class JSONConnector(SourceConnection):
 
     def get_data_iterator(self, table, options, max_rows=-1):
         """
-        Return data read from data source table in table. If max_rows is
+        Returns data read from data source table in table. If max_rows is
         specified only that number of rows.
         """
         return self.file_iterator(table, options, max_rows=max_rows), []

--- a/tests/spine_io/importers/test_json_reader.py
+++ b/tests/spine_io/importers/test_json_reader.py
@@ -13,7 +13,10 @@
 Contains unit tests for JSONConnector.
 
 """
+import json
+from pathlib import Path
 import pickle
+from tempfile import TemporaryDirectory
 import unittest
 from spinedb_api.spine_io.importers.json_reader import JSONConnector
 
@@ -23,6 +26,18 @@ class TestJSONConnector(unittest.TestCase):
         reader = JSONConnector(None)
         pickled = pickle.dumps(reader)
         self.assertTrue(pickled)
+
+    def test_file_iterator_works_with_empty_options(self):
+        reader = JSONConnector(None)
+        data = {"a": 1, "b": {"c": 2}}
+        with TemporaryDirectory() as temp_dir:
+            file_path = Path(temp_dir) / "test file.json"
+            with open(file_path, "w") as out_file:
+                json.dump(data, out_file)
+            reader.connect_to_source(str(file_path))
+            rows = list(reader.file_iterator("data", {}))
+            reader.disconnect()
+        self.assertEqual(rows, [["a", 1], ["b", "c", 2]])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This fixes an error message in Importer that was caused by `JSONConnector` expecting connector options to always contain certain fields.

Fixes spine-tools/Spine-Toolbox#2107

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [ ] Unit tests pass
