### PR TITLE
Improve support for undo/redo functionality in Toolbox

### DIFF
--- a/spinedb_api/db_cache.py
+++ b/spinedb_api/db_cache.py
@@ -229,6 +229,7 @@ class CacheItem(dict):
         if not self._removed:
             return
         self._removed = False
+        self._to_remove = False
         for referrer in self._referrers.values():
             referrer.cascade_readd()
         for weak_referrer in self._weak_referrers.values():

--- a/spinedb_api/db_cache.py
+++ b/spinedb_api/db_cache.py
@@ -146,6 +146,10 @@ class CacheItem(dict):
             return None
         return (self._item_type, self["id"])
 
+    @property
+    def referrers(self):
+        return self._referrers
+
     def __getattr__(self, name):
         """Overridden method to return the dictionary key named after the attribute, or None if it doesn't exist."""
         return self.get(name)

--- a/spinedb_api/db_mapping_remove_mixin.py
+++ b/spinedb_api/db_mapping_remove_mixin.py
@@ -28,19 +28,26 @@ class DatabaseMappingRemoveMixin:
 
         Args:
             **kwargs: keyword is table name, argument is list of ids to remove
+
+        Returns:
+            list of CacheItem: removed items
         """
         cascading_ids = self.cascading_ids(cache=cache, **kwargs)
-        self.remove_items(**cascading_ids)
+        return self.remove_items(**cascading_ids)
 
     def remove_items(self, **kwargs):
         """Removes items by id, *not in cascade*.
 
         Args:
             **kwargs: keyword is table name, argument is list of ids to remove
+
+        Returns:
+            list of CacheItems: removed items
         """
         if not self.committing:
             return
         self._make_commit_id()
+        removed_items = []
         for tablename, ids in kwargs.items():
             if not ids:
                 continue
@@ -52,10 +59,11 @@ class DatabaseMappingRemoveMixin:
                 table_cache = self.cache.get(tablename)
                 if table_cache:
                     for id_ in ids:
-                        table_cache.remove_item(id_)
+                        removed_items += table_cache.remove_item(id_)
             except DBAPIError as e:
                 msg = f"DBAPIError while removing {tablename} items: {e.orig.args}"
                 raise SpineDBAPIError(msg) from e
+        return removed_items
 
     # pylint: disable=redefined-builtin
     def cascading_ids(self, cache=None, **kwargs):


### PR DESCRIPTION
This PR includes a number of changes that are needed to fix issues with undo commands in Toolbox.

- `CacheItem.cascade_readd()` now sets `_to_remove` to `False`. Unless I missed something, this is the only truly backwards-incompatible change.
- Functions that remove items now return the cache items that were actually removed. This makes it possible to fully undo remove actions in Toolbox.
- A new function `CacheItem.readd()` adds items without adding their referrers. This allows redoing additions that have later received referrers. For example, redoing an 'add object class' command should only readd the object class, not its parameter definitions that were added later.
- `CacheItem.deepcopy()` can be used to create independent clones of CacheItems.

Re spine-tools/Spine-Toolbox#2228

@manuelma Just a heads-up: this might interfere with the entity branch.

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [ ] Unit tests pass
