### PR TITLE
Improve add items

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@ Fixes # (issue)
 
 ## Checklist before merging
 - [ ] Documentation (also in Toolbox repo) is up-to-date
-- [ ] Release notes in Toolbox repo have been updated
+- [ ] Release notes have been updated
 - [ ] Unit tests have been added/updated accordingly
 - [ ] Code has been formatted by black
 - [ ] Unit tests pass

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- It is not possible to omit `name` for `add_entity_class_item()` if `dimension_name_list` is supplied instead.
+  The name of the class is then automatically generated from the dimensions.
+- It is not possible to omit `name` for `add_entity_item()` if `element_name_list` is supplied instead.
+  The name of the entity is then automatically generated from the dimensions.
+
 ### Added
 
 ### Fixed

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -159,7 +159,7 @@ def _db_mapping_schema_lines():
             lines.extend([f"   * - {f_name}", f"     - {type_(f_dict)}", f"     - {f_dict['value']}"])
         lines.append("")
         lines.extend([".. list-table:: Unique keys", "   :header-rows: 0", ""])
-        for f_names in factory._unique_keys:
+        for f_names in factory.unique_keys:
             f_names = ", ".join(f_names)
             lines.append(f"   * - {f_names}")
         lines.append("")

--- a/spinedb_api/db_mapping.py
+++ b/spinedb_api/db_mapping.py
@@ -889,7 +889,7 @@ def _add_convenience_methods(node):
     def _uq_fields(factory):
         return {
             f_name: factory.fields[f_name]
-            for f_names in factory._unique_keys
+            for f_names in factory.unique_keys
             for f_name in set(f_names) & set(factory.fields.keys())
         }
 

--- a/spinedb_api/db_mapping_base.py
+++ b/spinedb_api/db_mapping_base.py
@@ -474,12 +474,35 @@ class _MappedTable(dict):
             current_item = None
             full_item, merge_error = item, None
         candidate_item = self._make_item(full_item)
+        if current_item is None:
+            error = self._check_unique_keys(candidate_item)
+            if error:
+                return None, error
         error = self._prepare_item(candidate_item, current_item, item)
         if error:
             return None, error
         valid_types = (type(None),) if for_update else ()
         self.check_fields(candidate_item._asdict(), valid_types=valid_types)
         return candidate_item, merge_error
+
+    def _check_unique_keys(self, item):
+        """Checks that unique keys are set in given item for addition.
+
+        Args:
+            item (MappedItemBase): item to check
+
+        Returns:
+            str: error or empty string if item is OK
+        """
+        missing = []
+        for key_set in item.unique_keys:
+            missing = [key for key in key_set if key not in item]
+            if not missing:
+                return ""
+            missing = [key for key in missing if item.corresponding_unique_id_keys.get(key) not in item]
+            if not missing:
+                return ""
+        return f"missing values for unique keys {missing}" if missing else ""
 
     def _prepare_item(self, candidate_item, current_item, original_item):
         """Prepares item for insertion or update, returns any errors.
@@ -654,9 +677,11 @@ class MappedItemBase(dict):
     """A dictionary mapping fields to a another dict mapping "type" to a Python type,
     "value" to a description of the value for the key, and "optional" to a bool."""
     _defaults = {}
-    """A dictionary mapping fields to their default values"""
-    _unique_keys = ()
-    """A tuple where each element is itself a tuple of fields corresponding to a unique key"""
+    """A dictionary mapping fields to their default values."""
+    unique_keys = ()
+    """A tuple where each element is itself a tuple of fields corresponding to a unique key."""
+    corresponding_unique_id_keys = {}
+    """A dictionary mapping unique keys to corresponding id keys."""
     _references = {}
     """A dictionary mapping source fields, to a tuple of reference item type and reference field.
     Used to access external fields.
@@ -906,7 +931,7 @@ class MappedItemBase(dict):
 
     @classmethod
     def unique_values_for_item(cls, item, skip_keys=()):
-        for key in cls._unique_keys:
+        for key in cls.unique_keys:
             if key not in skip_keys:
                 value = tuple(item.get(k) for k in key)
                 if None not in value:

--- a/spinedb_api/mapped_items.py
+++ b/spinedb_api/mapped_items.py
@@ -12,7 +12,7 @@
 
 from operator import itemgetter
 import time
-from .helpers import name_from_elements
+from .helpers import name_from_dimensions, name_from_elements
 from .parameter_value import to_database, from_database, ParameterValueFormatError
 from .db_mapping_base import MappedItemBase
 
