### PR TITLE
Make remove_credentials_from_url() work with special characters

### DIFF
--- a/spinedb_api/helpers.py
+++ b/spinedb_api/helpers.py
@@ -839,10 +839,11 @@ def remove_credentials_from_url(url):
     Returns:
         str: sanitized URL
     """
-    parsed = urlparse(url)
-    if parsed.username is None:
+    if "@" not in url:
         return url
-    return urlunparse(parsed._replace(netloc=parsed.netloc.partition("@")[-1]))
+    head, tail = url.rsplit("@", maxsplit=1)
+    scheme, credentials = head.split("://", maxsplit=1)
+    return scheme + "://" + tail
 
 
 def group_consecutive(list_of_numbers):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -8,36 +8,41 @@
 # Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
-
-"""
-Unit tests for helpers.py.
-
-"""
+"""Unit tests for helpers.py."""
 
 
 import unittest
-from spinedb_api.helpers import compare_schemas, create_new_spine_database
+from spinedb_api.helpers import compare_schemas, create_new_spine_database, remove_credentials_from_url
 
 
-class TestHelpers(unittest.TestCase):
-    def setUp(self):
-        pass
-
-    def tearDown(self):
-        pass
-
+class TestCreateNewSpineEngine(unittest.TestCase):
     def test_same_schema(self):
-        """Test that importing object class works"""
         engine1 = create_new_spine_database('sqlite://')
         engine2 = create_new_spine_database('sqlite://')
         self.assertTrue(compare_schemas(engine1, engine2))
 
     def test_different_schema(self):
-        """Test that importing object class works"""
         engine1 = create_new_spine_database('sqlite://')
         engine2 = create_new_spine_database('sqlite://')
         engine2.execute("drop table entity")
         self.assertFalse(compare_schemas(engine1, engine2))
+
+
+class TestRemoveCredentialsFromUrl(unittest.TestCase):
+    def test_url_without_credentials_is_returned_as_is(self):
+        url = "mysql://example.com/db"
+        sanitized = remove_credentials_from_url(url)
+        self.assertEqual(url, sanitized)
+
+    def test_username_and_password_are_removed(self):
+        url = "mysql://user:secret@example.com/db"
+        sanitized = remove_credentials_from_url(url)
+        self.assertEqual(sanitized, "mysql://example.com/db")
+
+    def test_password_with_special_characters(self):
+        url = "mysql://user:p@ass://word@example.com/db"
+        sanitized = remove_credentials_from_url(url)
+        self.assertEqual(sanitized, "mysql://example.com/db")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Some special characters (`?`, `@`, etc.) in passwords broke `remove_credentials_from_url()`.

No related issue

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
