### PR TITLE
Fix unnecessary error with pivoted import mappings

### DIFF
--- a/spinedb_api/export_mapping/export_mapping.py
+++ b/spinedb_api/export_mapping/export_mapping.py
@@ -9,10 +9,7 @@
 # Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
-"""
-Contains export mappings for database items such as entities, entity classes and parameter values.
-
-"""
+""" Contains export mappings for database items such as entities, entity classes and parameter values."""
 
 from dataclasses import dataclass
 from itertools import cycle, dropwhile, islice
@@ -28,25 +25,6 @@ from ..parameter_value import (
 )
 from ..mapping import Mapping, Position, is_pivoted, is_regular, unflatten
 from .group_functions import NoGroup
-
-
-def check_validity(root_mapping):
-    """Checks validity of a mapping hierarchy.
-
-    To check validity of individual mappings withing the hierarchy, use :func:`Mapping.check_validity`.
-
-    Args:
-        root_mapping (Mapping): root mapping
-
-    Returns:
-        list of str: a list of issue descriptions
-    """
-    issues = list()
-    flattened = root_mapping.flatten()
-    non_title_mappings = [m for m in flattened if m.position != Position.table_name]
-    if len(non_title_mappings) == 2 and is_pivoted(non_title_mappings[0].position):
-        issues.append("First mapping cannot be pivoted")
-    return issues
 
 
 class _MappingWithLeafMixin:
@@ -86,13 +64,7 @@ class ExportMapping(Mapping):
             list: a list of issues
         """
         issues = list()
-        if self.child is None:
-            is_effective_leaf = True
-        else:
-            is_effective_leaf = any(
-                child.position in (Position.hidden, Position.table_name) for child in self.child.flatten()
-            )
-        if is_effective_leaf and is_pivoted(self.position):
+        if self.is_effective_leaf() and is_pivoted(self.position):
             issues.append("Cannot be pivoted.")
         return issues
 

--- a/spinedb_api/import_mapping/import_mapping.py
+++ b/spinedb_api/import_mapping/import_mapping.py
@@ -168,10 +168,14 @@ class ImportMapping(Mapping):
         if for_preview:
             self._polish_for_preview(source_header)
 
-    def _polish_for_import(self, table_name, source_header, column_count):
+    def _polish_for_import(self, table_name, source_header, column_count, pivoted=None):
         # FIXME: Polish skip columns
+        if pivoted is None:
+            pivoted = self.is_pivoted()
+        if pivoted and self.parent and self.is_effective_leaf():
+            return
         if self.child is not None:
-            self.child._polish_for_import(table_name, source_header, column_count)
+            self.child._polish_for_import(table_name, source_header, column_count, pivoted)
         if isinstance(self.position, str):
             # Column mapping with string position, we need to find the index in the header
             try:

--- a/spinedb_api/mapping.py
+++ b/spinedb_api/mapping.py
@@ -158,6 +158,16 @@ class Mapping:
         """
         return [self] + (self.child.flatten() if self.child is not None else [])
 
+    def is_effective_leaf(self):
+        """Tests if mapping is effectively the leaf mapping.
+
+        Returns:
+            bool: True if mapping is effectively the last child, False otherwise
+        """
+        return self._child is None or any(
+            child.position in (Position.hidden, Position.table_name) for child in self._child.flatten()
+        )
+
     def is_pivoted(self):
         """
         Queries recursively if export items are pivoted.


### PR DESCRIPTION
This PR fixes a bug where pivoted import mappings would raise an error when leaf mapping had illegal position but was pivoted. The position should not be checked because pivoting makes it ignoreable.

Fixes spine-tools/Spine-Toolbox#2809

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
