### PR TITLE
Set active_by_default to true when migrating if is_active is missing

### DIFF
--- a/spinedb_api/alembic/versions/8b0eff478bcb_add_active_by_default_to_entity_class.py
+++ b/spinedb_api/alembic/versions/8b0eff478bcb_add_active_by_default_to_entity_class.py
@@ -26,19 +26,12 @@ def upgrade():
             ),
         )
     conn = op.get_bind()
-    session = sa.orm.sessionmaker(bind=conn)()
     metadata = sa.MetaData()
     metadata.reflect(bind=conn)
-    dimension_table = metadata.tables["entity_class_dimension"]
-    dimensional_class_ids = {row.entity_class_id for row in session.query(dimension_table)}
-    if not dimensional_class_ids:
-        return
     metadata.reflect(bind=conn)
     class_table = metadata.tables["entity_class"]
-    update_statement = (
-        class_table.update().where(class_table.c.id == sa.bindparam("target_id")).values(active_by_default=True)
-    )
-    conn.execute(update_statement, [{"target_id": class_id} for class_id in dimensional_class_ids])
+    update_statement = class_table.update().values(active_by_default=True)
+    conn.execute(update_statement)
     convert_tool_feature_method_to_active_by_default(conn, use_existing_tool_feature_method=True)
 
 

--- a/spinedb_api/compatibility.py
+++ b/spinedb_api/compatibility.py
@@ -80,10 +80,11 @@ def convert_tool_feature_method_to_active_by_default(conn, use_existing_tool_fea
     # where active_by_default is True if the value of 'is_active' is the one from the tool_feature_method specification
     entity_class_items_to_update = {
         x["entity_class_id"]: {
-            "active_by_default": x["list_value_id"] == lv_id_by_pdef_id[x["parameter_definition_id"]],
+            "active_by_default": False
+            if x["list_value_id"] is None
+            else x["list_value_id"] == lv_id_by_pdef_id[x["parameter_definition_id"]],
         }
         for x in is_active_default_vals
-        if x["list_value_id"] is not None
     }
     updated_items = []
     entity_class_table = meta.tables["entity_class"]


### PR DESCRIPTION
When migrating, set all active_by_defaults to true unless is_active (or equivalent) has been defined. This mimics the pre-0.8 behavior where all classes were visible by default.

Fixes #spine-tools/Spine-Toolbox#2611

## Checklist before merging
- [x] Code has been formatted by black
- [ ] Unit tests pass
