### PR TITLE
Fix SQLite URLs with Python 3.12.4

### DIFF
--- a/tests/filters/test_tools.py
+++ b/tests/filters/test_tools.py
@@ -9,10 +9,7 @@
 # Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
-"""
-Unit tests for the ``filters.tools`` module.
-
-"""
+""" Unit tests for the ``filters.tools`` module. """
 import os.path
 from tempfile import TemporaryDirectory
 import unittest
@@ -90,7 +87,7 @@ class TestApplyFilterStack(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls._dir = TemporaryDirectory()
-        cls._db_url.database = os.path.join(cls._dir.name, ".json")
+        cls._db_url.database = os.path.join(cls._dir.name, ".sqlite")
         db_map = DatabaseMapping(cls._db_url, create=True)
         import_object_classes(db_map, ("object_class",))
         db_map.commit_session("Add test data.")
@@ -137,7 +134,7 @@ class TestFilteredDatabaseMap(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls._dir = TemporaryDirectory()
-        cls._db_url.database = os.path.join(cls._dir.name, "TestFilteredDatabaseMap.json")
+        cls._db_url.database = os.path.join(cls._dir.name, "TestFilteredDatabaseMap.sqlite")
         db_map = DatabaseMapping(cls._db_url, create=True)
         import_object_classes(db_map, ("object_class",))
         db_map.commit_session("Add test data.")


### PR DESCRIPTION
Unparsing URL tuples using Python's standard library `urllib` functions has changed between Python 3.12.2 and 3.12.4 in a way that breaks SQLite URLs that point to a file. The incompatibility raises from the number of forward slashes after URL scheme that differs from previous Python versions and breaks SqlAlchemy's URL parsing. We now ensure that there is always three slashes between the scheme and the path.

No associated issue.

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
