### PR TITLE
Add more benchmarks

### DIFF
--- a/benchmarks/datetime_from_database.py
+++ b/benchmarks/datetime_from_database.py
@@ -20,7 +20,7 @@ def build_datetimes(count: int) -> Sequence[DateTime]:
         datetimes.append(DateTime(datetime.datetime(year, month, day, hour)))
         hour += 1
         if hour == 24:
-            hour = 1
+            hour = 0
             day += 1
             if day == 29:
                 day = 1
@@ -43,8 +43,8 @@ def value_from_database(loops: int, db_values_and_types: Sequence[Tuple[Any, str
 
 def run_benchmark():
     file_name = run_file_name()
-    runner = pyperf.Runner()
-    inner_loops = 100
+    runner = pyperf.Runner(loops=10)
+    inner_loops = 1000
     db_values_and_types = [to_database(x) for x in build_datetimes(inner_loops)]
     benchmark = runner.bench_time_func(
         "from_database[DateTime]", value_from_database, db_values_and_types, inner_loops=inner_loops

--- a/benchmarks/mapped_item_getitem.py
+++ b/benchmarks/mapped_item_getitem.py
@@ -1,0 +1,62 @@
+"""
+This benchmark tests the performance of the MappedItemBase.__getitem__() method.
+"""
+
+import pyperf
+import time
+from typing import Dict
+from spinedb_api import DatabaseMapping
+from spinedb_api.db_mapping_base import PublicItem
+from benchmarks.utils import run_file_name
+
+
+def use_subscript_operator(loops: int, items: PublicItem, field: Dict):
+    duration = 0.0
+    for _ in range(loops):
+        for item in items:
+            start = time.perf_counter()
+            value = item[field]
+            duration += time.perf_counter() - start
+    return duration
+
+
+def run_benchmark():
+    runner = pyperf.Runner()
+    inner_loops = 1000
+    object_class_names = [str(i) for i in range(inner_loops)]
+    relationship_class_names = [f"r{dimension}" for dimension in object_class_names]
+    with DatabaseMapping("sqlite://", create=True) as db_map:
+        object_classes = []
+        for name in object_class_names:
+            item, error = db_map.add_entity_class_item(name=name)
+            assert error is None
+            object_classes.append(item)
+        relationship_classes = []
+        for name, dimension in zip(relationship_class_names, object_classes):
+            item, error = db_map.add_entity_class_item(name, dimension_name_list=(dimension["name"],))
+            assert error is None
+            relationship_classes.append(item)
+    benchmarks = [
+        runner.bench_time_func(
+            "PublicItem subscript['name' in EntityClassItem]",
+            use_subscript_operator,
+            object_classes,
+            "name",
+            inner_loops=inner_loops,
+        ),
+        runner.bench_time_func(
+            "PublicItem subscript['dimension_name_list' in EntityClassItem]",
+            use_subscript_operator,
+            relationship_classes,
+            "dimension_name_list",
+            inner_loops=inner_loops,
+        ),
+    ]
+    file_name = run_file_name()
+    for benchmark in benchmarks:
+        if benchmark is not None:
+            pyperf.add_runs(file_name, benchmark)
+
+
+if __name__ == "__main__":
+    run_benchmark()


### PR DESCRIPTION
This PR adds a benchmark that was salvaged from a failed attempt to use [`numba`](https://numba.readthedocs.io/en/stable/user/overview.html) JIT compiler to speed up `MappedItem.__getitem__()`. Some profiling experiments identified `MappedItem.__getitem__()` as a hot spot when using `DatabaseMapping`, so it could have been nice if it was possible to improve its performance.

No associated issue.