### PR TITLE
Fix opening infinite db editor tabs from same db

### DIFF
--- a/spinedb_api/db_mapping.py
+++ b/spinedb_api/db_mapping.py
@@ -211,7 +211,7 @@ class DatabaseMapping(DatabaseMappingQueryMixin, DatabaseMappingCommitMixin, Dat
         if not self.sa_url.drivername.startswith("sqlite"):
             return self.sa_url.database
         if self.sa_url.database is not None:
-            return os.path.basename(self.sa_url.database)
+            return os.path.splitext(os.path.basename(self.sa_url.database))[0]
         hashing = hashlib.sha1()
         hashing.update(bytes(str(time.time()), "utf-8"))
         return hashing.hexdigest()


### PR DESCRIPTION
If a db_map is already opened in a db editor, new tabs with the same db_map won't be opened anymore. Instead the one already open is brought up. If however the same db_map is opened in a new window, it is allowed to open.

Re spine-tools/Spine-Toolbox#2435

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
