### PR TITLE
Improve time stamp parsing performance

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -22,5 +22,5 @@ Benchmarks from e.g. different commits/branches can be compared by
 python -mpyperf compare_to <benchmark file 1.json> <benchmark file 2.json>
 ```
 
-Check the [`pyperf` documentation]((https://pyperf.readthedocs.io/en/latest/index.html))
+Check the [`pyperf` documentation](https://pyperf.readthedocs.io/en/latest/index.html)
 for further things you can do with it.

--- a/benchmarks/datetime_from_database.py
+++ b/benchmarks/datetime_from_database.py
@@ -1,0 +1,56 @@
+"""
+This benchmark tests the performance of reading a DateTime value from database.
+"""
+
+import datetime
+import time
+from typing import Any, Sequence, Tuple
+import pyperf
+from spinedb_api import DateTime, from_database, to_database
+from benchmarks.utils import run_file_name
+
+
+def build_datetimes(count: int) -> Sequence[DateTime]:
+    datetimes = []
+    year = 2024
+    month = 1
+    day = 1
+    hour = 0
+    while len(datetimes) != count:
+        datetimes.append(DateTime(datetime.datetime(year, month, day, hour)))
+        hour += 1
+        if hour == 24:
+            hour = 1
+            day += 1
+            if day == 29:
+                day = 1
+                month += 1
+                if month == 13:
+                    month = 1
+                    year += 1
+    return datetimes
+
+
+def value_from_database(loops: int, db_values_and_types: Sequence[Tuple[Any, str]]) -> float:
+    duration = 0.0
+    for _ in range(loops):
+        for db_value, db_type in db_values_and_types:
+            start = time.perf_counter()
+            from_database(db_value, db_type)
+            duration += time.perf_counter() - start
+    return duration
+
+
+def run_benchmark():
+    file_name = run_file_name()
+    runner = pyperf.Runner()
+    inner_loops = 100
+    db_values_and_types = [to_database(x) for x in build_datetimes(inner_loops)]
+    benchmark = runner.bench_time_func(
+        "from_database[DateTime]", value_from_database, db_values_and_types, inner_loops=inner_loops
+    )
+    pyperf.add_runs(file_name, benchmark)
+
+
+if __name__ == "__main__":
+    run_benchmark()

--- a/benchmarks/map_from_database.py
+++ b/benchmarks/map_from_database.py
@@ -13,7 +13,7 @@ def value_from_database(loops, db_value, value_type):
     for _ in range(loops):
         start = time.perf_counter()
         from_database(db_value, value_type)
-        duration += (time.perf_counter() - start)
+        duration += time.perf_counter() - start
     return duration
 
 

--- a/benchmarks/map_from_database.py
+++ b/benchmarks/map_from_database.py
@@ -1,0 +1,40 @@
+"""
+This benchmark tests the performance of reading a Map type value from database.
+"""
+
+import time
+import pyperf
+from spinedb_api import from_database, to_database
+from benchmarks.utils import build_even_map, run_file_name
+
+
+def value_from_database(loops, db_value, value_type):
+    duration = 0.0
+    for _ in range(loops):
+        start = time.perf_counter()
+        from_database(db_value, value_type)
+        duration += (time.perf_counter() - start)
+    return duration
+
+
+def run_benchmark():
+    file_name = run_file_name()
+    runner = pyperf.Runner(loops=3)
+    runs = {
+        "value_from_database[Map(10, 10, 100)]": {"dimensions": (10, 10, 100)},
+        "value_from_database[Map(1000)]": {"dimensions": (10000,)},
+    }
+    for name, parameters in runs.items():
+        db_value, value_type = to_database(build_even_map(parameters["dimensions"]))
+        benchmark = runner.bench_time_func(
+            name,
+            value_from_database,
+            db_value,
+            value_type,
+        )
+        if benchmark is not None:
+            pyperf.add_runs(file_name, benchmark)
+
+
+if __name__ == "__main__":
+    run_benchmark()

--- a/benchmarks/update_default_value_to_different_value.py
+++ b/benchmarks/update_default_value_to_different_value.py
@@ -6,7 +6,7 @@ the update changes the default value from None to a somewhat complex Map.
 import time
 import pyperf
 from spinedb_api import DatabaseMapping, to_database
-from benchmarks.utils import build_sizeable_map, run_file_name
+from benchmarks.utils import build_even_map, run_file_name
 
 
 def update_default_value(loops, db_map, first_db_value, first_value_type, second_db_value, second_value_type):
@@ -29,13 +29,13 @@ def update_default_value(loops, db_map, first_db_value, first_value_type, second
 
 def run_benchmark():
     first_value, first_type = to_database(None)
-    second_value, second_type = to_database(build_sizeable_map())
+    second_value, second_type = to_database(build_even_map())
     with DatabaseMapping("sqlite://", create=True) as db_map:
         db_map.add_entity_class_item(name="Object")
         db_map.add_parameter_definition_item(
             name="x", entity_class_name="Object", default_value=first_value, default_type=first_type
         )
-        runner = pyperf.Runner(min_time=0.0001)
+        runner = pyperf.Runner(min_time=0.001)
         benchmark = runner.bench_time_func(
             "update_parameter_definition_item[None,Map]",
             update_default_value,
@@ -44,7 +44,6 @@ def run_benchmark():
             first_type,
             second_value,
             second_type,
-            inner_loops=10,
         )
     pyperf.add_runs(run_file_name(), benchmark)
 

--- a/benchmarks/update_default_value_to_same_value.py
+++ b/benchmarks/update_default_value_to_same_value.py
@@ -5,7 +5,7 @@ the default value is somewhat complex Map and the update does not change anythin
 import time
 import pyperf
 from spinedb_api import DatabaseMapping, to_database
-from benchmarks.utils import build_sizeable_map, run_file_name
+from benchmarks.utils import build_even_map, run_file_name
 
 
 def update_default_value(loops, db_map, value, value_type):
@@ -24,7 +24,7 @@ def update_default_value(loops, db_map, value, value_type):
 
 
 def run_benchmark():
-    value, value_type = to_database(build_sizeable_map())
+    value, value_type = to_database(build_even_map())
     with DatabaseMapping("sqlite://", create=True) as db_map:
         db_map.add_entity_class_item(name="Object")
         db_map.add_parameter_definition_item(
@@ -32,7 +32,7 @@ def run_benchmark():
         )
         runner = pyperf.Runner()
         benchmark = runner.bench_time_func(
-            "update_parameter_definition_item[Map,Map]", update_default_value, db_map, value, value_type, inner_loops=10
+            "update_parameter_definition_item[Map,Map]", update_default_value, db_map, value, value_type
         )
     pyperf.add_runs(run_file_name(), benchmark)
 

--- a/benchmarks/utils.py
+++ b/benchmarks/utils.py
@@ -1,32 +1,33 @@
 import datetime
 import math
+from typing import Sequence
 from spinedb_api import __version__, DateTime, Map
 
 
-def build_sizeable_map():
+def build_map(size: int) -> Map:
     start = datetime.datetime(year=2024, month=1, day=1)
-    root_xs = []
-    root_ys = []
-    i_max = 10
-    j_max = 10
-    k_max = 10
-    total = i_max * j_max * k_max
-    for i in range(i_max):
-        root_xs.append(DateTime(start + datetime.timedelta(hours=i)))
-        leaf_xs = []
-        leaf_ys = []
-        for j in range(j_max):
-            leaf_xs.append(DateTime(start + datetime.timedelta(hours=j)))
-            xs = []
-            ys = []
-            for k in range(k_max):
-                xs.append(DateTime(start + datetime.timedelta(hours=k)))
-                x = float(k + k_max * j + j_max * i) / total
-                ys.append(math.sin(x * math.pi / 2.0) + (x * j) ** 2 + x * i)
-            leaf_ys.append(Map(xs, ys))
-        root_ys.append(Map(leaf_xs, leaf_ys))
-    return Map(root_xs, root_ys)
+    xs = []
+    ys = []
+    for i in range(size):
+        xs.append(DateTime(start + datetime.timedelta(hours=i)))
+        x = i / size
+        ys.append(math.sin(x * math.pi / 2.0) + x)
+    return Map(xs, ys)
 
 
-def run_file_name():
+def build_even_map(shape: Sequence[int] = (10, 10, 10)) -> Map:
+    if not shape:
+        return Map([], [], index_type=DateTime)
+    if len(shape) == 1:
+        return build_map(shape[0])
+    xs = []
+    ys = []
+    for i in range(shape[0]):
+        start = datetime.datetime(year=2024, month=1, day=1)
+        xs.append(DateTime(start + datetime.timedelta(hours=i)))
+        ys.append(build_even_map(shape[1:]))
+    return Map(xs, ys)
+
+
+def run_file_name() -> str:
     return f"benchmark-{__version__}.json"

--- a/spinedb_api/parameter_value.py
+++ b/spinedb_api/parameter_value.py
@@ -389,9 +389,12 @@ def _break_dictionary(data):
 def _datetime_from_database(value):
     """Converts a datetime database value into a DateTime object."""
     try:
-        stamp = dateutil.parser.parse(value)
+        stamp = datetime.fromisoformat(value)
     except ValueError:
-        raise ParameterValueFormatError(f'Could not parse datetime from "{value}"')
+        try:
+            stamp = dateutil.parser.parse(value)
+        except ValueError:
+            raise ParameterValueFormatError(f'Could not parse datetime from "{value}"')
     return DateTime(stamp)
 
 
@@ -517,9 +520,12 @@ def _time_series_from_single_column(value_dict):
             duration = str(duration) + _TIME_SERIES_PLAIN_INDEX_UNIT
         relativedeltas.append(duration_to_relativedelta(duration))
     try:
-        start = dateutil.parser.parse(start)
+        start = datetime.fromisoformat(start)
     except ValueError:
-        raise ParameterValueFormatError(f'Could not decode start value "{start}"')
+        try:
+            start = dateutil.parser.parse(start)
+        except ValueError:
+            raise ParameterValueFormatError(f'Could not decode start value "{start}"')
     values = np.array(value_dict["data"])
     return TimeSeriesFixedResolution(
         start, relativedeltas, values, ignore_year, repeat, value_dict.get("index_name", "")
@@ -744,9 +750,12 @@ class DateTime(ParameterValue):
             value = datetime(year=2000, month=1, day=1)
         elif isinstance(value, str):
             try:
-                value = dateutil.parser.parse(value)
+                value = datetime.fromisoformat(value)
             except ValueError:
-                raise ParameterValueFormatError(f'Could not parse datetime from "{value}"')
+                try:
+                    value = dateutil.parser.parse(value)
+                except ValueError:
+                    raise ParameterValueFormatError(f'Could not parse datetime from "{value}"')
         elif isinstance(value, DateTime):
             value = copy(value._value)
         elif not isinstance(value, datetime):
@@ -1348,9 +1357,12 @@ class TimeSeriesFixedResolution(TimeSeries):
         """
         if isinstance(start, str):
             try:
-                self._start = dateutil.parser.parse(start)
+                self._start = datetime.fromisoformat(start)
             except ValueError:
-                raise ParameterValueFormatError(f'Cannot parse start time "{start}"')
+                try:
+                    self._start = dateutil.parser.parse(start)
+                except ValueError:
+                    raise ParameterValueFormatError(f'Cannot parse start time "{start}"')
         elif isinstance(start, np.datetime64):
             self._start = start.tolist()
         else:


### PR DESCRIPTION
We now try parsing time stamps with `datetime.fromisoformat()` before falling back to `dateutil.parser.parse()` which makes e.g. parsing `DateTime` objects from database ~x10 faster.

Resolves #385

## Checklist before merging
- [x] Code has been formatted by black
- [ ] Unit tests pass
