### PR TITLE
Fix docs/requirements.txt

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,6 +13,7 @@ build:
     
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
+  builder: html
   configuration: docs/source/conf.py
 
 # Optionally build your docs in additional formats such as PDF and ePub

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,9 @@
 # Requirements for compiling the documentation
-sphinx >= 7.1.2
-sphinx_rtd_theme >= 0.4.3
-recommonmark >= 0.6.0
-sphinx-autoapi >= 2.0.0
+markupsafe < 2.1  # Jinja2<3.0 tries to import soft_unicode, which has been removed in markupsafe 2.1
+jinja2 < 3.0  # Dagster 0.12.8 requires Jinja2<3.0
+docutils < 0.17
+sphinx < 5.2
+sphinx_rtd_theme
+recommonmark
+astroid < 3.0  # sphinx-autoapi installs the latest astroid. We are not compatible with astroid v3.0
+sphinx-autoapi < 2.1  # 2.1 removed support for sphinx < 5.2.0

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -74,7 +74,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.


### PR DESCRIPTION
This PR makes docs/requirements.txt compatible with Spine Toolbox requirements. When merged this commit should be cherry picked to master as well.

Re spine-tools/Spine-Toolbox#2342

## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes in Toolbox repo have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black
- [ ] Unit tests pass
