### PR TITLE
Bump Spine DB Server and cliend versions from 6 to 7

### DIFF
--- a/spinedb_api/spine_db_client.py
+++ b/spinedb_api/spine_db_client.py
@@ -19,7 +19,7 @@ import socket
 from sqlalchemy.engine.url import URL
 from .server_client_helpers import ReceiveAllMixing, encode, decode
 
-client_version = 6
+client_version = 7
 
 
 class SpineDBClient(ReceiveAllMixing):

--- a/spinedb_api/spine_db_server.py
+++ b/spinedb_api/spine_db_server.py
@@ -117,7 +117,7 @@ from .filters.alternative_filter import alternative_filter_config
 from .filters.tools import apply_filter_stack
 from .spine_db_client import SpineDBClient
 
-_current_server_version = 6
+_current_server_version = 7
 
 
 def get_current_server_version():


### PR DESCRIPTION
The interface is not compatible with version 6 anymore with all the `0.8-dev` changes.

No associated issue.

## Checklist before merging
- [x] Unit tests pass
