### PR TITLE
deep_copy_value() to accept None

### DIFF
--- a/spinedb_api/parameter_value.py
+++ b/spinedb_api/parameter_value.py
@@ -1745,7 +1745,7 @@ def deep_copy_value(value):
     Returns:
         Any: deep-copied value
     """
-    if isinstance(value, (Number, str)):
+    if isinstance(value, (Number, str)) or value is None:
         return value
     if isinstance(value, Array):
         return Array(value.values, value.value_type, value.index_name)

--- a/tests/test_parameter_value.py
+++ b/tests/test_parameter_value.py
@@ -1005,6 +1005,9 @@ class TestParameterValue(unittest.TestCase):
         self.assertEqual(nested_map, {"A": {"a": -3.2, "b": -2.3}, "B": {"c": 3.2, "d": 2.3}})
 
     def test_deep_copy_value_for_scalars(self):
+        x = None
+        copy_of_x = deep_copy_value(x)
+        self.assertIsNone(copy_of_x)
         x = 1.0
         copy_of_x = deep_copy_value(x)
         self.assertEqual(x, copy_of_x)


### PR DESCRIPTION
`None` is a valid parameter value.

No associated issue.

## Checklist before merging
- [x] Code has been formatted by black
- [x] Unit tests pass
