### PR TITLE
Fix importer fewer columns than expected Traceback

### DIFF
--- a/spinedb_api/import_mapping/generator.py
+++ b/spinedb_api/import_mapping/generator.py
@@ -83,6 +83,7 @@ def get_mapped_data(
     rows = list(data_source)
     if not rows:
         return mapped_data, errors
+    column_count = len(max(rows, key=lambda x: len(x) if x else 0))
     if column_convert_fns is None:
         column_convert_fns = {}
     if row_convert_fns is None:
@@ -92,7 +93,7 @@ def get_mapped_data(
     for mapping in mappings:
         read_state = {}
         mapping = deepcopy(mapping)
-        mapping.polish(table_name, data_header)
+        mapping.polish(table_name, data_header, column_count)
         mapping_errors = check_validity(mapping)
         if mapping_errors:
             errors += mapping_errors

--- a/spinedb_api/spine_io/importers/reader.py
+++ b/spinedb_api/spine_io/importers/reader.py
@@ -16,7 +16,7 @@ Contains a class template for a data source connector used in import ui.
 
 from itertools import islice
 
-from spinedb_api.exception import ConnectorError
+from spinedb_api.exception import ConnectorError, InvalidMappingComponent
 from spinedb_api.import_mapping.generator import get_mapped_data, identity
 from spinedb_api.import_mapping.import_mapping_compat import parse_named_mapping_spec
 from spinedb_api import DateTime, Duration, ParameterValueFormatError
@@ -151,7 +151,7 @@ class SourceConnection:
                     row_convert_fns,
                     unparse_value,
                 )
-            except (ConnectorError, ParameterValueFormatError) as error:
+            except (ConnectorError, ParameterValueFormatError, InvalidMappingComponent) as error:
                 errors.append(str(error))
                 continue
             for key, value in data.items():


### PR DESCRIPTION
Now when an importer spec is modified to have a column reference that is out of range for the source data, an error is shown. If such importer spec is executed an error will also be thrown and logged.

Fixes spine-tools/Spine-Toolbox#2333

## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes in Toolbox repo have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black
- [ ] Unit tests pass