@@ -47,7 +47,7 @@ class CommitItem(MappedItemBase):
         "date": {"type": str, "value": "Date and time of the commit in ISO 8601 format."},
         "user": {"type": str, "value": "Username of the committer."},
     }
-    _unique_keys = (("date",),)
+    unique_keys = (("date",),)
     is_protected = True
 
     def commit(self, commit_id):
@@ -76,8 +76,14 @@ class EntityClassItem(MappedItemBase):
             "optional": True,
         },
     }
-    _defaults = {"description": None, "display_icon": None, "display_order": 99, "hidden": False}
-    _unique_keys = (("name",),)
+    _defaults = {
+        "description": None,
+        "display_icon": None,
+        "display_order": 99,
+        "hidden": False,
+        "active_by_default": True,
+    }
+    unique_keys = (("name",),)
     _references = {"dimension_id_list": ("entity_class", "id")}
     _external_fields = {"dimension_name_list": ("dimension_id_list", "name")}
     _alt_references = {("dimension_name_list",): ("entity_class", ("name",))}
@@ -88,6 +94,8 @@ class EntityClassItem(MappedItemBase):
         dimension_id_list = kwargs.get("dimension_id_list")
         if dimension_id_list is None:
             dimension_id_list = ()
+            if "name" not in kwargs and "dimension_name_list" in kwargs:
+                kwargs["name"] = name_from_dimensions(kwargs["dimension_name_list"])
         if isinstance(dimension_id_list, str):
             dimension_id_list = (int(id_) for id_ in dimension_id_list.split(","))
         kwargs["dimension_id_list"] = tuple(dimension_id_list)
@@ -97,13 +105,6 @@ class EntityClassItem(MappedItemBase):
         if key in ("superclass_id", "superclass_name"):
             return self._get_ref("superclass_subclass", {"subclass_id": self["id"]}, strong=False).get(key)
         return super().__getitem__(key)
-
-    def polish(self):
-        error = super().polish()
-        if error:
-            return error
-        if "active_by_default" not in self:
-            self["active_by_default"] = True
 
     def merge(self, other):
         dimension_id_list = other.pop("dimension_id_list", None)
@@ -133,7 +134,8 @@ class EntityItem(MappedItemBase):
     }
 
     _defaults = {"description": None}
-    _unique_keys = (("entity_class_name", "name"), ("entity_class_name", "entity_byname"))
+    unique_keys = (("entity_class_name", "name"), ("entity_class_name", "entity_byname"))
+    corresponding_unique_id_keys = {"entity_class_name": "class_id"}
     _references = {"class_id": ("entity_class", "id"), "element_id_list": ("entity", "id")}
     _external_fields = {
         "entity_class_name": ("class_id", "name"),
@@ -157,6 +159,8 @@ class EntityItem(MappedItemBase):
         element_id_list = kwargs.get("element_id_list")
         if element_id_list is None:
             element_id_list = ()
+            if "name" not in kwargs and "element_name_list" in kwargs:
+                kwargs["name"] = name_from_elements(kwargs["element_name_list"])
         if isinstance(element_id_list, str):
             element_id_list = (int(id_) for id_ in element_id_list.split(","))
         kwargs["element_id_list"] = tuple(element_id_list)
@@ -267,7 +271,12 @@ class EntityGroupItem(MappedItemBase):
         "group_name": {"type": str, "value": "The group entity name."},
         "member_name": {"type": str, "value": "The member entity name."},
     }
-    _unique_keys = (("entity_class_name", "group_name", "member_name"),)
+    unique_keys = (("entity_class_name", "group_name", "member_name"),)
+    corresponding_unique_id_keys = {
+        "entity_class_name": "entity_class_id",
+        "group_name": "entity_id",
+        "member_name": "member_id",
+    }
     _references = {
         "entity_class_id": ("entity_class", "id"),
         "entity_id": ("entity", "id"),
@@ -316,7 +325,8 @@ class EntityAlternativeItem(MappedItemBase):
         },
     }
     _defaults = {"active": True}
-    _unique_keys = (("entity_class_name", "entity_byname", "alternative_name"),)
+    unique_keys = (("entity_class_name", "entity_byname", "alternative_name"),)
+    corresponding_unique_id_keys = {"entity_class_name": "entity_class_id", "alternative_name": "alternative_id"}
     _references = {
         "entity_id": ("entity", "id"),
         "entity_class_id": ("entity_class", "id"),
@@ -469,7 +479,8 @@ class ParameterDefinitionItem(ParameterItemBase):
         "description": {"type": str, "value": "The parameter description.", "optional": True},
     }
     _defaults = {"description": None, "default_value": None, "default_type": None, "parameter_value_list_id": None}
