### PR TITLE
fix importer source ref. changing

### DIFF
--- a/spinedb_api/import_mapping/import_mapping.py
+++ b/spinedb_api/import_mapping/import_mapping.py
@@ -107,6 +107,7 @@ class ImportMapping(Mapping):
         self.skip_columns = skip_columns
         self.read_start_row = read_start_row
         self._has_filter_cached = None
+        self._index = None
 
     @property
     def skip_columns(self):
@@ -190,6 +191,7 @@ class ImportMapping(Mapping):
                     raise InvalidMappingComponent(msg)
             # Integer value, we try and get the actual value from that index in the header
             try:
+                self._index = self.value
                 self.value = source_header[self.value]
             except IndexError:
                 msg = f"'{self.value}' is not a valid index in header '{source_header}'"
@@ -197,7 +199,7 @@ class ImportMapping(Mapping):
 
     def _polish_for_preview(self, source_header):
         if self.position == Position.header and self.value is not None:
-            self.value = source_header.index(self.value)
+            self.value = self._index
         if self.child is not None:
             self.child._polish_for_preview(source_header)
 

--- a/tests/import_mapping/test_import_mapping.py
+++ b/tests/import_mapping/test_import_mapping.py
@@ -141,6 +141,14 @@ class TestPolishImportMapping(unittest.TestCase):
         self.assertEqual(mapping.position, Position.header)
         self.assertEqual(mapping.value, "C")
 
+    def test_polish_column_header_mapping_duplicates(self):
+        mapping = ImportMapping(Position.header, value=3)
+        table_name = "tablename"
+        header = ["A", "B", "C", "A"]
+        mapping.polish(table_name, header, for_preview=True)
+        self.assertEqual(mapping.position, Position.header)
+        self.assertEqual(mapping.value, 3)
+
     def test_polish_column_header_mapping_invalid_header(self):
         mapping = ImportMapping(Position.header, value="D")
         table_name = "tablename"


### PR DESCRIPTION
In the case of duplicate headers, the value for Source ref. in the Mapping specification dock widget used to automatically change to the first occurrence of the duplicated header. Now the given column number remains even though if there is an earlier occurrence of the same exact header.

Re spine-tools\Spine-Toolbox#2158

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
