### PR TITLE
Add CommitItem

### DIFF
--- a/spinedb_api/mapped_items.py
+++ b/spinedb_api/mapped_items.py
@@ -18,6 +18,7 @@ from .temp_id import TempId
 
 def item_factory(item_type):
     return {
+        "commit": CommitItem,
         "entity_class": EntityClassItem,
         "entity": EntityItem,
         "entity_alternative": EntityAlternativeItem,
@@ -33,6 +34,18 @@ def item_factory(item_type):
         "entity_metadata": EntityMetadataItem,
         "parameter_value_metadata": ParameterValueMetadataItem,
     }.get(item_type, MappedItemBase)
+
+
+class CommitItem(MappedItemBase):
+    fields = {
+        "comment": ("str", "A comment describing the commit."),
+        "date": {"datetime", "Date and time of the commit."},
+        "user": {"str", "Username of the committer."},
+    }
+    _unique_keys = (("date",),)
+
+    def commit(self, commit_id):
+        raise RuntimeError("Commits are created automatically when session is committed.")
 
 
 class EntityClassItem(MappedItemBase):

--- a/tests/test_DatabaseMapping.py
+++ b/tests/test_DatabaseMapping.py
@@ -258,6 +258,12 @@ class TestDatabaseMapping(unittest.TestCase):
                 db_map.commit_session("Added a class")
                 self.assertFalse(db_map.has_external_commits())
 
+    def test_get_items_gives_commits(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            items = db_map.get_items("commit")
+            self.assertEqual(len(items), 1)
+            self.assertEqual(items[0].item_type, "commit")
+
 
 class TestDatabaseMappingLegacy(unittest.TestCase):
     """'Backward compatibility' tests, i.e. pre-entity tests converted to work with the entity structure."""


### PR DESCRIPTION
This makes it possible to `get_items("commit")`. Handy for things like Database editor's Commit viewer.


Fixes #spine-tools/Spine-Toolbox#2366

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
