### PR TITLE
Add more conversions to GAMS Eps value into GdxWriter

### DIFF
--- a/spinedb_api/spine_io/exporters/gdx_writer.py
+++ b/spinedb_api/spine_io/exporters/gdx_writer.py
@@ -9,10 +9,7 @@
 # Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
-"""
-Module contains a .gdx writer implementation.
-
-"""
+""" Module contains a .gdx writer implementation. """
 import math
 from gdx2py import GAMSSet, GAMSScalar, GAMSParameter, GdxFile
 from gdx2py.gdxfile import EPS_VALUE
@@ -20,7 +17,12 @@ import gdxcc
 from .writer import Writer, WriterException
 
 
-SPECIAL_CONVERSIONS = {EPS_VALUE: gdxcc.GMS_SV_EPS, math.inf: gdxcc.GMS_SV_PINF, -math.inf: gdxcc.GMS_SV_MINF}
+SPECIAL_CONVERSIONS = {
+    EPS_VALUE: gdxcc.GMS_SV_EPS,
+    1e-10: gdxcc.GMS_SV_EPS,
+    math.inf: gdxcc.GMS_SV_PINF,
+    -math.inf: gdxcc.GMS_SV_MINF,
+}
 
 
 class GdxWriter(Writer):
@@ -127,12 +129,14 @@ def _convert_to_gams(x):
     """Converts special float values to corresponding GAMS constants, otherwise returns x as is.
 
     Args:
-        x (float): value to convert
+        x (float or Any): value to convert
 
     Returns:
-        float: converted value
+        float or Any: converted value
     """
     if not isinstance(x, float):
+        if x == "EPS":
+            return gdxcc.GMS_SV_EPS
         return x
     if math.isnan(x):
         return gdxcc.GMS_SV_UNDEF

--- a/tests/spine_io/exporters/test_gdx_writer.py
+++ b/tests/spine_io/exporters/test_gdx_writer.py
@@ -276,13 +276,25 @@ class TestGdxWriter(unittest.TestCase):
         db_map = DatabaseMapping("sqlite://", create=True)
         import_object_classes(db_map, ("oc",))
         import_object_parameters(
-            db_map, (("oc", "epsilon"), ("oc", "infinity"), ("oc", "negative_infinity"), ("oc", "nan"))
+            db_map,
+            (
+                ("oc", "epsilon1"),
+                ("oc", "epsilon2"),
+                ("oc", "epsilon3"),
+                ("oc", "epsilon4"),
+                ("oc", "infinity"),
+                ("oc", "negative_infinity"),
+                ("oc", "nan"),
+            ),
         )
         import_objects(db_map, (("oc", "o1"),))
         import_object_parameter_values(
             db_map,
             (
-                ("oc", "o1", "epsilon", sys.float_info.min),
+                ("oc", "o1", "epsilon1", sys.float_info.min),
+                ("oc", "o1", "epsilon2", 2.2250738585072014e-308),
+                ("oc", "o1", "epsilon3", 1e-10),
+                ("oc", "o1", "epsilon4", "EPS"),
                 ("oc", "o1", "infinity", math.inf),
                 ("oc", "o1", "negative_infinity", -math.inf),
                 ("oc", "o1", "nan", math.nan),
@@ -301,8 +313,11 @@ class TestGdxWriter(unittest.TestCase):
             with GdxFile(str(file_path), "r", self._gams_dir) as gdx_file:
                 self.assertEqual(len(gdx_file), 1)
                 gams_parameter = gdx_file["oc"]
-                self.assertEqual(len(gams_parameter), 4)
-                self.assertEqual(gams_parameter[("o1", "epsilon")], sys.float_info.min)
+                self.assertEqual(len(gams_parameter), 7)
+                self.assertEqual(gams_parameter[("o1", "epsilon1")], sys.float_info.min)
+                self.assertEqual(gams_parameter[("o1", "epsilon2")], sys.float_info.min)
+                self.assertEqual(gams_parameter[("o1", "epsilon3")], sys.float_info.min)
+                self.assertEqual(gams_parameter[("o1", "epsilon4")], sys.float_info.min)
                 self.assertEqual(gams_parameter[("o1", "infinity")], math.inf)
                 self.assertEqual(gams_parameter[("o1", "negative_infinity")], -math.inf)
                 self.assertTrue(math.isnan(gams_parameter[("o1", "nan")]))


### PR DESCRIPTION
10<sup>-10</sup> and `EPS` are now converted to Eps.

Resolves #413

## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black
- [ ] Unit tests pass
