### PR TITLE
Make SqlAlchemyConnector work with database schemas

### DIFF
--- a/spinedb_api/spine_io/importers/csv_reader.py
+++ b/spinedb_api/spine_io/importers/csv_reader.py
@@ -46,11 +46,12 @@ class CSVConnector(SourceConnection):
         super().__init__(settings)
         self._filename = None
 
-    def connect_to_source(self, source):
+    def connect_to_source(self, source, **extras):
         """saves filepath
 
-        Arguments:
+        Args:
             source (str): filepath
+            **extras: ignored
         """
         self._filename = source
 

--- a/spinedb_api/spine_io/importers/datapackage_reader.py
+++ b/spinedb_api/spine_io/importers/datapackage_reader.py
@@ -58,11 +58,12 @@ class DataPackageConnector(SourceConnection):
         self.__dict__.update(state)
         self._resource_name_lock = threading.Lock()
 
-    def connect_to_source(self, source):
+    def connect_to_source(self, source, **extras):
         """Creates datapackage.
 
         Args:
             source (str): filepath of a datapackage.json file
+            **extras: ignored
         """
         if source:
             self._datapackage = Package(source)

--- a/spinedb_api/spine_io/importers/excel_reader.py
+++ b/spinedb_api/spine_io/importers/excel_reader.py
@@ -42,11 +42,12 @@ class ExcelConnector(SourceConnection):
         self._filename = None
         self._wb = None
 
-    def connect_to_source(self, source):
-        """saves filepath
+    def connect_to_source(self, source, **extras):
+        """Connects to Excel file.
 
-        Arguments:
-            source {str} -- filepath
+        Args:
+            source (str): path to file
+            **extras: ignored
         """
         if source:
             self._filename = source

--- a/spinedb_api/spine_io/importers/gdx_connector.py
+++ b/spinedb_api/spine_io/importers/gdx_connector.py
@@ -54,12 +54,13 @@ class GdxConnector(SourceConnection):
     def __del__(self):
         self.disconnect()
 
-    def connect_to_source(self, source):
+    def connect_to_source(self, source, **extras):
         """
         Connects to given .gdx file.
 
         Args:
             source (str): path to .gdx file.
+            **extras: ignored
         """
         if self._gams_dir is None:
             raise IOError(f"Could not find GAMS directory. Make sure you have GAMS installed.")

--- a/spinedb_api/spine_io/importers/json_reader.py
+++ b/spinedb_api/spine_io/importers/json_reader.py
@@ -37,11 +37,12 @@ class JSONConnector(SourceConnection):
         self._filename = None
         self._root_prefix = None
 
-    def connect_to_source(self, source):
+    def connect_to_source(self, source, **extras):
         """saves filepath
 
         Args:
             source (str): filepath
+            **extras: ignored
         """
         self._filename = source
         self._root_prefix = os.path.splitext(os.path.basename(source))[0]

--- a/spinedb_api/spine_io/importers/reader.py
+++ b/spinedb_api/spine_io/importers/reader.py
@@ -54,11 +54,12 @@ class SourceConnection:
             settings (dict, optional): connector specific settings or None
         """
 
-    def connect_to_source(self, source):
+    def connect_to_source(self, source, **extras):
         """Connects to source, ex: connecting to a database where source is a connection string.
 
-        Arguments:
-            source {} -- object with information on source to be connected to, ex: filepath string for a csv connection
+        Args:
+            source (str): file path or URL to connect to
+            **extras: additional source specific connection data
         """
         raise NotImplementedError()
 


### PR DESCRIPTION
It is now possible to pass database schema to `SqlAlchemyConnector.connect_to_source()`

Re spine-tools/Spine-Toolbox#2329

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
