### PR TITLE
Remove cx_oracle from requirements and 'oracle' from unsupported dialects

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ dependencies = [
     "chardet >=4.0.0",
     "pymysql >=1.0.2",
     "psycopg2",
-    "cx_Oracle",
 ]
 
 [project.urls]

--- a/spinedb_api/helpers.py
+++ b/spinedb_api/helpers.py
@@ -65,7 +65,6 @@ SUPPORTED_DIALECTS = {
 UNSUPPORTED_DIALECTS = {
     "mssql": "pyodbc",
     "postgresql": "psycopg2",
-    "oracle": "cx_oracle",
 }
 
 naming_convention = {


### PR DESCRIPTION
.. from spinedb-api's `master` branch.

Re spine-tools/Spine-Toolbox#2524

## Checklist before merging
- [ ] Unit tests pass
