### PR TITLE
Refresh cache aggressively after filter change

### DIFF
--- a/spinedb_api/db_mapping_base.py
+++ b/spinedb_api/db_mapping_base.py
@@ -498,8 +498,7 @@ class DatabaseMappingBase:
         attr_names = set(attr for tablename in tablenames for attr in self._get_table_to_sq_attr().get(tablename, []))
         for attr_name in attr_names:
             setattr(self, attr_name, None)
-        tablenames = list(tablenames)
-        for tablename in tablenames:
+        for tablename in list(self.cache):
             if self.cache.pop(tablename, None):
                 self._do_advance_cache_query(tablename)
 


### PR DESCRIPTION
To make sure things work, I propose we refresh the entire cache after changing a filter instead of trying to change only the affected tables. We were failing to do that correctly and it has brought a lot of problems.

Fixes #363

## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes in Toolbox repo have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black
- [ ] Unit tests pass
