### PR TITLE
Fix scenario alternatives not removed correctly

### DIFF
--- a/spinedb_api/db_mapping_base.py
+++ b/spinedb_api/db_mapping_base.py
@@ -183,7 +183,9 @@ class DatabaseMappingBase:
             else:
                 for item in mapped_table.values():
                     item.validate()
-                    if item.status == Status.to_remove and item.has_valid_id:
+                    if item.status == Status.to_remove:
+                        if item_type != "scenario_alternative" and not item.has_valid_id:
+                            continue
                         to_remove.append(item)
             if to_add or to_update or to_remove:
                 dirty_items.append((item_type, (to_add, to_update, to_remove)))


### PR DESCRIPTION
When deletions were made in a scenario so that the rank order changed, all the scenario alternatives were not removed. This caused an error when the updated scen alt with the new rank number was attempted to be added back to the db.

Fixes spine-tools/Spine-Toolbox#2830

## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
