### PR TITLE
Allow importing metadata

### DIFF
--- a/spinedb_api/import_mapping/generator.py
+++ b/spinedb_api/import_mapping/generator.py
@@ -162,7 +162,9 @@ def get_mapped_data(
                 mapping.import_row(full_row, read_state, mapped_data)
     _make_entity_classes(mapped_data)
     _make_entities(mapped_data)
+    _make_entity_metadata(mapped_data)
     _make_parameter_values(mapped_data, unparse_value)
+    _make_parameter_value_metadata(mapped_data)
     return mapped_data, errors
 
 
@@ -315,6 +317,17 @@ def _make_parameter_values(mapped_data, unparse_value):
                 full_rows.append(entity_definition)
         mapped_data[key] = full_rows
 
+def _make_parameter_value_metadata(mapped_data):
+    rows = mapped_data.get("parameter_value_metadata")
+    if rows is None:
+        return
+    mapped_data["parameter_value_metadata"] = list(rows)
+
+def _make_entity_metadata(mapped_data):
+    rows = mapped_data.get("entity_metadata")
+    if rows is None:
+        return
+    mapped_data["entity_metadata"] = list(rows)
 
 def _make_value(row, value_pos):
     try:

--- a/spinedb_api/import_mapping/generator.py
+++ b/spinedb_api/import_mapping/generator.py
@@ -317,17 +317,20 @@ def _make_parameter_values(mapped_data, unparse_value):
                 full_rows.append(entity_definition)
         mapped_data[key] = full_rows
 
+
 def _make_parameter_value_metadata(mapped_data):
     rows = mapped_data.get("parameter_value_metadata")
     if rows is None:
         return
     mapped_data["parameter_value_metadata"] = list(rows)
 
+
 def _make_entity_metadata(mapped_data):
     rows = mapped_data.get("entity_metadata")
     if rows is None:
         return
     mapped_data["entity_metadata"] = list(rows)
+
 
 def _make_value(row, value_pos):
     try:

--- a/spinedb_api/import_mapping/import_mapping.py
+++ b/spinedb_api/import_mapping/import_mapping.py
@@ -32,12 +32,14 @@ class ImportKey(Enum):
     PARAMETER_DEFAULT_VALUE_INDEXES = auto()
     PARAMETER_VALUES = auto()
     PARAMETER_VALUE_INDEXES = auto()
+    PARAMETER_VALUE_METADATA = auto()
     DIMENSION_NAMES = auto()
     ELEMENT_NAMES = auto()
     ALTERNATIVE_NAME = auto()
     SCENARIO_NAME = auto()
     SCENARIO_ALTERNATIVE = auto()
     PARAMETER_VALUE_LIST_NAME = auto()
+    ENTITY_METADATA = auto()
 
     def __str__(self):
         name = {
@@ -425,7 +427,13 @@ class EntityMetadataMapping(ImportMapping):
     MAP_TYPE = "EntityMetadata"
 
     def _import_row(self, source_data, state, mapped_data):
-        pass
+        entity_class_name = state[ImportKey.ENTITY_CLASS_NAME]
+        if state[ImportKey.DIMENSION_COUNT]:
+            entity_byname = state[ImportKey.ELEMENT_NAMES]
+        else:
+            entity_byname = (state[ImportKey.ENTITY_NAME],)
+        entity_metadata = state[ImportKey.ENTITY_METADATA] = source_data
+        mapped_data.setdefault("entity_metadata", {})[entity_class_name, entity_byname, entity_metadata] = None
 
 
 class EntityGroupMapping(ImportEntitiesMixin, ImportMapping):
@@ -692,7 +700,17 @@ class ParameterValueMetadataMapping(ImportMapping):
     MAP_TYPE = "ParameterValueMetadata"
 
     def _import_row(self, source_data, state, mapped_data):
-        pass
+        entity_class_name = state[ImportKey.ENTITY_CLASS_NAME]
+        if state[ImportKey.DIMENSION_COUNT]:
+            entity_byname = state[ImportKey.ELEMENT_NAMES]
+        else:
+            entity_byname = (state[ImportKey.ENTITY_NAME],)
+        parameter_name = state[ImportKey.PARAMETER_NAME]
+        alternative_name = state[ImportKey.ALTERNATIVE_NAME]
+        parameter_metadata = state[ImportKey.PARAMETER_VALUE_METADATA] = source_data
+        mapped_data.setdefault("parameter_value_metadata", {})[
+            entity_class_name, entity_byname, parameter_name, parameter_metadata, alternative_name
+        ] = None
 
 
 class ParameterValueIndexMapping(ImportMapping):


### PR DESCRIPTION
Adds import mappings for entity- and parameter value metadata so that they can be imported.

Fixes spine-tools/Spine-Toolbox#2831

## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes have been updated
- [ ] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
