### PR TITLE
Make entity and value metadata use class_name as unique key

### DIFF
--- a/spinedb_api/db_mapping.py
+++ b/spinedb_api/db_mapping.py
@@ -157,11 +157,8 @@ class DatabaseMapping(DatabaseMappingQueryMixin, DatabaseMappingCommitMixin, Dat
         self._filter_configs = filter_configs if apply_filters else None
         try:
             self.sa_url = make_url(db_url)
-        except ArgumentError as err:
-            raise SpineDBAPIError(
-                f"Could not parse the given URL. "
-                f"Please check that it is valid."
-            )
+        except ArgumentError:
+            raise SpineDBAPIError("Could not parse the given URL. Please check that it is valid.")
         self.username = username if username else "anon"
         self.codename = self._make_codename(codename)
         self._memory = memory

--- a/spinedb_api/import_functions.py
+++ b/spinedb_api/import_functions.py
@@ -642,7 +642,7 @@ def _get_metadata_for_import(db_map, data):
 
 
 def _get_entity_metadata_for_import(db_map, data):
-    key = ("entity_class_name", "entity_byname", "metadata_name", "metadata_value")
+    key = ("class_name", "entity_byname", "metadata_name", "metadata_value")
     for class_name, entity_byname, metadata in data:
         if isinstance(entity_byname, str):
             entity_byname = (entity_byname,)
@@ -652,7 +652,7 @@ def _get_entity_metadata_for_import(db_map, data):
 
 def _get_parameter_value_metadata_for_import(db_map, data):
     key = (
-        "entity_class_name",
+        "class_name",
         "entity_byname",
         "parameter_definition_name",
         "metadata_name",


### PR DESCRIPTION
`class_name` is required to uniquely identify entities and parameter values.

Fixes #328
Re #318

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
