### PR TITLE
Make export alternative mapping fully stand-alone

### DIFF
--- a/spinedb_api/export_mapping/export_mapping.py
+++ b/spinedb_api/export_mapping/export_mapping.py
@@ -1279,9 +1279,12 @@ class AlternativeMapping(ExportMapping):
         )
 
     def filter_query(self, db_map, query):
-        if self.parent is None:
-            return query
-        return query.filter(db_map.alternative_sq.c.id == db_map.parameter_value_sq.c.alternative_id)
+        parent = self.parent
+        while parent is not None:
+            if isinstance(parent, ParameterDefinitionMapping):
+                return query.filter(db_map.alternative_sq.c.id == db_map.parameter_value_sq.c.alternative_id)
+            parent = parent.parent
+        return query
 
     @staticmethod
     def name_field():

--- a/spinedb_api/import_functions.py
+++ b/spinedb_api/import_functions.py
@@ -351,7 +351,7 @@ def import_scenarios(db_map, data):
 
     Args:
         db_map (spinedb_api.DiffDatabaseMapping): database mapping
-        data (list(str,str)): tuples of (name, description)
+        data (list(str, bool, str)): tuples of (name, <unused_bool>, description)
 
     Returns:
         int: number of items imported


### PR DESCRIPTION
Export `AlternativeMapping` incorrectly assumed to be part of parameter value export when it wasn't the root mapping making it unusable without `ParameterDefinitionMapping` etc.

Re spine-tools/Spine-Toolbox#2339

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
