### PR TITLE
Simplify relationship object highlighting export mappings

### DIFF
--- a/spinedb_api/export_mapping/export_mapping.py
+++ b/spinedb_api/export_mapping/export_mapping.py
@@ -14,9 +14,8 @@ Contains export mappings for database items such as entities, entity classes and
 """
 
 from dataclasses import dataclass
-from functools import cached_property
 from itertools import cycle, dropwhile, islice
-from sqlalchemy import and_, or_
+from sqlalchemy import and_
 from sqlalchemy.sql.expression import literal
 from ..parameter_value import (
     from_database_to_single_value,
@@ -740,13 +739,30 @@ class RelationshipClassMapping(ExportMapping):
 
     MAP_TYPE = "RelationshipClass"
 
+    def __init__(self, position, value=None, header="", filter_re="", highlight_dimension=None):
+        super().__init__(position, value, header, filter_re)
+        self.highlight_dimension = highlight_dimension
+
     def add_query_columns(self, db_map, query):
-        return query.add_columns(
+        query = query.add_columns(
             db_map.wide_relationship_class_sq.c.id.label("relationship_class_id"),
             db_map.wide_relationship_class_sq.c.name.label("relationship_class_name"),
             db_map.wide_relationship_class_sq.c.object_class_id_list,
             db_map.wide_relationship_class_sq.c.object_class_name_list,
         )
+        if self.highlight_dimension is not None:
+            query = query.add_columns(
+                db_map.ext_relationship_class_sq.c.object_class_id.label("highlighted_object_class_id")
+            )
+        return query
+
+    def filter_query(self, db_map, query):
+        if self.highlight_dimension is not None:
+            query = query.outerjoin(
+                db_map.ext_relationship_class_sq,
+                db_map.ext_relationship_class_sq.c.id == db_map.wide_relationship_class_sq.c.id,
+            ).filter(db_map.ext_relationship_class_sq.c.dimension == self.highlight_dimension)
+        return query
 
     @staticmethod
     def name_field():
@@ -758,71 +774,26 @@ class RelationshipClassMapping(ExportMapping):
         return "relationship_class_name"
 
     def query_parents(self, what):
-        if what != "dimension":
-            return super().query_parents(what)
-        return -1
+        if what == "dimension":
+            return -1
+        if what == "highlight_dimension":
+            return self.highlight_dimension
+        return super().query_parents(what)
 
     def _title_state(self, db_row):
         state = super()._title_state(db_row)
         state["object_class_id_list"] = getattr(db_row, "object_class_id_list")
         return state
 
-
-class RelationshipClassObjectHighlightingMapping(RelationshipClassMapping):
-    """Maps relationships classes.
-
-    Adds object class dimension chosen by highlight_dimension to the query.
-
-    Can be used as the topmost mapping.
-    """
-
-    MAP_TYPE = "RelationshipClassObjectHighlightingMapping"
-
-    def __init__(self, position, value=None, header="", filter_re="", highlight_dimension=0):
-        super().__init__(position, value, header, filter_re)
-        self._highlight_dimension = highlight_dimension
-
-    @property
-    def highlight_dimension(self):
-        return self._highlight_dimension
-
-    @highlight_dimension.setter
-    def highlight_dimension(self, dimension):
-        self._highlight_dimension = dimension
-
-    def add_query_columns(self, db_map, query):
-        query = super().add_query_columns(db_map, query)
-        return query.add_columns(db_map.object_class_sq.c.id.label("object_class_id"))
-
-    def filter_query(self, db_map, query):
-        highlighted_object_class_qry = db_map.query(db_map.relationship_class_sq).filter(
-            db_map.relationship_class_sq.c.dimension == self._highlight_dimension
-        )
-        conditions = (
-            and_(db_map.wide_relationship_class_sq.c.id == x.id, db_map.object_class_sq.c.id == x.object_class_id)
-            for x in highlighted_object_class_qry
-        )
-        return query.filter(or_(*conditions))
-
-    @staticmethod
-    def id_field():
-        return "relationship_class_id"
-
-    def query_parents(self, what):
-        if what == "dimension":
-            return self._highlight_dimension - 1  # Object class mapping will increment by 1.
-        if what == "highlight_dimension":
-            return self._highlight_dimension
-        return super().query_parents(what)
-
     def to_dict(self):
         mapping_dict = super().to_dict()
-        mapping_dict["highlight_dimension"] = self._highlight_dimension
+        if self.highlight_dimension is not None:
+            mapping_dict["highlight_dimension"] = self.highlight_dimension
         return mapping_dict
 
     @classmethod
     def reconstruct(cls, position, value, header, filter_re, ignorable, mapping_dict):
-        highlight_dimension = mapping_dict["highlight_dimension"]
+        highlight_dimension = mapping_dict.get("highlight_dimension")
         mapping = cls(position, value, header, filter_re, highlight_dimension)
         mapping.set_ignorable(ignorable)
         return mapping
@@ -873,18 +844,26 @@ class RelationshipMapping(ExportMapping):
     MAP_TYPE = "Relationship"
 
     def add_query_columns(self, db_map, query):
-        return query.add_columns(
+        query = query.add_columns(
             db_map.wide_relationship_sq.c.id.label("relationship_id"),
             db_map.wide_relationship_sq.c.name.label("relationship_name"),
             db_map.wide_relationship_sq.c.object_id_list,
             db_map.wide_relationship_sq.c.object_name_list,
         )
+        if self.query_parents("highlight_dimension") is not None:
+            query = query.add_columns(db_map.ext_relationship_sq.c.object_id.label("highlighted_object_id"))
+        return query
 
     def filter_query(self, db_map, query):
-        return query.outerjoin(
+        query = query.outerjoin(
             db_map.wide_relationship_sq,
             db_map.wide_relationship_sq.c.class_id == db_map.wide_relationship_class_sq.c.id,
         )
+        if (highlight_dimension := self.query_parents("highlight_dimension")) is not None:
+            query = query.outerjoin(
+                db_map.ext_relationship_sq, db_map.ext_relationship_sq.c.id == db_map.wide_relationship_sq.c.id
+            ).filter(db_map.ext_relationship_sq.c.dimension == highlight_dimension)
+        return query
 
     @staticmethod
     def name_field():
@@ -907,45 +886,6 @@ class RelationshipMapping(ExportMapping):
     @staticmethod
     def is_buddy(parent):
         return isinstance(parent, RelationshipClassMapping)
-
-
-class RelationshipObjectHighlightingMapping(RelationshipMapping):
-    """Maps relationships.
-
-    Adds object dimension chosen by highlight_dimension in relationship class mapping to the query.
-
-    Cannot be used as the topmost mapping;
-    one of the parents must be :class:`RelationshipClassObjectHighlightingMapping`.
-    """
-
-    MAP_TYPE = "RelationshipObjectHighlightingMapping"
-
-    @cached_property
-    def _highlight_dimension(self):
-        return super().query_parents("highlight_dimension")
-
-    def add_query_columns(self, db_map, query):
-        query = super().add_query_columns(db_map, query)
-        return query.add_columns(db_map.object_sq.c.id.label("object_id"))
-
-    def filter_query(self, db_map, query):
-        highlighted_object_qry = db_map.query(db_map.relationship_sq).filter(
-            db_map.relationship_sq.c.dimension == self.query_parents("highlight_dimension")
-        )
-        conditions = (
-            and_(db_map.wide_relationship_sq.c.id == x.id, db_map.object_sq.c.id == x.object_id)
-            for x in highlighted_object_qry
-        )
-        return query.filter(or_(*conditions))
-
-    def query_parents(self, what):
-        if what != "dimension":
-            return super().query_parents(what)
-        return self._highlight_dimension - 1  # Object mapping will increment by one.
-
-    @staticmethod
-    def is_buddy(parent):
-        return isinstance(parent, RelationshipClassObjectHighlightingMapping)
 
 
 class RelationshipObjectMapping(ExportMapping):
@@ -1007,6 +947,12 @@ class ParameterDefinitionMapping(ExportMapping):
                 db_map.parameter_definition_sq.c.object_class_id == db_map.object_class_sq.c.id,
             )
         if "relationship_class_id" in column_names:
+            if self.query_parents("highlight_dimension") is not None:
+                return query.outerjoin(
+                    db_map.parameter_definition_sq,
+                    db_map.parameter_definition_sq.c.object_class_id
+                    == db_map.ext_relationship_class_sq.c.object_class_id,
+                )
             return query.outerjoin(
                 db_map.parameter_definition_sq,
                 db_map.parameter_definition_sq.c.relationship_class_id == db_map.wide_relationship_class_sq.c.id,
@@ -1192,6 +1138,13 @@ class ParameterValueMapping(ExportMapping):
                 )
             )
         if "relationship_id" in column_names:
+            if self.query_parents("highlight_dimension") is not None:
+                return query.filter(
+                    and_(
+                        db_map.parameter_value_sq.c.object_id == db_map.ext_relationship_sq.c.object_id,
+                        db_map.parameter_value_sq.c.parameter_definition_id == db_map.parameter_definition_sq.c.id,
+                    )
+                )
             return query.filter(
                 and_(
                     db_map.parameter_value_sq.c.relationship_id == db_map.wide_relationship_sq.c.id,
@@ -1887,9 +1840,7 @@ def from_dict(serialized):
             ParameterValueTypeMapping,
             RelationshipClassMapping,
             RelationshipClassObjectClassMapping,
-            RelationshipClassObjectHighlightingMapping,
             RelationshipMapping,
-            RelationshipObjectHighlightingMapping,
             RelationshipObjectMapping,
             ScenarioActiveFlagMapping,
             ScenarioAlternativeMapping,
@@ -1906,6 +1857,8 @@ def from_dict(serialized):
     }
     # Legacy
     mappings["ParameterIndex"] = ParameterValueIndexMapping
+    if any(m["map_type"] == "RelationshipClassObjectHighlightingMapping" for m in serialized):
+        _upgrade_legacy_object_highlighting_mapping(serialized)
     flattened = list()
     for mapping_dict in serialized:
         position = mapping_dict["position"]
@@ -1937,6 +1890,22 @@ def legacy_group_fn_from_dict(serialized):
         if group_fn is not None:
             return group_fn
     return NoGroup.NAME
+
+
+def _upgrade_legacy_object_highlighting_mapping(serialized):
+    """Upgrades legacy object highlighting mappings in place.
+
+    ``RelationshipClassObjectHighlightingMapping`` and ``RelationshipObjectHighlightingMapping``
+    have been replaced by a ``highlight_dimension`` argument in ``RelationshipClassObjectClassMapping``.
+
+    Args:
+        serialized (list of dict): serialized mappings
+    """
+    for mapping_dict in serialized:
+        if mapping_dict["map_type"] == "RelationshipClassObjectHighlightingMapping":
+            mapping_dict["map_type"] = RelationshipClassMapping.MAP_TYPE
+        elif mapping_dict["map_type"] == "RelationshipObjectHighlightingMapping":
+            mapping_dict["map_type"] = RelationshipMapping.MAP_TYPE
 
 
 def _expand_indexed_data(data, mapping):

--- a/spinedb_api/export_mapping/settings.py
+++ b/spinedb_api/export_mapping/settings.py
@@ -319,9 +319,7 @@ def relationship_object_parameter_default_value_export(
     """
     root_mapping = unflatten(
         [
-            RelationshipClassMapping(
-                relationship_class_position, highlight_dimension=highlight_dimension
-            ),
+            RelationshipClassMapping(relationship_class_position, highlight_dimension=highlight_dimension),
             ParameterDefinitionMapping(definition_position),
         ]
     )
