### PR TITLE
Internal conflict resolution

### DIFF
--- a/spinedb_api/db_mapping.py
+++ b/spinedb_api/db_mapping.py
@@ -178,7 +178,6 @@ class DatabaseMapping(DatabaseMappingQueryMixin, DatabaseMappingCommitMixin, Dat
         if self._filter_configs is not None:
             stack = load_filters(self._filter_configs)
             apply_filter_stack(self, stack)
-        self._commit_count = self._query_commit_count()
 
     def __enter__(self):
         return self
@@ -647,7 +646,7 @@ class DatabaseMapping(DatabaseMappingQueryMixin, DatabaseMappingCommitMixin, Dat
         item_types = set(self.item_types()) if not item_types else set(item_types) & set(self.item_types())
         for item_type in item_types:
             item_type = self.real_item_type(item_type)
-            self.do_fetch_all(item_type)
+            self.do_fetch_more(item_type)
 
     def query(self, *args, **kwargs):
         """Returns a :class:`~spinedb_api.query.Query` object to execute against the mapped DB.
@@ -729,7 +728,11 @@ class DatabaseMapping(DatabaseMappingQueryMixin, DatabaseMappingCommitMixin, Dat
         self._refresh()
 
     def has_external_commits(self):
-        """See base class."""
+        """Tests whether the database has had commits from other sources than this mapping.
+
+        Returns:
+            bool: True if database has external commits, False otherwise
+        """
         return self._commit_count != self._query_commit_count()
 
     def close(self):

--- a/spinedb_api/db_mapping.py
+++ b/spinedb_api/db_mapping.py
@@ -382,7 +382,7 @@ class DatabaseMapping(DatabaseMappingQueryMixin, DatabaseMappingCommitMixin, Dat
         mapped_table = self.mapped_table(item_type)
         mapped_table.check_fields(kwargs, valid_types=(type(None),))
         if fetch:
-            self.do_fetch_all(item_type, **kwargs)
+            self.do_fetch_more(item_type, offset=0, limit=None, **kwargs)
         get_items = mapped_table.valid_values if skip_removed else mapped_table.values
         return [x.public_item for x in get_items() if all(x.get(k) == v for k, v in kwargs.items())]
 

--- a/spinedb_api/db_mapping.py
+++ b/spinedb_api/db_mapping.py
@@ -727,11 +727,7 @@ class DatabaseMapping(DatabaseMappingQueryMixin, DatabaseMappingCommitMixin, Dat
         self._refresh()
 
     def has_external_commits(self):
-        """Tests whether the database has had commits from other sources than this mapping.
-
-        Returns:
-            bool: True if database has external commits, False otherwise
-        """
+        """See base class."""
         return self._commit_count != self.query(self.commit_sq).count()
 
     def close(self):

--- a/spinedb_api/db_mapping_base.py
+++ b/spinedb_api/db_mapping_base.py
@@ -1181,7 +1181,9 @@ class MappedItemBase(dict):
                         self._invalidate_ref(ref_type, {ref_key: x})
                 else:
                     self._invalidate_ref(ref_type, {ref_key: src_val})
+        id_ = self["id"]
         super().update(other)
+        self["id"] = id_
         if self._asdict() == self._backup:
             self._status = Status.committed
 
@@ -1242,7 +1244,7 @@ class PublicItem:
     def _asdict(self):
         return self._mapped_item._asdict()
 
-    def extended(self):
+    def _extended(self):
         return self._mapped_item._extended()
 
     def update(self, **kwargs):

--- a/spinedb_api/db_mapping_base.py
+++ b/spinedb_api/db_mapping_base.py
@@ -659,6 +659,7 @@ class MappedItemBase(dict):
         self._status = Status.committed
         self._removal_source = None
         self._status_when_removed = None
+        self._status_when_committed = None
         self._backup = None
         self.public_item = PublicItem(self._db_map, self)
 
@@ -1115,6 +1116,7 @@ class MappedItemBase(dict):
 
     def commit(self, commit_id):
         """Sets this item as committed with the given commit id."""
+        self._status_when_committed = self._status
         self._status = Status.committed
         if commit_id:
             self["commit_id"] = commit_id
@@ -1193,7 +1195,14 @@ class MappedItemBase(dict):
     def detach(self):
         """Detaches this item whose id now belongs to a different item after an external commit."""
         self["id"].unresolve()
-        # TODO: Update item's status.
+        # TODO: Test if the below works...
+        if self.is_committed():
+            self._status = self._status_when_committed
+        if self._status == Status.to_update:
+            self._status = Status.to_add
+        elif self._status == Status.to_remove:
+            self._status = Status.committed
+            self._status_when_removed = Status.to_add
 
 
 class PublicItem:

--- a/spinedb_api/db_mapping_base.py
+++ b/spinedb_api/db_mapping_base.py
@@ -549,12 +549,12 @@ class _MappedTable(dict):
             tuple(MappedItem,bool): A mapped item and whether it needs to be added to the unique key values dict.
         """
         mapped_item = self._find_item_by_unique_key(item, fetch=False, valid_only=False)
-        if mapped_item:
+        if mapped_item and mapped_item.is_equal_in_db(item):
             yield from self._force_id(mapped_item, item["id"])
             yield mapped_item, False
             return
         mapped_item = self.get(item["id"])
-        if mapped_item is not None and mapped_item.is_equal_in_db(item):
+        if mapped_item and mapped_item.is_equal_in_db(item):
             yield mapped_item, False
             return
         yield from self._free_id(item["id"])

--- a/spinedb_api/db_mapping_base.py
+++ b/spinedb_api/db_mapping_base.py
@@ -575,14 +575,20 @@ class _MappedTable(dict):
             self._resolve_conflict(conflicting_item)
 
     def _resolve_conflict(self, conflicting_item):
-        """Does something with conflicting item which has been removed from the DB by an external commit.
+        """Does something with conflicting_item which has been removed from the DB by an external commit.
 
         Args:
             conflicting_item (MappedItemBase): an item in the memory mapping.
         """
-        # Here we could let the user choose the strategy.
-        # For now, we keep the conflicting_item in memory with a new TempId.
-        # It will be committed in the next call to commit_session.
+        # Here we could let the user choose the strategy. For now we just 'rescue' the item.
+        self._rescue_item(conflicting_item)
+
+    def _rescue_item(self, conflicting_item):
+        """Rescues the given conflicting_item which has been removed from the DB by an external commit.
+
+        Args:
+            conflicting_item (MappedItemBase): an item in the memory mapping.
+        """
         self.remove_unique(conflicting_item)
         new_id = self._new_id()
         self._db_map.update_id(conflicting_item, new_id)

--- a/spinedb_api/db_mapping_base.py
+++ b/spinedb_api/db_mapping_base.py
@@ -819,16 +819,15 @@ class MappedItemBase(dict):
         Returns:
             str or None: unresolved reference's key if any.
         """
-        return next(self._invalid_keys(), None)
+        return next(self._resolve_refs(), None)
 
     # TODO: Maybe rename this method to reflect its more important task now of replacing fields with TempIds
-    def _invalid_keys(self):
-        """Goes through the ``_references`` class attribute and returns the keys of the ones
-        that cannot be resolved.
-        Also, replace fields referring to db-ids with TempIds.
+    def _resolve_refs(self):
+        """Goes through the ``_references`` class attribute and tries to resolve them.
+        If successful, replace source fields referring to db-ids with the reference TempId.
 
         Yields:
-            str: unresolved keys if any.
+            str: the source field of any unresolved reference.
         """
         for src_key, (ref_type, ref_key) in self._references.items():
             try:
@@ -981,7 +980,7 @@ class MappedItemBase(dict):
             return False
         self._to_remove = False
         self._corrupted = False
-        for _ in self._invalid_keys():  # This sets self._to_remove and self._corrupted
+        for _ in self._resolve_refs():  # This sets self._to_remove and self._corrupted
             pass
         if self._to_remove:
             self.cascade_remove()

--- a/spinedb_api/import_functions.py
+++ b/spinedb_api/import_functions.py
@@ -623,14 +623,14 @@ def _get_list_values_for_import(db_map, data, unparse_value):
         index = index_by_list_name.get(list_name)
         if index is None:
             current_list = db_map.mapped_table("parameter_value_list").find_item({"name": list_name})
-            index = max(
-                (
-                    x["index"]
-                    for x in db_map.mapped_table("list_value").valid_values()
-                    if x["parameter_value_list_id"] == current_list["id"]
-                ),
-                default=-1,
-            )
+            list_value_idx_by_val_typ = {
+                (x["value"], x["type"]): x["index"]
+                for x in db_map.mapped_table("list_value").valid_values()
+                if x["parameter_value_list_id"] == current_list["id"]
+            }
+            if (value, type_) in list_value_idx_by_val_typ:
+                continue
+            index = max((idx for idx in list_value_idx_by_val_typ.values()), default=-1)
         index += 1
         index_by_list_name[list_name] = index
         yield {"parameter_value_list_name": list_name, "value": value, "type": type_, "index": index}

--- a/spinedb_api/mapped_items.py
+++ b/spinedb_api/mapped_items.py
@@ -47,8 +47,8 @@ class CommitItem(MappedItemBase):
         'date': {'type': str, 'value': 'Date and time of the commit in ISO 8601 format.'},
         'user': {'type': str, 'value': 'Username of the committer.'},
     }
-
     _unique_keys = (("date",),)
+    is_protected = True
 
     def commit(self, commit_id):
         raise RuntimeError("Commits are created automatically when session is committed.")

--- a/spinedb_api/spine_db_server.py
+++ b/spinedb_api/spine_db_server.py
@@ -49,7 +49,6 @@ This is particularly useful in high-concurrency scenarios.
 The server is started using :func:`closing_spine_db_server`.
 To control the order of writing you need to provide a queue, that you would obtain by calling :func:`db_server_manager`.
 
-
 The below example illustrates most of the functionality of the module.
 We create two DB servers targeting the same DB, and set the second to write before the first
 (via the ``ordering`` argument to :func:`closing_spine_db_server`).
@@ -76,7 +75,9 @@ Only after the second writes, the first one also writes and the program finishes
     with db_server_manager() as mngr_queue:
         first_ordering = {"id": "second_before_first", "current": "first", "precursors": {"second"}, "part_count": 1}
         second_ordering = {"id": "second_before_first", "current": "second", "precursors": set(), "part_count": 1}
-        with closing_spine_db_server(db_url, server_manager_queue=mngr_queue, ordering=first_ordering) as first_server_url:
+        with closing_spine_db_server(
+            db_url, server_manager_queue=mngr_queue, ordering=first_ordering
+        ) as first_server_url:
             with closing_spine_db_server(
                 db_url, server_manager_queue=mngr_queue, ordering=second_ordering
             ) as second_server_url:

--- a/spinedb_api/temp_id.py
+++ b/spinedb_api/temp_id.py
@@ -45,6 +45,9 @@ class TempId(int):
         for callback in self._resolve_callbacks:
             callback(db_id)
 
+    def unresolve(self):
+        self._db_id = None
+
 
 def resolve(value):
     if isinstance(value, dict):

--- a/spinedb_api/temp_id.py
+++ b/spinedb_api/temp_id.py
@@ -35,7 +35,8 @@ class TempId(int):
         return int(self)
 
     def __repr__(self):
-        return f"TempId({self._item_type}, {super().__repr__()})"
+        resolved_to = f" - resolved to {self._db_id}" if self._db_id is not None else ""
+        return f"TempId({self._item_type}, {super().__repr__()}{resolved_to})"
 
     def add_resolve_callback(self, callback):
         self._resolve_callbacks.append(callback)

--- a/spinedb_api/temp_id.py
+++ b/spinedb_api/temp_id.py
@@ -13,15 +13,15 @@
 class TempId(int):
     _next_id = {}
 
-    def __new__(cls, item_type):
+    def __new__(cls, item_type, _id_map):
         id_ = cls._next_id.setdefault(item_type, -1)
         cls._next_id[item_type] -= 1
         return super().__new__(cls, id_)
 
-    def __init__(self, item_type):
+    def __init__(self, item_type, id_map):
         super().__init__()
         self._item_type = item_type
-        self._resolve_callbacks = []
+        self._id_map = id_map
         self._db_id = None
 
     @property
@@ -29,22 +29,20 @@ class TempId(int):
         return self._db_id
 
     def __eq__(self, other):
+        # FIXME: Can we avoid this?
         return super().__eq__(other) or (self._db_id is not None and other == self._db_id)
 
     def __hash__(self):
+        # FIXME: Can we avoid this?
         return int(self)
 
     def __repr__(self):
         resolved_to = f" resolved to {self._db_id}" if self._db_id is not None else ""
         return f"TempId({self._item_type}, {super().__repr__()}){resolved_to}"
 
-    def add_resolve_callback(self, callback):
-        self._resolve_callbacks.append(callback)
-
     def resolve(self, db_id):
         self._db_id = db_id
-        for callback in self._resolve_callbacks:
-            callback(db_id)
+        self._id_map[db_id] = self
 
     def unresolve(self):
         self._db_id = None

--- a/spinedb_api/temp_id.py
+++ b/spinedb_api/temp_id.py
@@ -42,8 +42,8 @@ class TempId(int):
 
     def resolve(self, db_id):
         self._db_id = db_id
-        while self._resolve_callbacks:
-            self._resolve_callbacks.pop(0)(db_id)
+        for callback in self._resolve_callbacks:
+            callback(db_id)
 
 
 def resolve(value):

--- a/spinedb_api/temp_id.py
+++ b/spinedb_api/temp_id.py
@@ -35,8 +35,8 @@ class TempId(int):
         return int(self)
 
     def __repr__(self):
-        resolved_to = f" - resolved to {self._db_id}" if self._db_id is not None else ""
-        return f"TempId({self._item_type}, {super().__repr__()}{resolved_to})"
+        resolved_to = f" resolved to {self._db_id}" if self._db_id is not None else ""
+        return f"TempId({self._item_type}, {super().__repr__()}){resolved_to}"
 
     def add_resolve_callback(self, callback):
         self._resolve_callbacks.append(callback)

--- a/tests/test_DatabaseMapping.py
+++ b/tests/test_DatabaseMapping.py
@@ -2037,6 +2037,7 @@ class TestDatabaseMappingUpdate(unittest.TestCase):
         self._db_map.add_object_classes({"id": 1, "name": "some_class"})
         self._db_map.add_objects({"id": 1, "name": "nemo", "class_id": 1})
         self._db_map.commit_session("update")
+        print("NOW")
         items, intgr_error_log = self._db_map.update_objects({"id": 1, "name": "klaus"})
         ids = {x["id"] for x in items}
         self._db_map.commit_session("test commit")

--- a/tests/test_DatabaseMapping.py
+++ b/tests/test_DatabaseMapping.py
@@ -2037,7 +2037,6 @@ class TestDatabaseMappingUpdate(unittest.TestCase):
         self._db_map.add_object_classes({"id": 1, "name": "some_class"})
         self._db_map.add_objects({"id": 1, "name": "nemo", "class_id": 1})
         self._db_map.commit_session("update")
-        print("NOW")
         items, intgr_error_log = self._db_map.update_objects({"id": 1, "name": "klaus"})
         ids = {x["id"] for x in items}
         self._db_map.commit_session("test commit")

--- a/tests/test_DatabaseMapping.py
+++ b/tests/test_DatabaseMapping.py
@@ -443,9 +443,9 @@ class TestDatabaseMapping(AssertSuccessTestCase):
             entities = db_map.fetch_more("entity")
             self.assertEqual([(x["entity_class_name"], x["name"]) for x in entities], [("Widget", "gadget")])
 
-    def test_has_external_commits_returns_false_initially(self):
+    def test_has_external_commits_returns_true_initially(self):
         with DatabaseMapping("sqlite://", create=True) as db_map:
-            self.assertFalse(db_map.has_external_commits())
+            self.assertTrue(db_map.has_external_commits())
 
     def test_has_external_commits_returns_true_when_another_db_mapping_has_made_commits(self):
         with TemporaryDirectory() as temp_dir:

--- a/tests/test_DatabaseMapping.py
+++ b/tests/test_DatabaseMapping.py
@@ -2928,7 +2928,7 @@ class TestDatabaseMappingCommitMixin(unittest.TestCase):
         self.assertEqual(ents, [])
 
 
-@unittest.skipIf(os.name == 'nt')
+@unittest.skipIf(os.name == 'nt', "Need to fix")
 class TestDatabaseMappingConcurrent(unittest.TestCase):
     def test_concurrent_commit_threading(self):
         self._do_test_concurrent_commit(threading.Thread)

--- a/tests/test_DatabaseMapping.py
+++ b/tests/test_DatabaseMapping.py
@@ -129,20 +129,24 @@ class TestDatabaseMapping(unittest.TestCase):
             url = "sqlite:///" + os.path.join(temp_dir, "database.sqlite")
             with DatabaseMapping(url, create=True) as db_map:
                 self._assert_success(db_map.add_item("entity_class", name="fish", description="It swims."))
-                self._assert_success(db_map.add_item(
-                    "entity", entity_class_name="fish", name="Nemo", description="Peacefully swimming away."
-                ))
+                self._assert_success(
+                    db_map.add_item(
+                        "entity", entity_class_name="fish", name="Nemo", description="Peacefully swimming away."
+                    )
+                )
                 self._assert_success(db_map.add_item("parameter_definition", entity_class_name="fish", name="color"))
                 value, type_ = to_database("mainly orange")
-                self._assert_success(db_map.add_item(
-                    "parameter_value",
-                    entity_class_name="fish",
-                    entity_byname=("Nemo",),
-                    parameter_definition_name="color",
-                    alternative_name="Base",
-                    value=value,
-                    type=type_,
-                ))
+                self._assert_success(
+                    db_map.add_item(
+                        "parameter_value",
+                        entity_class_name="fish",
+                        entity_byname=("Nemo",),
+                        parameter_definition_name="color",
+                        alternative_name="Base",
+                        value=value,
+                        type=type_,
+                    )
+                )
                 db_map.commit_session("Added data")
             with DatabaseMapping(url) as db_map:
                 color = db_map.get_item(
@@ -161,28 +165,40 @@ class TestDatabaseMapping(unittest.TestCase):
             with DatabaseMapping(url, create=True) as db_map:
                 self._assert_success(db_map.add_item("entity_class", name="fish", description="It swims."))
                 self._assert_success(db_map.add_item("entity_class", name="cat", description="Eats fish."))
-                self._assert_success(db_map.add_item(
-                    "entity_class",
-                    name="fish__cat",
-                    dimension_name_list=("fish", "cat"),
-                    description="A fish getting eaten by a cat?",
-                ))
-                self._assert_success(db_map.add_item("entity", entity_class_name="fish", name="Nemo", description="Lost (soon)."))
-                self._assert_success(db_map.add_item(
-                    "entity", entity_class_name="cat", name="Felix", description="The wonderful wonderful cat."
-                ))
-                self._assert_success(db_map.add_item("entity", entity_class_name="fish__cat", element_name_list=("Nemo", "Felix")))
-                self._assert_success(db_map.add_item("parameter_definition", entity_class_name="fish__cat", name="rate"))
+                self._assert_success(
+                    db_map.add_item(
+                        "entity_class",
+                        name="fish__cat",
+                        dimension_name_list=("fish", "cat"),
+                        description="A fish getting eaten by a cat?",
+                    )
+                )
+                self._assert_success(
+                    db_map.add_item("entity", entity_class_name="fish", name="Nemo", description="Lost (soon).")
+                )
+                self._assert_success(
+                    db_map.add_item(
+                        "entity", entity_class_name="cat", name="Felix", description="The wonderful wonderful cat."
+                    )
+                )
+                self._assert_success(
+                    db_map.add_item("entity", entity_class_name="fish__cat", element_name_list=("Nemo", "Felix"))
+                )
+                self._assert_success(
+                    db_map.add_item("parameter_definition", entity_class_name="fish__cat", name="rate")
+                )
                 value, type_ = to_database(0.23)
-                self._assert_success(db_map.add_item(
-                    "parameter_value",
-                    entity_class_name="fish__cat",
-                    entity_byname=("Nemo", "Felix"),
-                    parameter_definition_name="rate",
-                    alternative_name="Base",
-                    value=value,
-                    type=type_,
-                ))
+                self._assert_success(
+                    db_map.add_item(
+                        "parameter_value",
+                        entity_class_name="fish__cat",
+                        entity_byname=("Nemo", "Felix"),
+                        parameter_definition_name="rate",
+                        alternative_name="Base",
+                        value=value,
+                        type=type_,
+                    )
+                )
                 db_map.commit_session("Added data")
             with DatabaseMapping(url) as db_map:
                 color = db_map.get_item(
@@ -198,20 +214,24 @@ class TestDatabaseMapping(unittest.TestCase):
     def test_updating_entity_name_updates_the_name_in_parameter_value_too(self):
         with DatabaseMapping(IN_MEMORY_DB_URL, create=True) as db_map:
             self._assert_success(db_map.add_item("entity_class", name="fish", description="It swims."))
-            self._assert_success(db_map.add_item(
-                "entity", entity_class_name="fish", name="Nemo", description="Peacefully swimming away."
-            ))
+            self._assert_success(
+                db_map.add_item(
+                    "entity", entity_class_name="fish", name="Nemo", description="Peacefully swimming away."
+                )
+            )
             self._assert_success(db_map.add_item("parameter_definition", entity_class_name="fish", name="color"))
             value, type_ = to_database("mainly orange")
-            self._assert_success(db_map.add_item(
-                "parameter_value",
-                entity_class_name="fish",
-                entity_byname=("Nemo",),
-                parameter_definition_name="color",
-                alternative_name="Base",
-                value=value,
-                type=type_,
-            ))
+            self._assert_success(
+                db_map.add_item(
+                    "parameter_value",
+                    entity_class_name="fish",
+                    entity_byname=("Nemo",),
+                    parameter_definition_name="color",
+                    alternative_name="Base",
+                    value=value,
+                    type=type_,
+                )
+            )
             color = db_map.get_item(
                 "parameter_value",
                 entity_class_name="fish",
@@ -248,12 +268,14 @@ class TestDatabaseMapping(unittest.TestCase):
             entity_2 = self._assert_success(db_map.add_entity_item(name="entity_2", entity_class_name="my_class"))
             metadata_value = '{"sources": [], "contributors": []}'
             metadata = self._assert_success(db_map.add_metadata_item(name="my_metadata", value=metadata_value))
-            entity_metadata = self._assert_success(db_map.add_entity_metadata_item(
-                metadata_name="my_metadata",
-                metadata_value=metadata_value,
-                entity_class_name="my_class",
-                entity_byname=("entity_1",),
-            ))
+            entity_metadata = self._assert_success(
+                db_map.add_entity_metadata_item(
+                    metadata_name="my_metadata",
+                    metadata_value=metadata_value,
+                    entity_class_name="my_class",
+                    entity_byname=("entity_1",),
+                )
+            )
             entity_metadata.update(entity_byname=("entity_2",))
             self.assertEqual(
                 entity_metadata._extended(),
@@ -308,33 +330,39 @@ class TestDatabaseMapping(unittest.TestCase):
             self._assert_success(db_map.add_parameter_definition_item(name="y", entity_class_name="my_class"))
             self._assert_success(db_map.add_entity_item(name="my_entity", entity_class_name="my_class"))
             value, value_type = to_database(2.3)
-            self._assert_success(db_map.add_parameter_value_item(
-                entity_class_name="my_class",
-                entity_byname=("my_entity",),
-                parameter_definition_name="x",
-                alternative_name="Base",
-                value=value,
-                type=value_type,
-            ))
+            self._assert_success(
+                db_map.add_parameter_value_item(
+                    entity_class_name="my_class",
+                    entity_byname=("my_entity",),
+                    parameter_definition_name="x",
+                    alternative_name="Base",
+                    value=value,
+                    type=value_type,
+                )
+            )
             value, value_type = to_database(-2.3)
-            y = self._assert_success(db_map.add_parameter_value_item(
-                entity_class_name="my_class",
-                entity_byname=("my_entity",),
-                parameter_definition_name="y",
-                alternative_name="Base",
-                value=value,
-                type=value_type,
-            ))
+            y = self._assert_success(
+                db_map.add_parameter_value_item(
+                    entity_class_name="my_class",
+                    entity_byname=("my_entity",),
+                    parameter_definition_name="y",
+                    alternative_name="Base",
+                    value=value,
+                    type=value_type,
+                )
+            )
             metadata_value = '{"sources": [], "contributors": []}'
             metadata = self._assert_success(db_map.add_metadata_item(name="my_metadata", value=metadata_value))
-            value_metadata = self._assert_success(db_map.add_parameter_value_metadata_item(
-                metadata_name="my_metadata",
-                metadata_value=metadata_value,
-                entity_class_name="my_class",
-                entity_byname=("my_entity",),
-                parameter_definition_name="x",
-                alternative_name="Base",
-            ))
+            value_metadata = self._assert_success(
+                db_map.add_parameter_value_metadata_item(
+                    metadata_name="my_metadata",
+                    metadata_value=metadata_value,
+                    entity_class_name="my_class",
+                    entity_byname=("my_entity",),
+                    parameter_definition_name="x",
+                    alternative_name="Base",
+                )
+            )
             value_metadata.update(parameter_definition_name="y")
             self.assertEqual(
                 value_metadata._extended(),
@@ -458,7 +486,9 @@ class TestDatabaseMapping(unittest.TestCase):
                 # Remove the entity in the middle and add a multi-D one referring to the third entity.
                 # The multi-D one will go in the middle.
                 db_map.get_entity_item(name="Sylvester", entity_class_name="cat").remove()
-                self._assert_success(db_map.add_entity_item(element_name_list=("Pulgoso", "Tom"), entity_class_name="dog__cat"))
+                self._assert_success(
+                    db_map.add_entity_item(element_name_list=("Pulgoso", "Tom"), entity_class_name="dog__cat")
+                )
                 db_map.commit_session("Meow!")
             with DatabaseMapping(url) as db_map:
                 # The ("Pulgoso", "Tom") entity will be fetched before "Tom".
@@ -476,13 +506,13 @@ class TestDatabaseMapping(unittest.TestCase):
                 self.assertIsNotNone(item)
                 item = self._assert_success(db_map.add_scenario_item(name="my_scenario"))
                 self.assertIsNotNone(item)
-                item = self._assert_success(db_map.add_scenario_alternative_item(
-                    scenario_name="my_scenario", alternative_name="alt1", rank=0
-                ))
+                item = self._assert_success(
+                    db_map.add_scenario_alternative_item(scenario_name="my_scenario", alternative_name="alt1", rank=0)
+                )
                 self.assertIsNotNone(item)
-                item = self._assert_success(db_map.add_scenario_alternative_item(
-                    scenario_name="my_scenario", alternative_name="alt2", rank=1
-                ))
+                item = self._assert_success(
+                    db_map.add_scenario_alternative_item(scenario_name="my_scenario", alternative_name="alt2", rank=1)
+                )
                 self.assertIsNotNone(item)
                 db_map.commit_session("Add test data.")
             with DatabaseMapping(url) as db_map:
@@ -518,7 +548,11 @@ class TestDatabaseMapping(unittest.TestCase):
             self._assert_success(db_map.add_entity_class_item(name="my_class"))
             self._assert_success(db_map.add_entity_item(name="element", entity_class_name="my_class"))
             self._assert_success(db_map.add_entity_item(name="container", entity_class_name="my_class"))
-            self._assert_success(db_map.add_entity_group_item(group_name="container", member_name="element", entity_class_name="my_class"))
+            self._assert_success(
+                db_map.add_entity_group_item(
+                    group_name="container", member_name="element", entity_class_name="my_class"
+                )
+            )
             db_map.commit_session("Add entity group.")
             groups = db_map.get_entity_group_items()
             self.assertEqual(len(groups), 1)
@@ -528,40 +562,54 @@ class TestDatabaseMapping(unittest.TestCase):
         with DatabaseMapping("sqlite://", create=True) as db_map:
             self._assert_success(db_map.add_parameter_value_list_item(name="booleans"))
             value, value_type = to_database(True)
-            self._assert_success(db_map.add_list_value_item(parameter_value_list_name="booleans", value=value, type=value_type, index=0))
+            self._assert_success(
+                db_map.add_list_value_item(parameter_value_list_name="booleans", value=value, type=value_type, index=0)
+            )
             self._assert_success(db_map.add_entity_class_item(name="my_class"))
-            self._assert_success(db_map.add_parameter_definition_item(
-                name="is_active", entity_class_name="my_class", parameter_value_list_name="booleans"
-            ))
+            self._assert_success(
+                db_map.add_parameter_definition_item(
+                    name="is_active", entity_class_name="my_class", parameter_value_list_name="booleans"
+                )
+            )
             self._assert_success(db_map.add_entity_item(name="widget1", entity_class_name="my_class"))
             self._assert_success(db_map.add_entity_item(name="widget2", entity_class_name="my_class"))
             self._assert_success(db_map.add_entity_item(name="no_is_active", entity_class_name="my_class"))
-            self._assert_success(db_map.add_entity_alternative_item(
-                entity_class_name="my_class", entity_byname=("widget1",), alternative_name="Base", active=False
-            ))
-            self._assert_success(db_map.add_entity_alternative_item(
-                entity_class_name="my_class", entity_byname=("widget2",), alternative_name="Base", active=False
-            ))
-            self._assert_success(db_map.add_entity_alternative_item(
-                entity_class_name="my_class", entity_byname=("no_is_active",), alternative_name="Base", active=False
-            ))
+            self._assert_success(
+                db_map.add_entity_alternative_item(
+                    entity_class_name="my_class", entity_byname=("widget1",), alternative_name="Base", active=False
+                )
+            )
+            self._assert_success(
+                db_map.add_entity_alternative_item(
+                    entity_class_name="my_class", entity_byname=("widget2",), alternative_name="Base", active=False
+                )
+            )
+            self._assert_success(
+                db_map.add_entity_alternative_item(
+                    entity_class_name="my_class", entity_byname=("no_is_active",), alternative_name="Base", active=False
+                )
+            )
             value, value_type = to_database(True)
-            self._assert_success(db_map.add_parameter_value_item(
-                entity_class_name="my_class",
-                parameter_definition_name="is_active",
-                entity_byname=("widget1",),
-                alternative_name="Base",
-                value=value,
-                type=value_type,
-            ))
-            self._assert_success(db_map.add_parameter_value_item(
-                entity_class_name="my_class",
-                parameter_definition_name="is_active",
-                entity_byname=("widget2",),
-                alternative_name="Base",
-                value=value,
-                type=value_type,
-            ))
+            self._assert_success(
+                db_map.add_parameter_value_item(
+                    entity_class_name="my_class",
+                    parameter_definition_name="is_active",
+                    entity_byname=("widget1",),
+                    alternative_name="Base",
+                    value=value,
+                    type=value_type,
+                )
+            )
+            self._assert_success(
+                db_map.add_parameter_value_item(
+                    entity_class_name="my_class",
+                    parameter_definition_name="is_active",
+                    entity_byname=("widget2",),
+                    alternative_name="Base",
+                    value=value,
+                    type=value_type,
+                )
+            )
             db_map.commit_session("Add test data to see if this crashes.")
             entity_names = {entity["id"]: entity["name"] for entity in db_map.query(db_map.wide_entity_sq)}
             alternative_names = {
@@ -585,27 +633,35 @@ class TestDatabaseMapping(unittest.TestCase):
         with DatabaseMapping("sqlite://", create=True) as db_map:
             self._assert_success(db_map.add_parameter_value_list_item(name="booleans"))
             value, value_type = to_database(True)
-            self._assert_success(db_map.add_list_value_item(parameter_value_list_name="booleans", value=value, type=value_type, index=0))
+            self._assert_success(
+                db_map.add_list_value_item(parameter_value_list_name="booleans", value=value, type=value_type, index=0)
+            )
             self._assert_success(db_map.add_entity_class_item(name="Widget"))
-            self._assert_success(db_map.add_parameter_definition_item(
-                name="is_active",
-                entity_class_name="Widget",
-                parameter_value_list_name="booleans",
-                default_value=value,
-                default_type=value_type,
-            ))
+            self._assert_success(
+                db_map.add_parameter_definition_item(
+                    name="is_active",
+                    entity_class_name="Widget",
+                    parameter_value_list_name="booleans",
+                    default_value=value,
+                    default_type=value_type,
+                )
+            )
             self._assert_success(db_map.add_entity_class_item(name="Gadget"))
-            self._assert_success(db_map.add_parameter_definition_item(
-                name="is_active",
-                entity_class_name="Gadget",
-                parameter_value_list_name="booleans",
-                default_value=value,
-                default_type=value_type,
-            ))
+            self._assert_success(
+                db_map.add_parameter_definition_item(
+                    name="is_active",
+                    entity_class_name="Gadget",
+                    parameter_value_list_name="booleans",
+                    default_value=value,
+                    default_type=value_type,
+                )
+            )
             self._assert_success(db_map.add_entity_class_item(name="NoIsActiveDefault"))
-            self._assert_success(db_map.add_parameter_definition_item(
-                name="is_active", entity_class_name="NoIsActiveDefault", parameter_value_list_name="booleans"
-            ))
+            self._assert_success(
+                db_map.add_parameter_definition_item(
+                    name="is_active", entity_class_name="NoIsActiveDefault", parameter_value_list_name="booleans"
+                )
+            )
             db_map.commit_session("Add test data to see if this crashes")
             active_by_defaults = {
                 entity_class["name"]: entity_class["active_by_default"]
@@ -2928,11 +2984,12 @@ class TestDatabaseMappingCommitMixin(unittest.TestCase):
         self.assertEqual(ents, [])
 
 
-@unittest.skipIf(os.name == 'nt', "Need to fix")
 class TestDatabaseMappingConcurrent(unittest.TestCase):
+    @unittest.skipIf(os.name == 'nt', "Needs fixing")
     def test_concurrent_commit_threading(self):
         self._do_test_concurrent_commit(threading.Thread)
 
+    @unittest.skipIf(os.name == 'nt', "Needs fixing")
     def test_concurrent_commit_multiprocessing(self):
         self._do_test_concurrent_commit(multiprocessing.Process)
 
@@ -2942,7 +2999,6 @@ class TestDatabaseMappingConcurrent(unittest.TestCase):
 
         with TemporaryDirectory() as temp_dir:
             url = "sqlite:///" + os.path.join(temp_dir, "database.sqlite")
-
             with CustomDatabaseMapping(url, create=True) as db_map1:
                 with CustomDatabaseMapping(url) as db_map2:
                     db_map1.add_entity_class_item(name="dog")
@@ -2954,13 +3010,51 @@ class TestDatabaseMappingConcurrent(unittest.TestCase):
                     c1.start()
                     c1.join()
                     c2.join()
-
             with CustomDatabaseMapping(url) as db_map:
                 commit_msgs = {x["comment"] for x in db_map.query(db_map.commit_sq)}
                 entity_class_names = [x["name"] for x in db_map.query(db_map.entity_class_sq)]
                 self.assertEqual(commit_msgs, {"Create the database", "one", "two"})
                 self.assertEqual(len(entity_class_names), 2)
                 self.assertEqual(set(entity_class_names), {"cat", "dog"})
+
+    def test_uncommitted_mapped_items_take_id_from_externally_committed_items(self):
+        with TemporaryDirectory() as temp_dir:
+            url = "sqlite:///" + os.path.join(temp_dir, "database.sqlite")
+            with CustomDatabaseMapping(url, create=True) as db_map1:
+                with CustomDatabaseMapping(url) as db_map2:
+                    db_map1.add_entity_class_item(name="widget")
+                    db_map1.add_entity_class_item(name="gadget")
+                    db_map2.add_entity_class_item(name="gadget")
+                    db_map2.add_entity_class_item(name="widget")
+                    db_map2.commit_session("No comment")
+                    committed_resolved_entity_classes = [x.resolve() for x in db_map2.get_items("entity_class")]
+                    committed_resolved_id_by_name = {x["name"]: x["id"] for x in committed_resolved_entity_classes}
+                    uncommitted_entity_classes = db_map1.get_items("entity_class")
+                    uncommitted_resolved_entity_classes = [x.resolve() for x in uncommitted_entity_classes]
+                    uncommitted_resolved_id_by_name = {x["name"]: x["id"] for x in uncommitted_resolved_entity_classes}
+                    self.assertEqual(committed_resolved_id_by_name, uncommitted_resolved_id_by_name)
+                    for mapped_item in uncommitted_entity_classes:
+                        self.assertTrue(mapped_item.is_committed())
+                    with self.assertRaises(SpineDBAPIError):
+                        db_map1.commit_session("No comment")
+
+    def test_committed_mapped_items_take_id_from_externally_committed_items(self):
+        with TemporaryDirectory() as temp_dir:
+            url = "sqlite:///" + os.path.join(temp_dir, "database.sqlite")
+            with CustomDatabaseMapping(url, create=True) as db_map0:
+                db_map0.add_entity_class_item(name="widget")
+                db_map0.add_entity_class_item(name="gadget")
+                db_map0.commit_session("No comment")
+                with CustomDatabaseMapping(url) as db_map1:
+                    with CustomDatabaseMapping(url) as db_map2:
+                        entity_classes_before = db_map1.get_items("entity_class")
+                        db_map2.purge_items("entity_class")
+                        db_map2.add_entity_class_item(name="gadget")
+                        db_map2.add_entity_class_item(name="widget")
+                        db_map2.commit_session("No comment")
+                        entity_classes_after = db_map1.get_items("entity_class")
+                        # TODO: check that entity_classes_after is the same as entity_classes_before
+                        # with exchanged ids
 
 
 if __name__ == "__main__":

--- a/tests/test_db_mapping_base.py
+++ b/tests/test_db_mapping_base.py
@@ -28,8 +28,8 @@ class TestDBMapping(DatabaseMappingBase):
             return MappedItemBase
         raise RuntimeError(f"unknown item_type '{item_type}'")
 
-    def _query_commit_count(self):
-        return -1
+    def has_external_commits(self):
+        return False
 
     def _make_query(self, _item_type, **kwargs):
         return None

--- a/tests/test_db_mapping_base.py
+++ b/tests/test_db_mapping_base.py
@@ -28,6 +28,9 @@ class TestDBMapping(DatabaseMappingBase):
             return MappedItemBase
         raise RuntimeError(f"unknown item_type '{item_type}'")
 
+    def has_external_commits(self):
+        return False
+
     def _make_query(self, _item_type, **kwargs):
         return None
 
@@ -37,11 +40,11 @@ class TestDBMappingBase(unittest.TestCase):
         db_map = TestDBMapping()
         mapped_table = db_map.mapped_table("cutlery")
         item = mapped_table.add_item({})
-        self.assertTrue(item.is_id_valid)
+        self.assertTrue(item.has_valid_id)
         self.assertIn("id", item)
         id_ = item["id"]
         db_map._rollback()
-        self.assertFalse(item.is_id_valid)
+        self.assertFalse(item.has_valid_id)
         self.assertEqual(item["id"], id_)
 
 
@@ -52,9 +55,9 @@ class TestMappedTable(unittest.TestCase):
         item = mapped_table.add_item({})
         id_ = item["id"]
         db_map._rollback()
-        self.assertFalse(item.is_id_valid)
+        self.assertFalse(item.has_valid_id)
         mapped_table.add_item(item)
-        self.assertTrue(item.is_id_valid)
+        self.assertTrue(item.has_valid_id)
         self.assertNotEqual(item["id"], id_)
 
 
@@ -62,21 +65,21 @@ class TestMappedItemBase(unittest.TestCase):
     def test_id_is_valid_initially(self):
         db_map = TestDBMapping()
         item = MappedItemBase(db_map, "cutlery")
-        self.assertTrue(item.is_id_valid)
+        self.assertTrue(item.has_valid_id)
 
     def test_id_can_be_invalidated(self):
         db_map = TestDBMapping()
         item = MappedItemBase(db_map, "cutlery")
         item.invalidate_id()
-        self.assertFalse(item.is_id_valid)
+        self.assertFalse(item.has_valid_id)
 
     def test_setting_new_id_validates_it(self):
         db_map = TestDBMapping()
         item = MappedItemBase(db_map, "cutlery")
         item.invalidate_id()
-        self.assertFalse(item.is_id_valid)
+        self.assertFalse(item.has_valid_id)
         item["id"] = 23
-        self.assertTrue(item.is_id_valid)
+        self.assertTrue(item.has_valid_id)
 
 
 if __name__ == '__main__':

--- a/tests/test_db_mapping_base.py
+++ b/tests/test_db_mapping_base.py
@@ -28,8 +28,8 @@ class TestDBMapping(DatabaseMappingBase):
             return MappedItemBase
         raise RuntimeError(f"unknown item_type '{item_type}'")
 
-    def has_external_commits(self):
-        return False
+    def _query_commit_count(self):
+        return -1
 
     def _make_query(self, _item_type, **kwargs):
         return None

--- a/tests/test_import_functions.py
+++ b/tests/test_import_functions.py
@@ -1342,10 +1342,7 @@ class TestImportScenarioAlternative(unittest.TestCase):
         self.assertEqual(count, 2)
         scenario_alternatives = self.scenario_alternatives()
         self.assertEqual(scenario_alternatives, {"scenario": {"alternative1": 2, "alternative2": 1}})
-        count, errors = import_scenario_alternatives(
-            self._db_map,
-            [["scenario", "alternative3", "alternative1"]],
-        )
+        count, errors = import_scenario_alternatives(self._db_map, [["scenario", "alternative3", "alternative1"]])
         self.assertFalse(errors)
         self.assertEqual(count, 2)
         scenario_alternatives = self.scenario_alternatives()


### PR DESCRIPTION
Fixes 'id conflicts' between in-memory mapping and new contents of the DB. This is not about resolving conflicts on user-data, that should be done in another PR.

The core idea is, if a DB-item has the same unique key as a mapped-item, then they also need to have the same id. Conversely, if a DB-item has the same id as a mapped-item, then they need to have the same unique keys. The id to trust and respect will always be the most recent from the DB.

### Algorithm

```mermaid
flowchart TD
    A[Fetch a new item from the DB] --> C["Find a mapped-item that has the same unique key
    as the fetched DB-item"]
    C --> B{"mapped-item
    exists?"}
    B -->|Yes| D
    D{"DB-item id
    is equal to
    mapped-item id?"} -->|Yes| Z[Keep mapped-item]
    D -->|No| E{"mapped-item has been
    added in this session?"}
    E -->|Yes| F["Mark mapped-item as committed
    with the new DB id"] --> Z
    E -->|No| G["Free DB-item id*"]
    G --> H["Manually update mapped-item's
    id to the new DB id
    (also in referees)"] --> Z
    B -->|No| J["Find a mapped-item that has the same id
    as the fetched DB-item"]
    J --> K{"mapped-item exists and
    has the same unique-keys
    as DB-item?"}
    K --> |Yes| Z
    K --> |No| L["Free DB-item id*"]
    L --> M[Add DB-item]
```

*The *Free DB-item id* bit consists in making sure that no mapped-item has the same id as the DB-item. If that's the case, we need to decide what to do with the clashing mapped-item, as we cannot keep it with its current id. This is the only point that requires *conflict resolution*. At the moment we 'rescue' the mapped-item, which means we make it pending for addition with a new id - but we could use a different strategy or let the user choose between a number of strategies.

@soininen @jkiviluo you could start reviewing this if you will. I still need to polish things and especially improve unit-tests. One of the old tests is not passing. I have added two new tests but need to finalize one of them and add more to test all the different cases.

NOTE: In element I was proposing a different idea which consisted in using a tuple (last-commit-id, db-id) instead of the db-id, to avoid ambiguities, but that doesn't work. We need to resolve ambiguities and the above algorithm works much better to that end.

NOTE2: One important detail for the implementation is, we need to be able to find mapped items by unique key even if they have been removed from the memory-mapping. For this reason, the `_MappedTable._ids_by_unique_key_value` dictionary now also includes removed items, and we check if the items in it are removed or not depending on what we are using them for.

## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes in Toolbox repo have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black
- [ ] Unit tests pass
