### PR TITLE
Fix a bug where nD entity classes failed to import

### DIFF
--- a/spinedb_api/import_mapping/import_mapping.py
+++ b/spinedb_api/import_mapping/import_mapping.py
@@ -454,10 +454,13 @@ class DimensionMapping(ImportMapping):
     MAP_TYPE = "Dimension"
 
     def _import_row(self, source_data, state, mapped_data):
-        _ = state[ImportKey.ENTITY_CLASS_NAME]
-        dimension_name = str(source_data)
-        state[ImportKey.DIMENSION_NAMES].append(dimension_name)
+        if ImportKey.ENTITY_CLASS_NAME not in state:
+            raise KeyError(ImportKey.ENTITY_CLASS_NAME)
         dimension_names = state[ImportKey.DIMENSION_NAMES]
+        if len(dimension_names) == state[ImportKey.DIMENSION_COUNT]:
+            return
+        dimension_name = str(source_data)
+        dimension_names.append(dimension_name)
         if len(dimension_names) == state[ImportKey.DIMENSION_COUNT]:
             raise KeyFix(ImportKey.DIMENSION_NAMES)
 


### PR DESCRIPTION
This PR fixes a corner case where empty row in an input table would cause the dimensions of an entity class to become duplicated.

Fixes spine-tools/Spine-Toolbox#2760

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
