### PR TITLE
Add parameter_value_list_name to ParameterDefinitionItem

### DIFF
--- a/spinedb_api/mapped_items.py
+++ b/spinedb_api/mapped_items.py
@@ -481,11 +481,13 @@ class ParameterDefinitionItem(ParameterItemBase):
     _defaults = {"description": None, "default_value": None, "default_type": None, "parameter_value_list_id": None}
     unique_keys = (("entity_class_name", "name"),)
     corresponding_unique_id_keys = {"entity_class_name": "entity_class_id"}
-    _references = {"entity_class_id": ("entity_class", "id")}
+    _references = {"entity_class_id": ("entity_class", "id"), "parameter_value_list_id": ("parameter_value_list", "id")}
+    _soft_references = {"parameter_value_list_id"}
     _external_fields = {
         "entity_class_name": ("entity_class_id", "name"),
         "dimension_id_list": ("entity_class_id", "dimension_id_list"),
         "dimension_name_list": ("entity_class_id", "dimension_name_list"),
+        "parameter_value_list_name": ("parameter_value_list_id", "name"),
     }
     _alt_references = {
         ("entity_class_name",): ("entity_class", ("name",)),

--- a/tests/mock_helpers.py
+++ b/tests/mock_helpers.py
@@ -1,0 +1,18 @@
+######################################################################################################################
+# Copyright (C) 2017-2022 Spine project consortium
+# This file is part of Spine Database API.
+# Spine Database API is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+# General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+# Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+######################################################################################################################
+import unittest
+
+
+class AssertSuccessTestCase(unittest.TestCase):
+    def _assert_success(self, result):
+        item, error = result
+        self.assertIsNone(error)
+        return item

--- a/tests/test_db_mapping_base.py
+++ b/tests/test_db_mapping_base.py
@@ -10,7 +10,9 @@
 ######################################################################################################################
 import unittest
 
-from spinedb_api.db_mapping_base import MappedItemBase, DatabaseMappingBase
+from spinedb_api.db_mapping_base import MappedItemBase, DatabaseMappingBase, PublicItem
+from spinedb_api import DatabaseMapping
+from tests.mock_helpers import AssertSuccessTestCase
 
 
 class TestDBMapping(DatabaseMappingBase):
@@ -80,6 +82,13 @@ class TestMappedItemBase(unittest.TestCase):
         self.assertFalse(item.has_valid_id)
         item["id"] = 23
         self.assertTrue(item.has_valid_id)
+
+
+class TestPublicItem(AssertSuccessTestCase):
+    def test_contains_operator(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            item = self._assert_success(db_map.add_scenario_item(name="my scenario"))
+            self.assertIn("name", item)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR makes `parameter_value_list_name` available in `ParameterDefinitionItem`.

No associated issue.

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [ ] Unit tests pass
