### PR TITLE
Fix issue when readding a committed, then removed item

### DIFF
--- a/spinedb_api/db_mapping.py
+++ b/spinedb_api/db_mapping.py
@@ -487,6 +487,13 @@ class DatabaseMapping(DatabaseMappingQueryMixin, DatabaseMappingCommitMixin, Dat
         if not check:
             return mapped_table.add_item(kwargs), None
         checked_item, error = mapped_table.checked_item_and_error(kwargs)
+        if not error:
+            existing_item = mapped_table.find_item_by_unique_key(checked_item, fetch=False, valid_only=False)
+            if existing_item:
+                if not existing_item.removed:
+                    raise RuntimeError("Logic error: item exists but no error was issued")
+                existing_item.invalidate_id()
+                mapped_table.remove_unique(existing_item)
         return (mapped_table.add_item(checked_item).public_item if checked_item else None, error)
 
     def add_items(self, item_type, *items, check=True, strict=False):
@@ -611,7 +618,8 @@ class DatabaseMapping(DatabaseMappingQueryMixin, DatabaseMappingCommitMixin, Dat
         item, error = mapped_table.item_to_remove_and_error(id_)
         if check and error:
             return None, error
-        return mapped_table.remove_item(item).public_item, None
+        removed_item = mapped_table.remove_item(item)
+        return (removed_item.public_item, None) if removed_item else (None, "failed to remove")
 
     def remove_items(self, item_type, *ids, check=True, strict=False):
         """Removes many items from the in-memory mapping.
@@ -653,11 +661,12 @@ class DatabaseMapping(DatabaseMappingQueryMixin, DatabaseMappingCommitMixin, Dat
             id_ (int): The id of the item to restore.
 
         Returns:
-            tuple(:class:`PublicItem` or None, str): The restored item if any.
+            tuple(:class:`PublicItem` or None, str): The restored item if any and possible error.
         """
         item_type = self.real_item_type(item_type)
         mapped_table = self.mapped_table(item_type)
-        return mapped_table.restore_item(id_).public_item
+        restored_item = mapped_table.restore_item(id_)
+        return (restored_item.public_item, "") if restored_item else (None, "failed to restore item")
 
     def restore_items(self, item_type, *ids):
         """Restores many previously removed items into the in-memory mapping.

--- a/tests/custom_db_mapping.py
+++ b/tests/custom_db_mapping.py
@@ -10,11 +10,8 @@
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
 
-"""
-Unit tests for DatabaseMapping class.
-
-"""
-from spinedb_api import DatabaseMapping, SpineIntegrityError
+""" Unit tests for DatabaseMapping class. """
+from spinedb_api import DatabaseMapping
 
 
 class CustomDatabaseMapping(DatabaseMapping):


### PR DESCRIPTION
This PR fixes a bug where a committed item would disappear from the DB if it was removed, then readded (as new item, not via `restore()`).

Fixes spine-tools/Spine-Toolbox#2743

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [ ] Unit tests pass
