### PR TITLE
Make multidimensional entity naming more consistent

### DIFF
--- a/spinedb_api/helpers.py
+++ b/spinedb_api/helpers.py
@@ -17,7 +17,6 @@ import json
 import warnings
 from operator import itemgetter
 from itertools import groupby
-from urllib.parse import urlparse, urlunparse
 from sqlalchemy import (
     Boolean,
     BigInteger,
@@ -79,6 +78,32 @@ naming_convention = {
 model_meta = MetaData(naming_convention=naming_convention)
 
 LONGTEXT_LENGTH = 2 ** 32 - 1
+
+
+def name_from_elements(elements):
+    """Creates an entity name by combining element names.
+
+    Args:
+        elements (Sequence of str): element names
+
+    Returns:
+        str: entity name
+    """
+    if len(elements) == 1:
+        return elements[0] + "__"
+    return "__".join(elements)
+
+
+def name_from_dimensions(dimensions):
+    """Creates an entity class name by combining dimension names.
+
+    Args:
+        dimensions (Sequence of str): dimension names
+
+    Returns:
+        str: entity class name
+    """
+    return name_from_elements(dimensions)
 
 
 # NOTE: Deactivated since foreign keys are too difficult to get right in the diff tables.

--- a/spinedb_api/mapped_items.py
+++ b/spinedb_api/mapped_items.py
@@ -10,6 +10,8 @@
 ######################################################################################################################
 
 from operator import itemgetter
+
+from .helpers import name_from_elements
 from .parameter_value import to_database, from_database, ParameterValueFormatError
 from .db_mapping_base import MappedItemBase
 
@@ -168,7 +170,7 @@ class EntityItem(MappedItemBase):
                     return f"element '{el_name}' is not an instance of class '{dim_name}'"
         if self.get("name") is not None:
             return
-        base_name = "__".join(self["element_name_list"])
+        base_name = name_from_elements(self["element_name_list"])
         name = base_name
         index = 1
         while any(

--- a/tests/export_mapping/test_export_mapping.py
+++ b/tests/export_mapping/test_export_mapping.py
@@ -821,7 +821,7 @@ class TestExportMapping(unittest.TestCase):
         element1_mapping = relationship_mapping.child = ElementMapping(4)
         element1_mapping.child = ElementMapping(5)
         expected = [
-            ['rc1', 'oc1', '', 'o11', 'o11', ''],
+            ['rc1', 'oc1', '', 'o11__', 'o11', ''],
             ['rc2', 'oc2', 'oc1', 'o21__o11', 'o21', 'o11'],
             ['rc2', 'oc2', 'oc1', 'o21__o12', 'o21', 'o12'],
         ]
@@ -1486,28 +1486,27 @@ class TestExportMapping(unittest.TestCase):
         db_map.close()
 
     def test_export_object_parameters_while_exporting_relationships(self):
-        db_map = DatabaseMapping("sqlite://", create=True)
-        import_object_classes(db_map, ("oc",))
-        import_object_parameters(db_map, (("oc", "p"),))
-        import_objects(db_map, (("oc", "o"),))
-        import_object_parameter_values(db_map, (("oc", "o", "p", 23.0),))
-        import_relationship_classes(db_map, (("rc", ("oc",)),))
-        import_relationships(db_map, (("rc", ("o",)),))
-        db_map.commit_session("Add test data")
-        root_mapping = unflatten(
-            [
-                EntityClassMapping(0, highlight_position=0),
-                DimensionMapping(1),
-                EntityMapping(2),
-                ElementMapping(3),
-                ParameterDefinitionMapping(4),
-                AlternativeMapping(5),
-                ParameterValueMapping(6),
-            ]
-        )
-        expected = [["rc", "oc", "o", "o", "p", "Base", 23.0]]
-        self.assertEqual(list(rows(root_mapping, db_map)), expected)
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            import_object_classes(db_map, ("oc",))
+            import_object_parameters(db_map, (("oc", "p"),))
+            import_objects(db_map, (("oc", "o"),))
+            import_object_parameter_values(db_map, (("oc", "o", "p", 23.0),))
+            import_relationship_classes(db_map, (("rc", ("oc",)),))
+            import_relationships(db_map, (("rc", ("o",)),))
+            db_map.commit_session("Add test data")
+            root_mapping = unflatten(
+                [
+                    EntityClassMapping(0, highlight_position=0),
+                    DimensionMapping(1),
+                    EntityMapping(2),
+                    ElementMapping(3),
+                    ParameterDefinitionMapping(4),
+                    AlternativeMapping(5),
+                    ParameterValueMapping(6),
+                ]
+            )
+            expected = [["rc", "oc", "o__", "o", "p", "Base", 23.0]]
+            self.assertEqual(list(rows(root_mapping, db_map)), expected)
 
     def test_export_default_values_of_object_parameters_while_exporting_relationships(self):
         db_map = DatabaseMapping("sqlite://", create=True)

--- a/tests/test_DatabaseMapping.py
+++ b/tests/test_DatabaseMapping.py
@@ -24,6 +24,7 @@ from spinedb_api import (
     SpineDBAPIError,
     SpineIntegrityError,
 )
+from spinedb_api.helpers import name_from_elements
 from .custom_db_mapping import CustomDatabaseMapping
 
 
@@ -676,7 +677,7 @@ class TestDatabaseMappingQueries(unittest.TestCase):
         entity_rows = self._db_map.query(self._db_map.entity_sq).all()
         self.assertEqual(len(entity_rows), len(objects) + len(relationships))
         object_names = [o[1] for o in objects]
-        relationship_names = ["__".join(r[1]) for r in relationships]
+        relationship_names = [name_from_elements(r[1]) for r in relationships]
         for row, expected_name in zip(entity_rows, object_names + relationship_names):
             self.assertEqual(row.name, expected_name)
 
@@ -720,7 +721,7 @@ class TestDatabaseMappingQueries(unittest.TestCase):
         relationship_rows = self._db_map.query(self._db_map.wide_relationship_sq).all()
         self.assertEqual(len(relationship_rows), 2)
         for row, relationship in zip(relationship_rows, relationships):
-            self.assertEqual(row.name, "__".join(relationship[1]))
+            self.assertEqual(row.name, name_from_elements(relationship[1]))
             self.assertEqual(row.class_name, relationship[0])
             self.assertEqual(row.object_class_name_list, ",".join(object_classes[relationship[0]]))
             self.assertEqual(row.object_name_list, ",".join(relationship[1]))
@@ -1453,7 +1454,7 @@ class TestDatabaseMappingAdd(unittest.TestCase):
             dict(entity_metadata[0]),
             {
                 "entity_id": 2,
-                "entity_name": "my_object",
+                "entity_name": "my_object__",
                 "metadata_name": "title",
                 "metadata_value": "My metadata.",
                 "metadata_id": 1,

--- a/tests/test_export_functions.py
+++ b/tests/test_export_functions.py
@@ -105,7 +105,7 @@ class TestExportFunctions(unittest.TestCase):
         self.assertIn("entities", exported)
         self.assertEqual(
             exported["entities"],
-            [("object_class", "object", (), None), ("relationship_class", "object", ("object",), None)],
+            [("object_class", "object", (), None), ("relationship_class", "object__", ("object",), None)],
         )
         self.assertIn("parameter_values", exported)
         self.assertEqual(

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -12,7 +12,29 @@
 
 
 import unittest
-from spinedb_api.helpers import compare_schemas, create_new_spine_database, remove_credentials_from_url
+from spinedb_api.helpers import (
+    compare_schemas,
+    create_new_spine_database,
+    name_from_dimensions,
+    name_from_elements,
+    remove_credentials_from_url,
+)
+
+
+class TestNameFromElements(unittest.TestCase):
+    def test_single_element(self):
+        self.assertEqual(name_from_elements(("a",)), "a__")
+
+    def test_multiple_elements(self):
+        self.assertEqual(name_from_elements(("a", "b")), "a__b")
+
+
+class TestNameFromDimensions(unittest.TestCase):
+    def test_single_dimension(self):
+        self.assertEqual(name_from_dimensions(("a",)), "a__")
+
+    def test_multiple_dimension(self):
+        self.assertEqual(name_from_dimensions(("a", "b")), "a__b")
 
 
 class TestCreateNewSpineEngine(unittest.TestCase):

--- a/tests/test_import_functions.py
+++ b/tests/test_import_functions.py
@@ -354,7 +354,7 @@ class TestImportRelationship(unittest.TestCase):
         _, errors = import_relationships(db_map, (("relationship_class", ("object",)),))
         self.assertFalse(errors)
         db_map.commit_session("test")
-        self.assertIn("object", [r.name for r in db_map.query(db_map.relationship_sq)])
+        self.assertIn("object__", [r.name for r in db_map.query(db_map.relationship_sq)])
         db_map.close()
 
     def test_import_valid_relationship(self):
@@ -1399,7 +1399,7 @@ class TestImportParameterValueMetadata(unittest.TestCase):
             dict(metadata[0]),
             {
                 "alternative_name": "Base",
-                "entity_name": "object",
+                "entity_name": "object__",
                 "id": 1,
                 "metadata_id": 1,
                 "metadata_name": "co-author",
@@ -1413,7 +1413,7 @@ class TestImportParameterValueMetadata(unittest.TestCase):
             dict(metadata[1]),
             {
                 "alternative_name": "Base",
-                "entity_name": "object",
+                "entity_name": "object__",
                 "id": 2,
                 "metadata_id": 2,
                 "metadata_name": "age",


### PR DESCRIPTION
Toolbox' Database editor prepends 1-dimensional entity names with double underscore `__`. This PR makes `import_functions` consistent with that behavior.

Re spine-tools/Spine-Toolbox#2423

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
