### PR TITLE
Make unsupported database dialects official - fix for 0.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,9 @@ description = "An API to talk to Spine databases."
 keywords = ["energy system modelling", "workflow", "optimisation", "database"]
 readme = {file = "README.md", content-type = "text/markdown"}
 classifiers = [
-	    "Programming Language :: Python :: 3",
-	    "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
-	    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
+    "Operating System :: OS Independent",
 ]
 requires-python = ">=3.8.1, <3.12"
 dependencies = [
@@ -27,6 +27,8 @@ dependencies = [
     "ijson >=3.1.4",
     "chardet >=4.0.0",
     "pymysql >=1.0.2",
+    "psycopg2",
+    "cx_Oracle",
 ]
 
 [project.urls]
@@ -49,10 +51,10 @@ include-package-data = true
 
 [tool.setuptools.packages.find]
 exclude = [
-	"bin*",
-	"docs*",
-	"fig*",
-	"tests*",
+    "bin*",
+    "docs*",
+    "fig*",
+    "tests*",
 ]
 
 [tool.coverage.run]

--- a/spinedb_api/helpers.py
+++ b/spinedb_api/helpers.py
@@ -56,16 +56,20 @@ from alembic.migration import MigrationContext
 from alembic.environment import EnvironmentContext
 from .exception import SpineDBAPIError, SpineDBVersionError
 
-# Supported dialects and recommended dbapi. Restricted to mysql and sqlite for now:
-# - sqlite works
-# - mysql is trying to work
 SUPPORTED_DIALECTS = {
     "mysql": "pymysql",
     "sqlite": "sqlite3",
-    # "mssql": "pyodbc",
-    # "postgresql": "psycopg2",
-    # "oracle": "cx_oracle",
 }
+"""Currently supported dialects and recommended dbapi."""
+
+
+UNSUPPORTED_DIALECTS = {
+    "mssql": "pyodbc",
+    "postgresql": "psycopg2",
+    "oracle": "cx_oracle",
+}
+"""Dialects and recommended dbapi that are not supported by DatabaseMapping but are supported by SqlAlchemy."""
+
 
 naming_convention = {
     "pk": "pk_%(table_name)s",


### PR DESCRIPTION
This PR adds `psycopg2` and `cx_Oracle` packages to dependencies so the `spine_io` package can support more dialects when importing/exporting data from/to generic database.

Re spine-tools/Spine-Toolbox#2329

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
