### PR TITLE
Fix importing scenario alternatives out-of-order

### DIFF
--- a/spinedb_api/helpers.py
+++ b/spinedb_api/helpers.py
@@ -66,7 +66,6 @@ UNSUPPORTED_DIALECTS = {
     "mssql": "pyodbc",
     "postgresql": "psycopg2",
     "oracle": "cx_oracle",
-
 }
 
 naming_convention = {

--- a/tests/filters/test_scenario_filter.py
+++ b/tests/filters/test_scenario_filter.py
@@ -248,7 +248,7 @@ class TestScenarioFilter(unittest.TestCase):
         import_object_parameter_values(self._out_map, [("object_class", "object", "parameter", 300.0, "alternative3")])
         import_scenarios(self._out_map, [("scenario", True)])
         import_scenarios(self._out_map, [("non_active_scenario", False)])
-        import_scenario_alternatives(
+        result = import_scenario_alternatives(
             self._out_map,
             [
                 ("scenario", "alternative2"),
@@ -256,7 +256,8 @@ class TestScenarioFilter(unittest.TestCase):
                 ("scenario", "alternative1", "alternative3"),
             ],
         )
-        import_scenario_alternatives(
+        self.assertEqual(result, (7, []))
+        result = import_scenario_alternatives(
             self._out_map,
             [
                 ("non_active_scenario", "non_active_alternative"),
@@ -265,6 +266,7 @@ class TestScenarioFilter(unittest.TestCase):
                 ("scenario", "alternative1", "alternative3"),
             ],
         )
+        self.assertEqual(result, (11, []))
         self._out_map.commit_session("Add test data")
         for db_map in [self._db_map, self._diff_db_map]:
             apply_scenario_filter_to_subqueries(db_map, "scenario")
@@ -278,6 +280,7 @@ class TestScenarioFilter(unittest.TestCase):
                     {"name": "alternative3", "description": None, "id": 2, "commit_id": 2},
                     {"name": "alternative1", "description": None, "id": 3, "commit_id": 2},
                     {"name": "alternative2", "description": None, "id": 4, "commit_id": 2},
+                    {"name": "non_active_alternative", "description": None, "id": 5, "commit_id": 2},
                 ],
             )
             scenarios = [s._asdict() for s in db_map.query(db_map.wide_scenario_sq).all()]
@@ -288,8 +291,8 @@ class TestScenarioFilter(unittest.TestCase):
                         "name": "scenario",
                         "description": None,
                         "active": True,
-                        "alternative_name_list": "alternative1,alternative3,alternative2",
-                        "alternative_id_list": "3,2,4",
+                        "alternative_name_list": "alternative1,alternative3,alternative2,non_active_alternative",
+                        "alternative_id_list": "3,2,4,5",
                         "id": 1,
                         "commit_id": 2,
                     }

--- a/tests/test_import_functions.py
+++ b/tests/test_import_functions.py
@@ -1061,6 +1061,41 @@ class TestImportScenarioAlternative(unittest.TestCase):
         self.assertTrue(errors)
         self.assertEqual(count, 2)
 
+    def test_importing_existing_scenario_alternative_does_not_alter_scenario_alternatives(self):
+        count, errors = import_scenario_alternatives(
+            self._db_map,
+            [["scenario", "alternative2", "alternative1"], ["scenario", "alternative1"]],
+        )
+        self.assertFalse(errors)
+        self.assertEqual(count, 5)
+        scenario_alternatives = self.scenario_alternatives()
+        self.assertEqual(scenario_alternatives, {"scenario": {"alternative1": 2, "alternative2": 1}})
+        count, errors = import_scenario_alternatives(
+            self._db_map,
+            [["scenario", "alternative1"]],
+        )
+        self.assertFalse(errors)
+        self.assertEqual(count, 3)
+        scenario_alternatives = self.scenario_alternatives()
+        self.assertEqual(scenario_alternatives, {"scenario": {"alternative1": 2, "alternative2": 1}})
+
+    def test_import_scenario_alternatives_in_arbitrary_order(self):
+        count, errors = import_scenarios(self._db_map, [('A (1)', False, '')])
+        self.assertEqual(errors, [])
+        self.assertEqual(count, 1)
+        count, errors = import_alternatives(
+            self._db_map, [('Base', 'Base alternative'), ('b', ''), ('c', ''), ('d', '')]
+        )
+        self.assertEqual(errors, [])
+        self.assertEqual(count, 4)
+        count, errors = import_scenario_alternatives(
+            self._db_map, [('A (1)', 'c', 'd'), ('A (1)', 'd', None), ('A (1)', 'Base', 'b'), ('A (1)', 'b', 'c')]
+        )
+        self.assertEqual(errors, [])
+        self.assertEqual(count, 9)
+        scenario_alternatives = self.scenario_alternatives()
+        self.assertEqual(scenario_alternatives, {"A (1)": {"Base": 1, "b": 2, "c": 3, "d": 4}})
+
     def scenario_alternatives(self):
         scenario_alternative_qry = (
             self._db_map.query(


### PR DESCRIPTION
This PR fixes cases where before alternatives were not introduced in order in the import data, e.g.

```python
import_scenario_alternatives(
    self._db_map, [('A', 'c', 'd'), ('A', 'd', None), ('A', 'Base', 'b'), ('A', 'b', 'c')]
)
```
now correctly orders the alternatives as Base, b, c, d whereas before this fix, the order was b, c, d, Base

Fixes spine-tools/Spine-Toolbox#2374

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