-    _unique_keys = (("entity_class_name", "name"),)
+    unique_keys = (("entity_class_name", "name"),)
+    corresponding_unique_id_keys = {"entity_class_name": "entity_class_id"}
     _references = {"entity_class_id": ("entity_class", "id")}
     _external_fields = {
         "entity_class_name": ("entity_class_id", "name"),
@@ -541,7 +552,13 @@ class ParameterValueItem(ParameterItemBase):
         "type": {"type": str, "value": "The value type.", "optional": True},
         "alternative_name": {"type": str, "value": "The alternative name - defaults to 'Base'.", "optional": True},
     }
-    _unique_keys = (("entity_class_name", "parameter_definition_name", "entity_byname", "alternative_name"),)
+    unique_keys = (("entity_class_name", "parameter_definition_name", "entity_byname", "alternative_name"),)
+    corresponding_unique_id_keys = {
+        "entity_class_name": "entity_id",
+        "parameter_definition_name": "parameter_definition_id",
+        "entity_byname": "entity_id",
+        "alternative_name": "alternative_id",
+    }
     _references = {
         "entity_class_id": ("entity_class", "id"),
         "parameter_definition_id": ("parameter_definition", "id"),
@@ -602,7 +619,7 @@ class ParameterValueItem(ParameterItemBase):
 
 class ParameterValueListItem(MappedItemBase):
     fields = {"name": {"type": str, "value": "The parameter value list name."}}
-    _unique_keys = (("name",),)
+    unique_keys = (("name",),)
 
 
 class ListValueItem(ParsedValueBase):
@@ -612,7 +629,8 @@ class ListValueItem(ParsedValueBase):
         "type": {"type": str, "value": "The value type.", "optional": True},
         "index": {"type": int, "value": "The value index.", "optional": True},
     }
-    _unique_keys = (("parameter_value_list_name", "value_and_type"), ("parameter_value_list_name", "index"))
+    unique_keys = (("parameter_value_list_name", "value_and_type"), ("parameter_value_list_name", "index"))
+    corresponding_unique_id_keys = {"parameter_value_list_name": "parameter_value_list_id"}
     _references = {"parameter_value_list_id": ("parameter_value_list", "id")}
     _external_fields = {"parameter_value_list_name": ("parameter_value_list_id", "name")}
     _alt_references = {("parameter_value_list_name",): ("parameter_value_list", ("name",))}
@@ -638,7 +656,7 @@ class AlternativeItem(MappedItemBase):
         "description": {"type": str, "value": "The alternative description.", "optional": True},
     }
     _defaults = {"description": None}
-    _unique_keys = (("name",),)
+    unique_keys = (("name",),)
 
 
 class ScenarioItem(MappedItemBase):
@@ -648,7 +666,7 @@ class ScenarioItem(MappedItemBase):
         "active": {"type": bool, "value": "Not in use at the moment.", "optional": True},
     }
     _defaults = {"active": False, "description": None}
-    _unique_keys = (("name",),)
+    unique_keys = (("name",),)
 
     def __getitem__(self, key):
         if key == "alternative_id_list":
@@ -674,7 +692,8 @@ class ScenarioAlternativeItem(MappedItemBase):
         "alternative_name": {"type": str, "value": "The alternative name."},
         "rank": {"type": int, "value": "The rank - higher has precedence."},
     }
-    _unique_keys = (("scenario_name", "alternative_name"), ("scenario_name", "rank"))
+    unique_keys = (("scenario_name", "alternative_name"), ("scenario_name", "rank"))
+    corresponding_unique_id_keys = {"scenario_name": "scenario_id", "alternative_name": "alternative_id"}
     _references = {"scenario_id": ("scenario", "id"), "alternative_id": ("alternative", "id")}
     _external_fields = {"scenario_name": ("scenario_id", "name"), "alternative_name": ("alternative_id", "name")}
     _alt_references = {("scenario_name",): ("scenario", ("name",)), ("alternative_name",): ("alternative", ("name",))}
@@ -701,7 +720,7 @@ class MetadataItem(MappedItemBase):
         "name": {"type": str, "value": "The metadata entry name."},
         "value": {"type": str, "value": "The metadata entry value."},
     }
