### PR TITLE
Fix TempId.__hash__ to follow python rules

### DIFF
--- a/spinedb_api/db_mapping_base.py
+++ b/spinedb_api/db_mapping_base.py
@@ -363,7 +363,6 @@ class _MappedTable(dict):
         self._item_type = item_type
         self._ids_by_unique_key_value = {}
         self._temp_id_by_db_id = {}
-        self._next_id = -1
         self.wildcard_item = MappedItemBase(self._db_map, self._item_type, id=Asterisk)
 
     @property
@@ -379,9 +378,7 @@ class _MappedTable(dict):
         return super().get(id_, default)
 
     def _new_id(self):
-        id_ = self._next_id
-        self._next_id -= 1
-        return TempId(id_, self._item_type, self._temp_id_by_db_id)
+        return TempId(self._item_type, self._temp_id_by_db_id)
 
     def _unique_key_value_to_id(self, key, value, fetch=True):
         """Returns the id that has the given value for the given unique key, or None.
@@ -846,7 +843,9 @@ class MappedItemBase(dict):
 
     def _something_to_update(self, other):
         def _convert(x):
-            return tuple(x) if isinstance(x, list) else x
+            if isinstance(x, list):
+                x = tuple(x)
+            return resolve(x)
 
         return not all(
             _convert(self.get(key)) == _convert(value)

--- a/spinedb_api/mapped_items.py
+++ b/spinedb_api/mapped_items.py
@@ -792,7 +792,7 @@ class SuperclassSubclassItem(MappedItemBase):
     _internal_fields = {"superclass_id": (("superclass_name",), "id"), "subclass_id": (("subclass_name",), "id")}
 
     def _subclass_entities(self):
-        return self._db_map.get_items("entity", class_id=self["subclass_id"])
+        return self._db_map.get_items("entity", class_id=self["subclass_id"], fetch=False)
 
     def check_mutability(self):
         if self._subclass_entities():

--- a/tests/test_DatabaseMapping.py
+++ b/tests/test_DatabaseMapping.py
@@ -432,7 +432,7 @@ class TestDatabaseMapping(AssertSuccessTestCase):
         with DatabaseMapping("sqlite://", create=True) as db_map:
             alternatives = db_map.fetch_more("alternative")
             expected = [{"id": 1, "name": "Base", "description": "Base alternative", "commit_id": 1}]
-            self.assertEqual([a._asdict() for a in alternatives], expected)
+            self.assertEqual([a.resolve() for a in alternatives], expected)
 
     def test_fetch_more_after_commit_and_refresh(self):
         with DatabaseMapping("sqlite://", create=True) as db_map:
@@ -3117,7 +3117,7 @@ class TestDatabaseMappingConcurrent(AssertSuccessTestCase):
                 items = db_map.get_items("entity")
                 self.assertEqual(len(items), 1)
                 self.assertEqual(
-                    items[0]._asdict(),
+                    items[0].resolve(),
                     {
                         "id": 1,
                         "name": "my_entity",


### PR DESCRIPTION
The idea here is that TempId.__hash__ plays well with TempId.__eq__ as per the Python spec, to avoid all kinds of bugs down the line.

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
