### PR TITLE
Reformat source code with latest Black

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,4 +65,4 @@ ignore_errors = true
 
 [tool.black]
 line-length = 120
-exclude = '\.git'
+exclude = '\.git|version.py'

--- a/spinedb_api/alembic/versions/070a0eb89e88_drop_category_tables.py
+++ b/spinedb_api/alembic/versions/070a0eb89e88_drop_category_tables.py
@@ -5,6 +5,7 @@ Revises: bba1e2ef5153
 Create Date: 2019-09-20 13:04:52.423483
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/spinedb_api/alembic/versions/0c7d199ae915_add_list_value_table.py
+++ b/spinedb_api/alembic/versions/0c7d199ae915_add_list_value_table.py
@@ -5,6 +5,7 @@ Revises: 7d0b467f2f4e
 Create Date: 2022-03-07 14:55:32.802765
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.ext.automap import automap_base

--- a/spinedb_api/alembic/versions/1892adebc00f_create_metadata_tables.py
+++ b/spinedb_api/alembic/versions/1892adebc00f_create_metadata_tables.py
@@ -5,6 +5,7 @@ Revises: defbda3bf2b5
 Create Date: 2020-10-05 14:51:13.787685
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/spinedb_api/alembic/versions/1e4997105288_separate_type_from_value.py
+++ b/spinedb_api/alembic/versions/1e4997105288_separate_type_from_value.py
@@ -19,7 +19,7 @@ down_revision = "fbb540efbf15"
 branch_labels = None
 depends_on = None
 
-LONGTEXT_LENGTH = 2 ** 32 - 1
+LONGTEXT_LENGTH = 2**32 - 1
 
 
 def upgrade():

--- a/spinedb_api/alembic/versions/39e860a11b05_add_alternatives_and_scenarios.py
+++ b/spinedb_api/alembic/versions/39e860a11b05_add_alternatives_and_scenarios.py
@@ -5,6 +5,7 @@ Revises: 9da58d2def22
 Create Date: 2020-03-05 14:04:00.854936
 
 """
+
 from datetime import datetime, timezone
 from alembic import op
 import sqlalchemy as sa

--- a/spinedb_api/alembic/versions/51fd7b69acf7_add_parameter_tag_and_parameter_value_list.py
+++ b/spinedb_api/alembic/versions/51fd7b69acf7_add_parameter_tag_and_parameter_value_list.py
@@ -5,6 +5,7 @@ Revises: 8c19c53d5701
 Create Date: 2019-01-25 15:47:05.100028
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/spinedb_api/alembic/versions/5385f063bef2_create_superclass_subclass_table.py
+++ b/spinedb_api/alembic/versions/5385f063bef2_create_superclass_subclass_table.py
@@ -5,6 +5,7 @@ Revises: ce9faa82ed59
 Create Date: 2023-10-30 17:11:23.316879
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/spinedb_api/alembic/versions/6b7c994c1c61_drop_object_and_relationship_tables.py
+++ b/spinedb_api/alembic/versions/6b7c994c1c61_drop_object_and_relationship_tables.py
@@ -5,6 +5,7 @@ Revises: 989fccf80441
 Create Date: 2023-02-09 06:48:46.585108
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 from spinedb_api.helpers import naming_convention

--- a/spinedb_api/alembic/versions/738d494a08ac_fix_foreign_key_constraints_in_object_.py
+++ b/spinedb_api/alembic/versions/738d494a08ac_fix_foreign_key_constraints_in_object_.py
@@ -5,6 +5,7 @@ Revises: 1e4997105288
 Create Date: 2022-01-05 09:18:48.858784
 
 """
+
 from alembic import op
 from spinedb_api.helpers import naming_convention
 

--- a/spinedb_api/alembic/versions/7d0b467f2f4e_fix_foreign_key_constraints_in_entity_.py
+++ b/spinedb_api/alembic/versions/7d0b467f2f4e_fix_foreign_key_constraints_in_entity_.py
@@ -5,6 +5,7 @@ Revises: fd542cebf699
 Create Date: 2022-02-15 15:41:06.794006
 
 """
+
 from alembic import op
 from spinedb_api.helpers import naming_convention
 

--- a/spinedb_api/alembic/versions/8b0eff478bcb_add_active_by_default_to_entity_class.py
+++ b/spinedb_api/alembic/versions/8b0eff478bcb_add_active_by_default_to_entity_class.py
@@ -5,6 +5,7 @@ Revises: 5385f063bef2
 Create Date: 2024-01-12 09:55:08.934574
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 import sqlalchemy.orm

--- a/spinedb_api/alembic/versions/8c19c53d5701_rename_parameter_to_parameter_definition.py
+++ b/spinedb_api/alembic/versions/8c19c53d5701_rename_parameter_to_parameter_definition.py
@@ -5,6 +5,7 @@ Revises:
 Create Date: 2019-01-24 16:47:21.493240
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/spinedb_api/alembic/versions/989fccf80441_replace_values_with_reference_to_list_.py
+++ b/spinedb_api/alembic/versions/989fccf80441_replace_values_with_reference_to_list_.py
@@ -5,6 +5,7 @@ Revises: 0c7d199ae915
 Create Date: 2022-03-14 11:33:13.777028
 
 """
+
 from alembic import op
 from sqlalchemy import MetaData
 from sqlalchemy.sql.expression import bindparam

