### PR TITLE
Fix item removal ovewriting updates in database cache

### DIFF
--- a/spinedb_api/db_mapping_remove_mixin.py
+++ b/spinedb_api/db_mapping_remove_mixin.py
@@ -83,6 +83,7 @@ class DatabaseMappingRemoveMixin:
                 force_tablenames={"entity_metadata", "parameter_value_metadata"}
                 if any(x in kwargs for x in ("entity_metadata", "parameter_value_metadata", "metadata"))
                 else None,
+                keep_existing=True,
             )
         ids = {}
         self._merge(ids, self._object_class_cascading_ids(kwargs.get("object_class", set()), cache))


### PR DESCRIPTION
We call `cascade_remove_items()` from Toolbox without supplying db cache apparently to ensure that all cascading ids get cached in `cascading_ids()`. The call to `make_cache()`, however, overwrote all existing items in the cache destroying pending updates. We now supply a new parameter, `keep_existing`, to `make_cache()` to prevent overwriting existing items.

Fixes spine-tools/Spine-Toolbox#2259

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
