### PR TITLE
Allow the restoration of purged items one-by-one.

### DIFF
--- a/spinedb_api/db_mapping_base.py
+++ b/spinedb_api/db_mapping_base.py
@@ -556,7 +556,7 @@ class _MappedTable(dict):
             self.purged = True
             for current_item in self.valid_values():
                 self.remove_unique(current_item)
-                current_item.cascade_remove(source=self.wildcard_item)
+                current_item.cascade_remove()
             return self.wildcard_item
         self.remove_unique(item)
         item.cascade_remove()
@@ -567,7 +567,7 @@ class _MappedTable(dict):
             self.purged = False
             for current_item in self.values():
                 self.add_unique(current_item)
-                current_item.cascade_restore(source=self.wildcard_item)
+                current_item.cascade_restore()
             return self.wildcard_item
         current_item = self.find_item({"id": id_})
         if current_item:

--- a/tests/test_DatabaseMapping.py
+++ b/tests/test_DatabaseMapping.py
@@ -644,6 +644,25 @@ class TestDatabaseMapping(unittest.TestCase):
                 self.assertEqual(len(entity_classes), 1)
                 self.assertEqual(entity_classes[0]["name"], "Gadget")
 
+    def test_restored_entity_class_item_has_display_icon_field(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            entity_class = self._assert_success(db_map.add_entity_class_item(name="Gadget"))
+            db_map.purge_items("entity_class")
+            entity_class.restore()
+            item = db_map.get_entity_class_item(name="Gadget")
+            self.assertIsNone(item["display_icon"])
+
+    def test_trying_to_restore_item_whose_parent_is_removed_fails(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            entity_class = self._assert_success(db_map.add_entity_class_item(name="Object"))
+            entity = self._assert_success(db_map.add_entity_item(name="knife", entity_class_name="Object"))
+            entity_class.remove()
+            self.assertFalse(entity.is_valid())
+            entity.restore()
+            self.assertFalse(entity.is_valid())
+            entity_class.restore()
+            self.assertTrue(entity.is_valid())
+
 
 class TestDatabaseMappingLegacy(unittest.TestCase):
     """'Backward compatibility' tests, i.e. pre-entity tests converted to work with the entity structure."""


### PR DESCRIPTION
Previously it was not possible to call `restore()` on an item that had been purged. This removes the artificial limitation.

Resolves #325

## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes in Toolbox repo have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black
- [ ] Unit tests pass
