### PR TITLE
Separate unique id creation from TempId initialization

### DIFF
--- a/spinedb_api/db_mapping_base.py
+++ b/spinedb_api/db_mapping_base.py
@@ -379,7 +379,7 @@ class _MappedTable(dict):
         return super().get(id_, default)
 
     def _new_id(self):
-        return TempId(self._item_type, self._temp_id_lookup)
+        return TempId.new_unique(self._item_type, self._temp_id_lookup)
 
     def _unique_key_value_to_id(self, key, value, fetch=True):
         """Returns the id that has the given value for the given unique key, or None.

--- a/spinedb_api/temp_id.py
+++ b/spinedb_api/temp_id.py
@@ -13,14 +13,19 @@
 class TempId:
     _next_id = {}
 
-    def __init__(self, item_type, temp_id_lookup):
+    def __init__(self, id_, item_type, temp_id_lookup=None):
         super().__init__()
-        self._id = self._next_id.get(item_type, -1)
-        self._next_id[item_type] = self._id - 1
+        self._id = id_
         self._item_type = item_type
-        self._temp_id_lookup = temp_id_lookup
+        self._temp_id_lookup = temp_id_lookup if temp_id_lookup is not None else {}
         self._db_id = None
         self._temp_id_lookup[self._id] = self
+
+    @staticmethod
+    def new_unique(item_type, temp_id_lookup):
+        id_ = TempId._next_id.get(item_type, -1)
+        TempId._next_id[item_type] = id_ - 1
+        return TempId(id_, item_type, temp_id_lookup)
 
     @property
     def private_id(self):


### PR DESCRIPTION
Immediate use is in unit tests where we can now create TempIds for equality comparisons.

No issue.

## Checklist before merging
- [ ] Unit tests pass