@@ -370,9 +368,7 @@ def relationship_object_parameter_export(
         object_class_positions = list()
     if object_positions is None:
         object_positions = list()
-    relationship_class = RelationshipClassMapping(
-        relationship_class_position, highlight_dimension=highlight_dimension
-    )
+    relationship_class = RelationshipClassMapping(relationship_class_position, highlight_dimension=highlight_dimension)
     object_or_relationship_class = _generate_dimensions(
         relationship_class, RelationshipClassObjectClassMapping, object_class_positions
     )

--- a/spinedb_api/export_mapping/settings.py
+++ b/spinedb_api/export_mapping/settings.py
@@ -36,9 +36,7 @@ from .export_mapping import (
     Position,
     RelationshipClassMapping,
     RelationshipClassObjectClassMapping,
-    RelationshipClassObjectHighlightingMapping,
     RelationshipMapping,
-    RelationshipObjectHighlightingMapping,
     RelationshipObjectMapping,
     ScenarioActiveFlagMapping,
     ScenarioAlternativeMapping,
@@ -321,7 +319,7 @@ def relationship_object_parameter_default_value_export(
     """
     root_mapping = unflatten(
         [
-            RelationshipClassObjectHighlightingMapping(
+            RelationshipClassMapping(
                 relationship_class_position, highlight_dimension=highlight_dimension
             ),
             ParameterDefinitionMapping(definition_position),
@@ -372,7 +370,7 @@ def relationship_object_parameter_export(
         object_class_positions = list()
     if object_positions is None:
         object_positions = list()
-    relationship_class = RelationshipClassObjectHighlightingMapping(
+    relationship_class = RelationshipClassMapping(
         relationship_class_position, highlight_dimension=highlight_dimension
     )
     object_or_relationship_class = _generate_dimensions(
@@ -382,7 +380,7 @@ def relationship_object_parameter_export(
     value_list.set_ignorable(True)
     definition = ParameterDefinitionMapping(definition_position)
     object_or_relationship_class.child = definition
-    relationship = RelationshipObjectHighlightingMapping(relationship_position)
+    relationship = RelationshipMapping(relationship_position)
     definition.child = value_list
     value_list.child = relationship
     object_or_relationship = _generate_dimensions(relationship, RelationshipObjectMapping, object_positions)

--- a/tests/export_mapping/test_export_mapping.py
+++ b/tests/export_mapping/test_export_mapping.py
@@ -32,7 +32,6 @@ from spinedb_api import (
     import_tool_feature_methods,
     import_tools,
     Map,
-    TimeSeriesFixedResolution,
 )
 from spinedb_api.import_functions import import_object_groups
 from spinedb_api.mapping import Position, to_dict
@@ -67,9 +66,7 @@ from spinedb_api.export_mapping.export_mapping import (
     ParameterValueTypeMapping,
     RelationshipClassMapping,
     RelationshipClassObjectClassMapping,
-    RelationshipClassObjectHighlightingMapping,
     RelationshipMapping,
-    RelationshipObjectHighlightingMapping,
     RelationshipObjectMapping,
     ScenarioActiveFlagMapping,
     ScenarioAlternativeMapping,
@@ -1336,13 +1333,11 @@ class TestExportMapping(unittest.TestCase):
         highlight_dimension = 5
         mappings = [
             ObjectClassMapping(0),
-            RelationshipClassMapping(Position.table_name),
-            RelationshipClassObjectHighlightingMapping(Position.header, highlight_dimension=highlight_dimension),
+            RelationshipClassMapping(Position.table_name, highlight_dimension=highlight_dimension),
             RelationshipClassObjectClassMapping(2),
             ParameterDefinitionMapping(1),
             ObjectMapping(-1),
             RelationshipMapping(Position.hidden),
-            RelationshipObjectHighlightingMapping(9),
             RelationshipObjectMapping(-1),
             AlternativeMapping(3),
             ParameterValueMapping(4),
@@ -1361,7 +1356,7 @@ class TestExportMapping(unittest.TestCase):
         for m in deserialized:
             if isinstance(m, FixedValueMapping):
                 self.assertEqual(m.value, "gaga")
-            elif isinstance(m, RelationshipClassObjectHighlightingMapping):
+            elif isinstance(m, RelationshipClassMapping):
                 self.assertEqual(m.highlight_dimension, highlight_dimension)
 
     def test_setting_ignorable_flag(self):
@@ -1531,7 +1526,7 @@ class TestExportMapping(unittest.TestCase):
         db_map.commit_session("Add test data")
         root_mapping = unflatten(
             [
-                RelationshipClassObjectHighlightingMapping(0),
+                RelationshipClassMapping(0, highlight_dimension=0),
                 RelationshipClassObjectClassMapping(1),
                 ParameterDefinitionMapping(2),
             ]
@@ -1548,7 +1543,7 @@ class TestExportMapping(unittest.TestCase):
         db_map.commit_session("Add test data")
         root_mapping = unflatten(
             [
-                RelationshipClassObjectHighlightingMapping(0),
+                RelationshipClassMapping(0, highlight_dimension=0),
                 RelationshipClassObjectClassMapping(1),
                 RelationshipClassObjectClassMapping(3),
                 ParameterDefinitionMapping(2),
@@ -1569,10 +1564,10 @@ class TestExportMapping(unittest.TestCase):
         db_map.commit_session("Add test data")
         root_mapping = unflatten(
             [
-                RelationshipClassObjectHighlightingMapping(0),
+                RelationshipClassMapping(0, highlight_dimension=0),
                 RelationshipClassObjectClassMapping(1),
                 RelationshipClassObjectClassMapping(2),
-                RelationshipObjectHighlightingMapping(3),
+                RelationshipMapping(3),
                 RelationshipObjectMapping(4),
                 RelationshipObjectMapping(5),
             ]
@@ -1595,9 +1590,9 @@ class TestExportMapping(unittest.TestCase):
         db_map.commit_session("Add test data")
         root_mapping = unflatten(
             [
-                RelationshipClassObjectHighlightingMapping(0),
+                RelationshipClassMapping(0, highlight_dimension=0),
                 RelationshipClassObjectClassMapping(1),
-                RelationshipObjectHighlightingMapping(2),
+                RelationshipMapping(2),
                 RelationshipObjectMapping(3),
                 ParameterDefinitionMapping(4),
                 AlternativeMapping(5),
@@ -1608,7 +1603,27 @@ class TestExportMapping(unittest.TestCase):
         self.assertEqual(list(rows(root_mapping, db_map)), expected)
         db_map.connection.close()
 
-    def test_export_object_parameters_while_exporting_relationships_with_multiple_parameters_and_classes(self):
+    def test_export_default_values_of_object_parameters_while_exporting_relationships(self):
+        db_map = DatabaseMapping("sqlite://", create=True)
+        import_object_classes(db_map, ("oc",))
+        import_object_parameters(db_map, (("oc", "p", 23.0),))
+        import_objects(db_map, (("oc", "o"),))
+        import_relationship_classes(db_map, (("rc", ("oc",)),))
+        import_relationships(db_map, (("rc", ("o",)),))
+        db_map.commit_session("Add test data")
+        root_mapping = unflatten(
+            [
+                RelationshipClassMapping(0, highlight_dimension=0),
+                RelationshipClassObjectClassMapping(1),
+                ParameterDefinitionMapping(2),
+                ParameterDefaultValueMapping(3),
+            ]
+        )
+        expected = [["rc", "oc", "p", 23.0]]
+        self.assertEqual(list(rows(root_mapping, db_map)), expected)
+        db_map.connection.close()
+
+    def test_export_object_parameters_while_exporting_relationships_with_multiple_parameters_and_classes2(self):
         db_map = DatabaseMapping("sqlite://", create=True)
         import_object_classes(db_map, ("oc1", "oc2", "oc3"))
         import_object_parameters(db_map, (("oc1", "p11"), ("oc1", "p12"), ("oc2", "p21"), ("oc3", "p31")))
@@ -1628,19 +1643,21 @@ class TestExportMapping(unittest.TestCase):
         db_map.commit_session("Add test data")
         root_mapping = unflatten(
             [
-                RelationshipClassObjectHighlightingMapping(0, highlight_dimension=1),
+                RelationshipClassMapping(0, highlight_dimension=1),
                 RelationshipClassObjectClassMapping(1),
-                RelationshipObjectHighlightingMapping(2),
-                RelationshipObjectMapping(3),
-                ParameterDefinitionMapping(4),
-                AlternativeMapping(5),
-                ParameterValueMapping(6),
+                RelationshipClassObjectClassMapping(2),
+                RelationshipMapping(3),
+                RelationshipObjectMapping(4),
+                RelationshipObjectMapping(5),
+                ParameterDefinitionMapping(6),
+                AlternativeMapping(7),
+                ParameterValueMapping(8),
             ]
         )
         expected = [
-            ["rc12", "oc2", "rc12_o11__o21", "o21", "p21", "Base", 5.5],
-            ["rc12", "oc2", "rc12_o12__o21", "o21", "p21", "Base", 5.5],
-            ["rc23", "oc3", "rc23_o21__o31", "o31", "p31", "Base", 7.7],
+            ["rc12", "oc1", "oc2", "rc12_o11__o21", "o11", "o21", "p21", "Base", 5.5],
+            ["rc12", "oc1", "oc2", "rc12_o12__o21", "o12", "o21", "p21", "Base", 5.5],
+            ["rc23", "oc2", "oc3", "rc23_o21__o31", "o21", "o31", "p31", "Base", 7.7],
         ]
         self.assertEqual(list(rows(root_mapping, db_map)), expected)
         db_map.connection.close()

--- a/tests/export_mapping/test_export_mapping.py
+++ b/tests/export_mapping/test_export_mapping.py
@@ -1608,6 +1608,43 @@ class TestExportMapping(unittest.TestCase):
         self.assertEqual(list(rows(root_mapping, db_map)), expected)
         db_map.connection.close()
 
+    def test_export_object_parameters_while_exporting_relationships_with_multiple_parameters_and_classes(self):
+        db_map = DatabaseMapping("sqlite://", create=True)
+        import_object_classes(db_map, ("oc1", "oc2", "oc3"))
+        import_object_parameters(db_map, (("oc1", "p11"), ("oc1", "p12"), ("oc2", "p21"), ("oc3", "p31")))
+        import_objects(db_map, (("oc1", "o11"), ("oc1", "o12"), ("oc2", "o21"), ("oc2", "o22"), ("oc3", "o31")))
+        import_object_parameter_values(db_map, (("oc1", "o11", "p11", 1.1),))
+        import_object_parameter_values(db_map, (("oc1", "o11", "p12", 2.2),))
+        import_object_parameter_values(db_map, (("oc1", "o12", "p11", 3.3),))
+        import_object_parameter_values(db_map, (("oc1", "o12", "p12", 4.4),))
+        import_object_parameter_values(db_map, (("oc2", "o21", "p21", 5.5),))
+        import_object_parameter_values(db_map, (("oc2", "o22", "p21", 6.6),))
+        import_object_parameter_values(db_map, (("oc3", "o31", "p31", 7.7),))
+        import_relationship_classes(db_map, (("rc12", ("oc1", "oc2")),))
+        import_relationship_classes(db_map, (("rc23", ("oc2", "oc3")),))
+        import_relationships(db_map, (("rc12", ("o11", "o21")),))
+        import_relationships(db_map, (("rc12", ("o12", "o21")),))
+        import_relationships(db_map, (("rc23", ("o21", "o31")),))
+        db_map.commit_session("Add test data")
+        root_mapping = unflatten(
+            [
+                RelationshipClassObjectHighlightingMapping(0, highlight_dimension=1),
+                RelationshipClassObjectClassMapping(1),
+                RelationshipObjectHighlightingMapping(2),
+                RelationshipObjectMapping(3),
+                ParameterDefinitionMapping(4),
+                AlternativeMapping(5),
+                ParameterValueMapping(6),
+            ]
+        )
+        expected = [
+            ["rc12", "oc2", "rc12_o11__o21", "o21", "p21", "Base", 5.5],
+            ["rc12", "oc2", "rc12_o12__o21", "o21", "p21", "Base", 5.5],
+            ["rc23", "oc3", "rc23_o21__o31", "o31", "p31", "Base", 7.7],
+        ]
+        self.assertEqual(list(rows(root_mapping, db_map)), expected)
+        db_map.connection.close()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Object dimension "highlighting" can be more easily implemented directly in `RelationshipClassMapping` and `RelationshipMapping` without the need for the special `RelationshipClassObjectHighlightingMapping` and
`RelationshipObjectHighlighlightingMapping`. The new implementation also does not suffer from the scalability problems of the old.

Fixes #244

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
