### PR TITLE
Fix Indexed value equality

### DIFF
--- a/spinedb_api/parameter_value.py
+++ b/spinedb_api/parameter_value.py
@@ -898,7 +898,7 @@ class _Indexes(np.ndarray):
         super().__setitem__(position, index)
 
     def __eq__(self, other):
-        return len(self) == len(other) and np.all(super().__eq__(other))
+        return np.array_equal(self, other)
 
     def __bool__(self):
         return np.size(self) != 0
@@ -1624,6 +1624,12 @@ def convert_containers_to_maps(value):
             if isinstance(value, TimeSeries):
                 return Map([], [], DateTime, index_name=TimeSeries.DEFAULT_INDEX_NAME)
             return Map([], [], str)
+        if isinstance(value, TimeSeries):
+            return Map(
+                [DateTime(t) for t in np.datetime_as_string(value.indexes)],
+                list(value.values),
+                index_name=value.index_name,
+            )
         return Map(list(value.indexes), list(value.values), index_name=value.index_name)
     return value
 

--- a/tests/test_parameter_value.py
+++ b/tests/test_parameter_value.py
@@ -868,6 +868,9 @@ class TestParameterValue(unittest.TestCase):
     def test_Map_inequality(self):
         map_value = Map(["1", "2", "3", "4", "5"], [-2.3, 2.3, 2.3, 2.3, 2.3])
         self.assertNotEqual(map_value, Map(["a", "b"], [2.3, -2.3]))
+        self.assertNotEqual(
+            Map([DateTime("2024-05-30T00:00:00")], [2.3]), Map([DateTime("2024-05-30T10:00:00")], [2.3])
+        )
 
     def test_TimePattern_equality(self):
         pattern = TimePattern(["D1-2", "D3-7"], np.array([-2.3, -5.0]))


### PR DESCRIPTION
The previous method failed e.g. when index type for Maps was datetime. `numpy.array_equal()` works on all arrays and data types.

Fixes spine-tools/Spine-Toolbox#2806

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [ ] Unit tests pass