-    _unique_keys = (("name", "value"),)
+    unique_keys = (("name", "value"),)
 
 
 class EntityMetadataItem(MappedItemBase):
@@ -711,7 +730,13 @@ class EntityMetadataItem(MappedItemBase):
         "metadata_name": {"type": str, "value": "The metadata entry name."},
         "metadata_value": {"type": str, "value": "The metadata entry value."},
     }
-    _unique_keys = (("entity_class_name", "entity_byname", "metadata_name", "metadata_value"),)
+    unique_keys = (("entity_class_name", "entity_byname", "metadata_name", "metadata_value"),)
+    corresponding_unique_id_keys = {
+        "entity_class_name": "entity_id",
+        "entity_byname": "entity_id",
+        "metadata_name": "metadata_id",
+        "metadata_value": "metadata_id",
+    }
     _references = {
         "entity_id": ("entity", "id"),
         "metadata_id": ("metadata", "id"),
@@ -747,7 +772,7 @@ class ParameterValueMetadataItem(MappedItemBase):
         "metadata_name": {"type": str, "value": "The metadata entry name."},
         "metadata_value": {"type": str, "value": "The metadata entry value."},
     }
-    _unique_keys = (
+    unique_keys = (
         (
             "entity_class_name",
             "parameter_definition_name",
@@ -757,6 +782,14 @@ class ParameterValueMetadataItem(MappedItemBase):
             "metadata_value",
         ),
     )
+    corresponding_unique_id_keys = {
+        "entity_class_name": "parameter_value_id",
+        "parameter_definition_name": "parameter_value_id",
+        "entity_byname": "parameter_value_id",
+        "alternative_name": "parameter_value_id",
+        "metadata_name": "metadata_id",
+        "metadata_value": "metadata_id",
+    }
     _references = {"parameter_value_id": ("parameter_value", "id"), "metadata_id": ("metadata", "id")}
     _external_fields = {
         "entity_class_name": ("parameter_value_id", "entity_class_name"),
@@ -787,7 +820,8 @@ class SuperclassSubclassItem(MappedItemBase):
         "superclass_name": {"type": str, "value": "The superclass name."},
         "subclass_name": {"type": str, "value": "The subclass name."},
     }
-    _unique_keys = (("subclass_name",),)
+    unique_keys = (("subclass_name",),)
+    corresponding_unique_id_keys = {"subclass_name": "subclass_id"}
     _references = {"superclass_id": ("entity_class", "id"), "subclass_id": ("entity_class", "id")}
     _external_fields = {
         "superclass_name": ("superclass_id", "name"),

--- a/tests/test_DatabaseMapping.py
+++ b/tests/test_DatabaseMapping.py
@@ -858,6 +858,31 @@ class TestDatabaseMapping(AssertSuccessTestCase):
                 )
                 self.assertEqual(value, {})
 
+    def test_add_entity_class_by_dimension_names(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(db_map.add_entity_class_item(name="Fish"))
+            self._assert_success(db_map.add_entity_class_item(name="Cat"))
+            entity_class = self._assert_success(db_map.add_entity_class_item(dimension_name_list=("Fish", "Cat")))
+            self.assertEqual(entity_class["name"], "Fish__Cat")
+
+    def test_add_entity_by_element_names(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(db_map.add_entity_class_item(name="Fish"))
+            self._assert_success(db_map.add_entity_item(name="Nemo", entity_class_name="Fish"))
+            self._assert_success(db_map.add_entity_class_item(name="Cat"))
+            self._assert_success(db_map.add_entity_item(name="Jerry", entity_class_name="Cat"))
+            relation = self._assert_success(db_map.add_entity_class_item(dimension_name_list=("Fish", "Cat")))
+            entity = self._assert_success(
+                db_map.add_entity_item(entity_class_name=relation["name"], element_name_list=("Nemo", "Jerry"))
+            )
+            self.assertEqual(entity["name"], "Nemo__Jerry")
+
+    def test_add_alternative_without_name_gives_error(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            item, error = db_map.add_alternative_item()
+            self.assertEqual(error, "missing values for unique keys ['name']")
+            self.assertIsNone(item)
+
 
 class TestDatabaseMappingLegacy(unittest.TestCase):
     """'Backward compatibility' tests, i.e. pre-entity tests converted to work with the entity structure."""


### PR DESCRIPTION
This PR fixes a bug that allowed adding items that didn't have all unique keys.

Also, it is now possible to add an entity class or entity item without a name if `dimension_name_list` or `element_name_list` is given. In this case the name will be generated from the list.

No associated issue

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
