### PR TITLE
Fix commit and redo causes Traceback

### DIFF
--- a/spinedb_api/db_cache_base.py
+++ b/spinedb_api/db_cache_base.py
@@ -769,6 +769,8 @@ class CacheItemBase(dict):
             return
         if self.status in (Status.added_and_removed, Status.to_remove):
             self._status = self._status_when_removed
+        elif self.status == Status.committed:
+            self._status = Status.to_add
         else:
             raise RuntimeError("invalid status for item being restored")
         self._removed = False


### PR DESCRIPTION
Bringing back an item by redo that was previously removed by undo didn't work and caused a Traceback. Now it should work and no errors should be raised in this case.

Fixes spine-tools/Spine-Toolbox#2325

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