--- a/spinedb_api/alembic/versions/9da58d2def22_create_entity_group_table.py
+++ b/spinedb_api/alembic/versions/9da58d2def22_create_entity_group_table.py
@@ -5,6 +5,7 @@ Revises: 070a0eb89e88
 Create Date: 2020-06-09 21:31:07.912724
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/spinedb_api/alembic/versions/bba1e2ef5153_move_to_entity_based_design.py
+++ b/spinedb_api/alembic/versions/bba1e2ef5153_move_to_entity_based_design.py
@@ -5,6 +5,7 @@ Revises: bf255c179bce
 Create Date: 2019-09-17 13:38:53.437119
 
 """
+
 from datetime import datetime
 from alembic import op
 import sqlalchemy as sa

--- a/spinedb_api/alembic/versions/bf255c179bce_get_rid_of_unused_fields_in_parameter_.py
+++ b/spinedb_api/alembic/versions/bf255c179bce_get_rid_of_unused_fields_in_parameter_.py
@@ -5,6 +5,7 @@ Revises: 51fd7b69acf7
 Create Date: 2019-03-26 15:34:26.550171
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/spinedb_api/alembic/versions/ce9faa82ed59_create_entity_alternative_table.py
+++ b/spinedb_api/alembic/versions/ce9faa82ed59_create_entity_alternative_table.py
@@ -5,6 +5,7 @@ Revises: 6b7c994c1c61
 Create Date: 2023-09-21 14:35:28.867803
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 from spinedb_api.compatibility import convert_tool_feature_method_to_entity_alternative

--- a/spinedb_api/alembic/versions/defbda3bf2b5_add_tool_feature_tables.py
+++ b/spinedb_api/alembic/versions/defbda3bf2b5_add_tool_feature_tables.py
@@ -5,6 +5,7 @@ Revises: 39e860a11b05
 Create Date: 2020-09-01 20:12:57.300147
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/spinedb_api/alembic/versions/fbb540efbf15_add_support_for_mysql.py
+++ b/spinedb_api/alembic/versions/fbb540efbf15_add_support_for_mysql.py
@@ -5,6 +5,7 @@ Revises: 1892adebc00f
 Create Date: 2021-01-05 10:40:16.720937
 
 """
+
 from alembic import op
 from sqlalchemy import Text
 from spinedb_api.helpers import LONGTEXT_LENGTH, naming_convention

--- a/spinedb_api/alembic/versions/fd542cebf699_drop_on_update_clauses_from_object_and_.py
+++ b/spinedb_api/alembic/versions/fd542cebf699_drop_on_update_clauses_from_object_and_.py
@@ -5,6 +5,7 @@ Revises: 738d494a08ac
 Create Date: 2022-01-05 11:00:31.154790
 
 """
+
 from alembic import op
 from spinedb_api.helpers import naming_convention
 

--- a/spinedb_api/compatibility.py
+++ b/spinedb_api/compatibility.py
@@ -81,9 +81,11 @@ def convert_tool_feature_method_to_active_by_default(conn, use_existing_tool_fea
     # where active_by_default is True if the value of 'is_active' is the one from the tool_feature_method specification
     entity_class_items_to_update = {
         x["entity_class_id"]: {
-            "active_by_default": False
-            if x["list_value_id"] is None
-            else x["list_value_id"] == lv_id_by_pdef_id[x["parameter_definition_id"]],
+            "active_by_default": (
+                False
+                if x["list_value_id"] is None
+                else x["list_value_id"] == lv_id_by_pdef_id[x["parameter_definition_id"]]
+            ),
         }
         for x in is_active_default_vals
     }

--- a/spinedb_api/db_mapping.py
+++ b/spinedb_api/db_mapping.py
@@ -877,6 +877,7 @@ for it in DatabaseMapping.item_types():
     setattr(DatabaseMapping, "remove_" + it + "_item", partialmethod(DatabaseMapping.remove_item, it))
     setattr(DatabaseMapping, "restore_" + it + "_item", partialmethod(DatabaseMapping.restore_item, it))
 
+
 # Astroid transform so DatabaseMapping looks like it has the convenience methods defined above
 def _add_convenience_methods(node):
     if node.name != "DatabaseMapping":

--- a/spinedb_api/graph_layout_generator.py
+++ b/spinedb_api/graph_layout_generator.py
@@ -151,7 +151,7 @@ class GraphLayoutGenerator:
         heavy_pos = arr(heavy_pos_list)
         if heavy_ind.any():
             layout[heavy_ind, :] = heavy_pos
-        weights = matrix ** self.weight_exp  # bus-pair weights (lower for distant buses)
+        weights = matrix**self.weight_exp  # bus-pair weights (lower for distant buses)
         maxstep = 1 / np.min(weights[mask])
         minstep = 1 / np.max(weights[mask])
         lambda_ = np.log(minstep / maxstep) / (self.max_iters - 1)  # exponential decay of allowed adjustment

--- a/spinedb_api/helpers.py
+++ b/spinedb_api/helpers.py
@@ -75,7 +75,7 @@ naming_convention = {
 
 model_meta = MetaData(naming_convention=naming_convention)
 
-LONGTEXT_LENGTH = 2 ** 32 - 1
+LONGTEXT_LENGTH = 2**32 - 1
 
 
 def name_from_elements(elements):

--- a/spinedb_api/spine_io/gdx_utils.py
+++ b/spinedb_api/spine_io/gdx_utils.py
@@ -26,7 +26,7 @@ def _python_interpreter_bitness():
     """Returns 64 for 64bit Python interpreter or 32 for 32bit interpreter."""
     # As recommended in Python's docs:
     # https://docs.python.org/3/library/platform.html#cross-platform
-    return 64 if sys.maxsize > 2 ** 32 else 32
+    return 64 if sys.maxsize > 2**32 else 32
 
 
 def _windows_dlls_exist(gams_path):


### PR DESCRIPTION
This PR formats the code with `black` version 24.4.2.

No functional changes whatsoever.

Re spine-tools/Spine-Toolbox#2733

## Checklist before merging
- [x] Code has been formatted by black
