### PR TITLE
Add methods to generate entity and entity class names

### DIFF
--- a/spinedb_api/helpers.py
+++ b/spinedb_api/helpers.py
@@ -17,7 +17,6 @@ import json
 import warnings
 from operator import itemgetter
 from itertools import groupby
-from urllib.parse import urlparse, urlunparse
 from sqlalchemy import (
     Boolean,
     BigInteger,
@@ -79,6 +78,32 @@ naming_convention = {
 model_meta = MetaData(naming_convention=naming_convention)
 
 LONGTEXT_LENGTH = 2 ** 32 - 1
+
+
+def name_from_elements(elements):
+    """Creates an entity name by combining element names.
+
+    Args:
+        elements (Sequence of str): element names
+
+    Returns:
+        str: entity name
+    """
+    if len(elements) == 1:
+        return elements[0] + "__"
+    return "__".join(elements)
+
+
+def name_from_dimensions(dimensions):
+    """Creates an entity class name by combining dimension names.
+
+    Args:
+        dimensions (Sequence of str): dimension names
+
+    Returns:
+        str: entity class name
+    """
+    return name_from_elements(dimensions)
 
 
 # NOTE: Deactivated since foreign keys are too difficult to get right in the diff tables.

--- a/spinedb_api/mapped_items.py
+++ b/spinedb_api/mapped_items.py
@@ -10,6 +10,8 @@
 ######################################################################################################################
 
 from operator import itemgetter
+
+from .helpers import name_from_elements
 from .parameter_value import to_database, from_database, ParameterValueFormatError
 from .db_mapping_base import MappedItemBase
 
@@ -168,7 +170,7 @@ class EntityItem(MappedItemBase):
                     return f"element '{el_name}' is not an instance of class '{dim_name}'"
         if self.get("name") is not None:
             return
-        base_name = "__".join(self["element_name_list"])
+        base_name = name_from_elements(self["element_name_list"])
         name = base_name
         index = 1
         while any(

--- a/tests/test_DatabaseMapping.py
+++ b/tests/test_DatabaseMapping.py
@@ -24,6 +24,7 @@ from spinedb_api import (
     SpineDBAPIError,
     SpineIntegrityError,
 )
+from spinedb_api.helpers import name_from_elements
 from .custom_db_mapping import CustomDatabaseMapping
 
 
@@ -676,7 +677,7 @@ class TestDatabaseMappingQueries(unittest.TestCase):
         entity_rows = self._db_map.query(self._db_map.entity_sq).all()
         self.assertEqual(len(entity_rows), len(objects) + len(relationships))
         object_names = [o[1] for o in objects]
-        relationship_names = ["__".join(r[1]) for r in relationships]
+        relationship_names = [name_from_elements(r[1]) for r in relationships]
         for row, expected_name in zip(entity_rows, object_names + relationship_names):
             self.assertEqual(row.name, expected_name)
 
@@ -720,7 +721,7 @@ class TestDatabaseMappingQueries(unittest.TestCase):
         relationship_rows = self._db_map.query(self._db_map.wide_relationship_sq).all()
         self.assertEqual(len(relationship_rows), 2)
         for row, relationship in zip(relationship_rows, relationships):
-            self.assertEqual(row.name, "__".join(relationship[1]))
+            self.assertEqual(row.name, name_from_elements(relationship[1]))
             self.assertEqual(row.class_name, relationship[0])
             self.assertEqual(row.object_class_name_list, ",".join(object_classes[relationship[0]]))
             self.assertEqual(row.object_name_list, ",".join(relationship[1]))

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -12,7 +12,29 @@
 
 
 import unittest
-from spinedb_api.helpers import compare_schemas, create_new_spine_database, remove_credentials_from_url
+from spinedb_api.helpers import (
+    compare_schemas,
+    create_new_spine_database,
+    name_from_dimensions,
+    name_from_elements,
+    remove_credentials_from_url,
+)
+
+
+class TestNameFromElements(unittest.TestCase):
+    def test_single_element(self):
+        self.assertEqual(name_from_elements(("a",)), "a__")
+
+    def test_multiple_elements(self):
+        self.assertEqual(name_from_elements(("a", "b")), "a__b")
+
+
+class TestNameFromDimensions(unittest.TestCase):
+    def test_single_dimension(self):
+        self.assertEqual(name_from_dimensions(("a",)), "a__")
+
+    def test_multiple_dimension(self):
+        self.assertEqual(name_from_dimensions(("a", "b")), "a__b")
 
 
 class TestCreateNewSpineEngine(unittest.TestCase):


### PR DESCRIPTION
Having functions to generate entity class names from dimension and entity names from elements makes it easier to standardize the naming conventions and change the default later on.

Re spine-tools/Spine-Toolbox#2421

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [ ] Unit tests pass
