### PR TITLE
Make compatibility transforms optional on commit

### DIFF
--- a/spinedb_api/alembic/versions/8b0eff478bcb_add_active_by_default_to_entity_class.py
+++ b/spinedb_api/alembic/versions/8b0eff478bcb_add_active_by_default_to_entity_class.py
@@ -32,7 +32,7 @@ def upgrade():
     class_table = metadata.tables["entity_class"]
     update_statement = class_table.update().values(active_by_default=True)
     conn.execute(update_statement)
-    convert_tool_feature_method_to_active_by_default(conn, use_existing_tool_feature_method=True)
+    convert_tool_feature_method_to_active_by_default(conn, use_existing_tool_feature_method=True, apply=True)
 
 
 def downgrade():

--- a/spinedb_api/alembic/versions/ce9faa82ed59_create_entity_alternative_table.py
+++ b/spinedb_api/alembic/versions/ce9faa82ed59_create_entity_alternative_table.py
@@ -47,7 +47,7 @@ def upgrade():
         op.drop_table('next_id')
     except sa.exc.OperationalError:
         pass
-    convert_tool_feature_method_to_entity_alternative(op.get_bind(), use_existing_tool_feature_method=True)
+    convert_tool_feature_method_to_entity_alternative(op.get_bind(), use_existing_tool_feature_method=True, apply=True)
 
 
 def downgrade():

--- a/spinedb_api/db_mapping.py
+++ b/spinedb_api/db_mapping.py
@@ -745,11 +745,12 @@ class DatabaseMapping(DatabaseMappingQueryMixin, DatabaseMappingCommitMixin, Dat
         """
         return Query(self.engine, *args)
 
-    def commit_session(self, comment):
+    def commit_session(self, comment, apply_compatibility_transforms=True):
         """Commits the changes from the in-memory mapping to the database.
 
         Args:
             comment (str): commit message
+            apply_compatibility_transforms (bool): if True, apply compatibility transforms
 
         Returns:
             tuple(list, list): compatibility transformations
@@ -777,7 +778,7 @@ class DatabaseMapping(DatabaseMappingQueryMixin, DatabaseMappingCommitMixin, Dat
                 self._do_add_items(connection, tablename, *to_add)
             if self._memory:
                 self._memory_dirty = True
-            transformation_info = compatibility_transformations(connection)
+            transformation_info = compatibility_transformations(connection, apply=apply_compatibility_transforms)
         self._commit_count = self._query_commit_count()
         return transformation_info
 

--- a/tests/test_import_functions.py
+++ b/tests/test_import_functions.py
@@ -1141,23 +1141,26 @@ class TestImportParameterValue(unittest.TestCase):
                 'entity_classes': [('A', (), None, None, False)],
                 'entities': [('A', 'aa', None)],
                 'parameter_definitions': [('A', 'test1', None, None, None)],
-                'parameter_values': [(
-                    'A',
-                    'aa',
-                    'test1',
-                    {
-                        'type': 'time_series',
-                        'index': {
-                            'start': '2000-01-01 00:00:00',
-                            'resolution': '1h',
-                            'ignore_year': False,
-                            'repeat': False
+                'parameter_values': [
+                    (
+                        'A',
+                        'aa',
+                        'test1',
+                        {
+                            'type': 'time_series',
+                            'index': {
+                                'start': '2000-01-01 00:00:00',
+                                'resolution': '1h',
+                                'ignore_year': False,
+                                'repeat': False,
+                            },
+                            'data': [0.0, 1.0, 2.0, 4.0, 8.0, 0.0],
                         },
-                        'data': [0.0, 1.0, 2.0, 4.0, 8.0, 0.0]
-                    },
-                    'Base'
-                )],
-                'alternatives': [('Base', 'Base alternative')]}
+                        'Base',
+                    )
+                ],
+                'alternatives': [('Base', 'Base alternative')],
+            }
 
             count, errors = import_data(db_map, **data, unparse_value=dump_db_value)
             self.assertEqual(errors, [])
@@ -1172,11 +1175,7 @@ class TestImportParameterValue(unittest.TestCase):
 
             time_series = from_database(value.value, value.type)
             expected_result = TimeSeriesFixedResolution(
-                '2000-01-01 00:00:00',
-                '1h',
-                [0.0, 1.0, 2.0, 4.0, 8.0, 0.0],
-                False,
-                False
+                '2000-01-01 00:00:00', '1h', [0.0, 1.0, 2.0, 4.0, 8.0, 0.0], False, False
             )
             self.assertEqual(time_series, expected_result)
 


### PR DESCRIPTION
Some clients like DB manager may want to apply the compatibility transforms that take place on commit themselves.

Re spine-tools/Spine-Toolbox#2625

## Checklist before merging
- [x] Code has been formatted by black
- [x] Unit tests pass
