### PR TITLE
Stop iterating import mappings when row gets skipped

### DIFF
--- a/spinedb_api/import_mapping/import_mapping.py
+++ b/spinedb_api/import_mapping/import_mapping.py
@@ -258,6 +258,7 @@ class ImportMapping(Mapping):
             source_data = self._data(source_row)
             if source_data is None:
                 self._skip_row(state)
+                return
             else:
                 try:
                     self._import_row(source_data, state, mapped_data)

--- a/tests/import_mapping/test_generator.py
+++ b/tests/import_mapping/test_generator.py
@@ -510,6 +510,36 @@ class TestGetMappedData(unittest.TestCase):
             },
         )
 
+    def test_importing_empty_rows_does_unnecessarily_not_repeat_mapped_data(self):
+        header = ["Generator", "HydroGenerator"]
+        data_source = iter(
+            [["MyHydroGenerator", "MyHydroGenerator"], ["NonHydroGenerator", None], ["OtherGenerator", None]]
+        )
+        mappings = [
+            [
+                {"map_type": "EntityClass", "position": "header", "value": 0},
+                {"map_type": "Entity", "position": 1},
+                {"map_type": "EntityMetadata", "position": "hidden"},
+                {"map_type": "ParameterDefinition", "position": "hidden", "value": "Type"},
+                {"map_type": "Alternative", "position": "hidden"},
+                {"map_type": "ParameterValueMetadata", "position": "hidden"},
+                {"map_type": "ParameterValue", "position": "hidden", "value": "Hydro"},
+            ]
+        ]
+        convert_function_specs = {0: "string", 1: "string"}
+        convert_functions = {column: value_to_convert_spec(spec) for column, spec in convert_function_specs.items()}
+        mapped_data, errors = get_mapped_data(data_source, mappings, header, column_convert_fns=convert_functions)
+        self.assertEqual(errors, [])
+        self.assertEqual(
+            mapped_data,
+            {
+                "entities": [("Generator", "MyHydroGenerator")],
+                "entity_classes": [("Generator",)],
+                "parameter_definitions": [("Generator", "Type")],
+                "parameter_values": [["Generator", "MyHydroGenerator", "Type", "Hydro"]],
+            },
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR fixes a bug where `import_mappings` would produce repeated mapped data in case there were rows that should have been skipped.

Fixes spine-tools/Spine-Toolbox#2749

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [ ] Unit tests pass
