### PR TITLE
Make updating parameter (default) values faster and add benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 /htmlcov
 
 spinedb_api/version.py
+benchmarks/*.json

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,26 @@
+# Performance benchmarks
+
+This Python package contains performance benchmarks for `spinedb_api`.
+The benchmarks use [`pyperf`](https://pyperf.readthedocs.io/en/latest/index.html)
+which can be installed by installing the optional developer dependencies:
+
+```commandline
+python -mpip install .[dev]
+```
+
+Each Python file is an individual script
+that writes the run results into a common `.json` file.
+The file can be inspected by
+
+```commandline
+python -mpyperf show <benchmark file.json>
+```
+
+Benchmarks from e.g. different commits/branches can be compared by
+
+```commandline
+python -mpyperf compare_to <benchmark file 1.json> <benchmark file 2.json>
+```
+
+Check the [`pyperf` documentation]((https://pyperf.readthedocs.io/en/latest/index.html))
+for further things you can do with it.

--- a/benchmarks/update_default_value_to_different_value.py
+++ b/benchmarks/update_default_value_to_different_value.py
@@ -1,0 +1,53 @@
+"""
+This benchmark tests the performance of updating a parameter definition when
+the update changes the default value from None to a somewhat complex Map.
+"""
+
+import time
+import pyperf
+from spinedb_api import DatabaseMapping, to_database
+from benchmarks.utils import build_sizeable_map, run_file_name
+
+
+def update_default_value(loops, db_map, first_db_value, first_value_type, second_db_value, second_value_type):
+    total_time = 0.0
+    for counter in range(loops):
+        start = time.perf_counter()
+        result = db_map.update_parameter_definition_item(
+            name="x", entity_class_name="Object", default_value=second_db_value, default_type=second_value_type
+        )
+        finish = time.perf_counter()
+        error = result[1]
+        if error:
+            raise RuntimeError(error)
+        total_time += finish - start
+        db_map.update_parameter_definition_item(
+            name="x", entity_class_name="Object", default_value=first_db_value, default_type=first_value_type
+        )
+    return total_time
+
+
+def run_benchmark():
+    first_value, first_type = to_database(None)
+    second_value, second_type = to_database(build_sizeable_map())
+    with DatabaseMapping("sqlite://", create=True) as db_map:
+        db_map.add_entity_class_item(name="Object")
+        db_map.add_parameter_definition_item(
+            name="x", entity_class_name="Object", default_value=first_value, default_type=first_type
+        )
+        runner = pyperf.Runner(min_time=0.0001)
+        benchmark = runner.bench_time_func(
+            "update_parameter_definition_item[None,Map]",
+            update_default_value,
+            db_map,
+            first_value,
+            first_type,
+            second_value,
+            second_type,
+            inner_loops=10,
+        )
+    pyperf.add_runs(run_file_name(), benchmark)
+
+
+if __name__ == "__main__":
+    run_benchmark()

--- a/benchmarks/update_default_value_to_same_value.py
+++ b/benchmarks/update_default_value_to_same_value.py
@@ -1,0 +1,41 @@
+"""
+This benchmark tests the performance of updating a parameter definition item when
+the default value is somewhat complex Map and the update does not change anything.
+"""
+import time
+import pyperf
+from spinedb_api import DatabaseMapping, to_database
+from benchmarks.utils import build_sizeable_map, run_file_name
+
+
+def update_default_value(loops, db_map, value, value_type):
+    total_time = 0.0
+    for counter in range(loops):
+        start = time.perf_counter()
+        result = db_map.update_parameter_definition_item(
+            name="x", entity_class_name="Object", default_value=value, default_type=value_type
+        )
+        finish = time.perf_counter()
+        error = result[1]
+        if error:
+            raise RuntimeError(error)
+        total_time += finish - start
+    return total_time
+
+
+def run_benchmark():
+    value, value_type = to_database(build_sizeable_map())
+    with DatabaseMapping("sqlite://", create=True) as db_map:
+        db_map.add_entity_class_item(name="Object")
+        db_map.add_parameter_definition_item(
+            name="x", entity_class_name="Object", default_value=value, default_type=value_type
+        )
+        runner = pyperf.Runner()
+        benchmark = runner.bench_time_func(
+            "update_parameter_definition_item[Map,Map]", update_default_value, db_map, value, value_type, inner_loops=10
+        )
+    pyperf.add_runs(run_file_name(), benchmark)
+
+
+if __name__ == "__main__":
+    run_benchmark()

--- a/benchmarks/utils.py
+++ b/benchmarks/utils.py
@@ -1,0 +1,32 @@
+import datetime
+import math
+from spinedb_api import __version__, DateTime, Map
+
+
+def build_sizeable_map():
+    start = datetime.datetime(year=2024, month=1, day=1)
+    root_xs = []
+    root_ys = []
+    i_max = 10
+    j_max = 10
+    k_max = 10
+    total = i_max * j_max * k_max
+    for i in range(i_max):
+        root_xs.append(DateTime(start + datetime.timedelta(hours=i)))
+        leaf_xs = []
+        leaf_ys = []
+        for j in range(j_max):
+            leaf_xs.append(DateTime(start + datetime.timedelta(hours=j)))
+            xs = []
+            ys = []
+            for k in range(k_max):
+                xs.append(DateTime(start + datetime.timedelta(hours=k)))
+                x = float(k + k_max * j + j_max * i) / total
+                ys.append(math.sin(x * math.pi / 2.0) + (x * j) ** 2 + x * i)
+            leaf_ys.append(Map(xs, ys))
+        root_ys.append(Map(leaf_xs, leaf_ys))
+    return Map(root_xs, root_ys)
+
+
+def run_file_name():
+    return f"benchmark-{__version__}.json"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
 Repository = "https://github.com/spine-tools/Spine-Database-API"
 
 [project.optional-dependencies]
-dev = ["coverage[toml]"]
+dev = ["coverage[toml]", "pyperf"]
 
 [build-system]
 requires = ["setuptools>=64", "setuptools_scm[toml]>=6.2", "wheel", "build"]

--- a/spinedb_api/mapped_items.py
+++ b/spinedb_api/mapped_items.py
@@ -11,7 +11,7 @@
 ######################################################################################################################
 
 from operator import itemgetter
-
+import time
 from .helpers import name_from_elements
 from .parameter_value import to_database, from_database, ParameterValueFormatError
 from .db_mapping_base import MappedItemBase
@@ -380,16 +380,21 @@ class ParsedValueBase(MappedItemBase):
         return super().__getitem__(key)
 
     def _something_to_update(self, other):
-        other = other.copy()
         if self._value_key in other and self._type_key in other:
-            try:
-                other_parsed_value = from_database(other[self._value_key], other[self._type_key])
-                if self.parsed_value != other_parsed_value:
-                    return True
-                _ = other.pop(self._value_key, None)
-                _ = other.pop(self._type_key, None)
-            except ParameterValueFormatError:
-                pass
+            other_value_type = other[self._type_key]
+            if self.type != other_value_type:
+                return True
+            other_value = other[self._value_key]
+            if self.value != other_value:
+                try:
+                    other_parsed_value = from_database(other_value, other_value_type)
+                    if self.parsed_value != other_parsed_value:
+                        return True
+                    other = other.copy()
+                    _ = other.pop(self._value_key, None)
+                    _ = other.pop(self._type_key, None)
+                except ParameterValueFormatError:
+                    pass
         return super()._something_to_update(other)
 
 


### PR DESCRIPTION
`updated_parameter_definition()` (and similar ways to update values) always parses the new (default) value before comparing it to the old one which can make the call very slow. This PR modifies the code such that we parse the value only if absolutely necessary. This makes cases where the values are completely different (e.g. updates from None to Map) or cases where the values are exactly the same (in database representation) much faster, up to over 300 times according to the performance benchmarks included.

No associated issue.

## Checklist before merging
- [x] Code has been formatted by black
- [x] Unit tests pass
