### PR TITLE
Don't set default value to None after applying compat transformation

### DIFF
--- a/spinedb_api/compatibility.py
+++ b/spinedb_api/compatibility.py
@@ -97,16 +97,6 @@ def convert_tool_feature_method_to_active_by_default(conn, use_existing_tool_fea
             conn.execute(update_statement.where(entity_class_table.c.id == class_id), update)
         update["id"] = class_id
         updated_items.append(update)
-    parameter_definitions_to_update = (
-        x["parameter_definition_id"] for x in is_active_default_vals if x["list_value_id"] is not None
-    )
-    update_statement = pd_table.update()
-    for definition_id in parameter_definitions_to_update:
-        update = {"default_value": None, "default_type": None}
-        if apply:
-            conn.execute(update_statement.where(pd_table.c.id == definition_id), update)
-        update["id"] = definition_id
-        updated_items.append(update)
     return [], updated_items, []
 
 

--- a/tests/test_DatabaseMapping.py
+++ b/tests/test_DatabaseMapping.py
@@ -674,7 +674,7 @@ class TestDatabaseMapping(AssertSuccessTestCase):
                 from_database(definition["default_value"], definition["default_type"])
                 for definition in db_map.query(db_map.parameter_definition_sq)
             ]
-            self.assertEqual(defaults, 3 * [None])
+            self.assertEqual(defaults, [True, True, None])
 
     def test_remove_items_by_asterisk(self):
         with DatabaseMapping("sqlite://", create=True) as db_map:


### PR DESCRIPTION
Re #395

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
