### PR TITLE
Black (re-)formatting

### DIFF
--- a/spinedb_api/alembic/versions/1e4997105288_separate_type_from_value.py
+++ b/spinedb_api/alembic/versions/1e4997105288_separate_type_from_value.py
@@ -19,7 +19,7 @@ down_revision = 'fbb540efbf15'
 branch_labels = None
 depends_on = None
 
-LONGTEXT_LENGTH = 2**32 - 1
+LONGTEXT_LENGTH = 2 ** 32 - 1
 
 
 def upgrade():

--- a/spinedb_api/graph_layout_generator.py
+++ b/spinedb_api/graph_layout_generator.py
@@ -129,7 +129,7 @@ class GraphLayoutGenerator:
         heavy_pos = arr(heavy_pos_list)
         if heavy_ind.any():
             layout[heavy_ind, :] = heavy_pos
-        weights = matrix**self.weight_exp  # bus-pair weights (lower for distant buses)
+        weights = matrix ** self.weight_exp  # bus-pair weights (lower for distant buses)
         maxstep = 1 / np.min(weights[mask])
         minstep = 1 / np.max(weights[mask])
         lambda_ = np.log(minstep / maxstep) / (self.max_iters - 1)  # exponential decay of allowed adjustment

--- a/spinedb_api/helpers.py
+++ b/spinedb_api/helpers.py
@@ -74,7 +74,7 @@ naming_convention = {
 
 model_meta = MetaData(naming_convention=naming_convention)
 
-LONGTEXT_LENGTH = 2**32 - 1
+LONGTEXT_LENGTH = 2 ** 32 - 1
 
 
 # NOTE: Deactivated since foreign keys are too difficult to get right in the diff tables.

--- a/spinedb_api/spine_io/gdx_utils.py
+++ b/spinedb_api/spine_io/gdx_utils.py
@@ -25,7 +25,7 @@ def _python_interpreter_bitness():
     """Returns 64 for 64bit Python interpreter or 32 for 32bit interpreter."""
     # As recommended in Python's docs:
     # https://docs.python.org/3/library/platform.html#cross-platform
-    return 64 if sys.maxsize > 2**32 else 32
+    return 64 if sys.maxsize > 2 ** 32 else 32
 
 
 def _windows_dlls_exist(gams_path):


### PR DESCRIPTION
We had to downgrade black due to dependency conflicts.

Re spine-tools/Spine-Toolbox#2115

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
