### PR TITLE
Fix database migration when database has no multidimensional entity classes

### DIFF
--- a/spinedb_api/alembic/versions/8b0eff478bcb_add_active_by_default_to_entity_class.py
+++ b/spinedb_api/alembic/versions/8b0eff478bcb_add_active_by_default_to_entity_class.py
@@ -30,6 +30,8 @@ def upgrade():
     metadata.reflect(bind=conn)
     dimension_table = metadata.tables["entity_class_dimension"]
     dimensional_class_ids = {row.entity_class_id for row in session.query(dimension_table)}
+    if not dimensional_class_ids:
+        return
     metadata.reflect(bind=conn)
     class_table = metadata.tables["entity_class"]
     update_statement = (


### PR DESCRIPTION
This PR fixes the migration script that add `active_by_default` column to `entity_class` tables. The script resulted in a Traceback when the upgradeable database did not have multidimensional entity classes.

Fixes spine-tools/Spine-Toolbox#2512

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
