### PR TITLE
Fix editing a locked db

### DIFF
--- a/spinedb_api/db_mapping_remove_mixin.py
+++ b/spinedb_api/db_mapping_remove_mixin.py
@@ -77,13 +77,16 @@ class DatabaseMappingRemoveMixin:
             cascading_ids (dict): cascading ids keyed by table name
         """
         if cache is None:
-            cache = self.make_cache(
-                set(kwargs),
-                include_descendants=True,
-                force_tablenames={"entity_metadata", "parameter_value_metadata"}
-                if any(x in kwargs for x in ("entity_metadata", "parameter_value_metadata", "metadata"))
-                else None,
-            )
+            try:
+                cache = self.make_cache(
+                    set(kwargs),
+                    include_descendants=True,
+                    force_tablenames={"entity_metadata", "parameter_value_metadata"}
+                    if any(x in kwargs for x in ("entity_metadata", "parameter_value_metadata", "metadata"))
+                    else None,
+                )
+            except DBAPIError as e:
+                raise SpineDBAPIError(f"Fail to get cascading ids: {e.orig.args}")
         ids = {}
         self._merge(ids, self._object_class_cascading_ids(kwargs.get("object_class", set()), cache))
         self._merge(ids, self._object_cascading_ids(kwargs.get("object", set()), cache))

--- a/spinedb_api/db_mapping_update_mixin.py
+++ b/spinedb_api/db_mapping_update_mixin.py
@@ -15,7 +15,7 @@
 from collections import Counter
 from sqlalchemy.exc import DBAPIError
 from sqlalchemy.sql.expression import bindparam
-from .exception import SpineDBAPIError
+from .exception import SpineDBAPIError, SpineIntegrityError
 
 
 class DatabaseMappingUpdateMixin:
@@ -78,7 +78,10 @@ class DatabaseMappingUpdateMixin:
             )
         else:
             checked_items, intgr_error_log = list(items), []
-        updated_ids = self._update_items(tablename, *checked_items)
+        try:
+            updated_ids = self._update_items(tablename, *checked_items)
+        except SpineDBAPIError as e:
+            intgr_error_log.append(f"Fail to update items: {e}")
         if return_items:
             return checked_items, intgr_error_log
         return updated_ids, intgr_error_log


### PR DESCRIPTION
In a locked db if existing values are updated, the changes are stored in the cache and can be committed when the db is no longer locked. Removing items also works the same way. Adding items to a locked db is denied and will result in an error. If trying to commit changes in the db while it is locked an error telling the commit failed pops up. When the lock is resolved the changes can again be committed.

Re spine-tools/Spine-Toolbox#2201

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
