### PR TITLE
Make Query.filter() accept any number of criteria

### DIFF
--- a/spinedb_api/query.py
+++ b/spinedb_api/query.py
@@ -38,8 +38,9 @@ class Query:
         self._select = select(self._entities)
         return self
 
-    def filter(self, clause):
-        self._select = self._select.where(clause)
+    def filter(self, *clauses):
+        for clause in clauses:
+            self._select = self._select.where(clause)
         return self
 
     def filter_by(self, **kwargs):


### PR DESCRIPTION
This makes `Query.filter()` consistent with SQLAlchemy and fixes broken backwards compatibility.

Fixes #267

## Checklist before merging
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
