### PR TITLE
Change active_by_default server default from False to True

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The server default of `active_by_default` is now `True`.
+
 ### Added
 
 ### Fixed

--- a/spinedb_api/alembic/versions/e010777927a5_change_active_by_default_server_default_.py
+++ b/spinedb_api/alembic/versions/e010777927a5_change_active_by_default_server_default_.py
@@ -1,0 +1,26 @@
+"""change active_by_default server default to true
+
+Revision ID: e010777927a5
+Revises: 8b0eff478bcb
+Create Date: 2024-05-13 13:00:28.059409
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "e010777927a5"
+down_revision = "8b0eff478bcb"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("entity_class") as batch_op:
+        batch_op.alter_column("active_by_default", server_default=sa.true())
+
+
+def downgrade():
+    pass

--- a/spinedb_api/helpers.py
+++ b/spinedb_api/helpers.py
@@ -379,7 +379,7 @@ def create_spine_metadata():
         Column("display_order", Integer, server_default="99"),
         Column("display_icon", BigInteger, server_default=null()),
         Column("hidden", Integer, server_default="0"),
-        Column("active_by_default", Boolean(name="active_by_default"), server_default=false(), nullable=False),
+        Column("active_by_default", Boolean(name="active_by_default"), server_default=true(), nullable=False),
     )
     Table(
         "superclass_subclass",

--- a/spinedb_api/mapped_items.py
+++ b/spinedb_api/mapped_items.py
@@ -103,7 +103,7 @@ class EntityClassItem(MappedItemBase):
         if error:
             return error
         if "active_by_default" not in self:
-            self["active_by_default"] = bool(dict.get(self, "dimension_id_list"))
+            self["active_by_default"] = True
 
     def merge(self, other):
         dimension_id_list = other.pop("dimension_id_list", None)
@@ -164,7 +164,7 @@ class EntityItem(MappedItemBase):
 
     @classmethod
     def unique_values_for_item(cls, item, skip_keys=()):
-        """Overriden to also yield unique values for the superclass."""
+        """Overridden to also yield unique values for the superclass."""
         for key, value in super().unique_values_for_item(item, skip_keys=skip_keys):
             yield key, value
             sc_value = tuple(item.get("superclass_name" if k == "entity_class_name" else k) for k in key)

--- a/tests/filters/test_tools.py
+++ b/tests/filters/test_tools.py
@@ -101,7 +101,7 @@ class TestApplyFilterStack(unittest.TestCase):
         try:
             apply_filter_stack(db_map, [])
             object_classes = export_entity_classes(db_map)
-            self.assertEqual(object_classes, [("object_class", (), None, None, False)])
+            self.assertEqual(object_classes, [("object_class", (), None, None, True)])
         finally:
             db_map.close()
 
@@ -111,7 +111,7 @@ class TestApplyFilterStack(unittest.TestCase):
             stack = [entity_class_renamer_config(object_class="renamed_once")]
             apply_filter_stack(db_map, stack)
             object_classes = export_entity_classes(db_map)
-            self.assertEqual(object_classes, [("renamed_once", (), None, None, False)])
+            self.assertEqual(object_classes, [("renamed_once", (), None, None, True)])
         finally:
             db_map.close()
 
@@ -124,7 +124,7 @@ class TestApplyFilterStack(unittest.TestCase):
             ]
             apply_filter_stack(db_map, stack)
             object_classes = export_entity_classes(db_map)
-            self.assertEqual(object_classes, [("renamed_twice", (), None, None, False)])
+            self.assertEqual(object_classes, [("renamed_twice", (), None, None, True)])
         finally:
             db_map.close()
 
@@ -147,7 +147,7 @@ class TestFilteredDatabaseMap(unittest.TestCase):
         db_map = DatabaseMapping(self._db_url, self._engine)
         try:
             object_classes = export_entity_classes(db_map)
-            self.assertEqual(object_classes, [("object_class", (), None, None, False)])
+            self.assertEqual(object_classes, [("object_class", (), None, None, True)])
         finally:
             db_map.close()
 
@@ -159,7 +159,7 @@ class TestFilteredDatabaseMap(unittest.TestCase):
         db_map = DatabaseMapping(url, self._engine)
         try:
             object_classes = export_entity_classes(db_map)
-            self.assertEqual(object_classes, [("renamed_once", (), None, None, False)])
+            self.assertEqual(object_classes, [("renamed_once", (), None, None, True)])
         finally:
             db_map.close()
 
@@ -175,7 +175,7 @@ class TestFilteredDatabaseMap(unittest.TestCase):
         db_map = DatabaseMapping(url, self._engine)
         try:
             object_classes = export_entity_classes(db_map)
-            self.assertEqual(object_classes, [("renamed_twice", (), None, None, False)])
+            self.assertEqual(object_classes, [("renamed_twice", (), None, None, True)])
         finally:
             db_map.close()
 
@@ -185,7 +185,7 @@ class TestFilteredDatabaseMap(unittest.TestCase):
         db_map = DatabaseMapping(url, self._engine)
         try:
             object_classes = export_entity_classes(db_map)
-            self.assertEqual(object_classes, [("renamed_once", (), None, None, False)])
+            self.assertEqual(object_classes, [("renamed_once", (), None, None, True)])
         finally:
             db_map.close()
 

--- a/tests/test_DatabaseMapping.py
+++ b/tests/test_DatabaseMapping.py
@@ -93,10 +93,10 @@ class AssertSuccessTestCase(unittest.TestCase):
 
 
 class TestDatabaseMapping(AssertSuccessTestCase):
-    def test_active_by_default_is_initially_false_for_zero_dimensional_entity_class(self):
+    def test_active_by_default_is_initially_true_for_zero_dimensional_entity_class(self):
         with DatabaseMapping("sqlite://", create=True) as db_map:
             item = self._assert_success(db_map.add_entity_class_item(name="Entity"))
-            self.assertFalse(item["active_by_default"])
+            self.assertTrue(item["active_by_default"])
 
     def test_active_by_default_is_initially_false_for_multi_dimensional_entity_class(self):
         with DatabaseMapping("sqlite://", create=True) as db_map:

--- a/tests/test_export_functions.py
+++ b/tests/test_export_functions.py
@@ -84,7 +84,7 @@ class TestExportFunctions(unittest.TestCase):
                 db_map.add_entity_class_item(name="Relation", dimension_name_list=("Object",))
             )
             exported = export_entity_classes(db_map)
-            expected = (("Object", (), None, None, False), ("Relation", ("Object",), None, None, True))
+            expected = (("Object", (), None, None, True), ("Relation", ("Object",), None, None, True))
             self.assertCountEqual(exported, expected)
 
     def test_export_data(self):
@@ -116,7 +116,7 @@ class TestExportFunctions(unittest.TestCase):
             self.assertIn("entity_classes", exported)
             self.assertEqual(
                 exported["entity_classes"],
-                [("object_class", (), None, None, False), ("relationship_class", ("object_class",), None, None, True)],
+                [("object_class", (), None, None, True), ("relationship_class", ("object_class",), None, None, True)],
             )
             self.assertIn("parameter_definitions", exported)
             self.assertEqual(

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -73,7 +73,7 @@ class TestRemoveCredentialsFromUrl(unittest.TestCase):
 class TestGetHeadAlembicVersion(unittest.TestCase):
     def test_returns_latest_version(self):
         # This test must be updated each time new migration script is added.
-        self.assertEqual(get_head_alembic_version(), "8b0eff478bcb")
+        self.assertEqual(get_head_alembic_version(), "e010777927a5")
 
 
 class TestStringToBool(unittest.TestCase):


### PR DESCRIPTION
New databases now come with `active_by_default` column default set to True. A migration script handles updates of old databases. There was no need to modify the compatibility functions as discussed in the issue: we already set `active_by_default` unconditionally to True.

Resolves spine-tools/Spine-Toolbox#2744

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
