### PR TITLE
Make restore_items() consistent with remove_items()

### DIFF
--- a/spinedb_api/db_mapping.py
+++ b/spinedb_api/db_mapping.py
@@ -703,11 +703,9 @@ class DatabaseMapping(DatabaseMappingQueryMixin, DatabaseMappingCommitMixin, Dat
             *ids (Iterable(int)): Ids of items to be removed.
 
         Returns:
-            list(:class:`PublicItem`): the restored items.
+            tuple(list(:class:`PublicItem`),list(str)): items successfully restored and found violations.
         """
-        if not ids:
-            return []
-        return [self.restore_item(item_type, id_) for id_ in ids]
+        return self._modify_items(lambda x: self.restore_item(item_type, x), *ids)
 
     def purge_items(self, item_type):
         """Removes all items of one type.

--- a/tests/test_DatabaseMapping.py
+++ b/tests/test_DatabaseMapping.py
@@ -1135,6 +1135,35 @@ class TestDatabaseMapping(AssertSuccessTestCase):
                 active = db_map.item_active_in_scenario(entity_items[1], 2)
                 self.assertTrue(active)
 
+    def test_remove_items(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            alternative_1 = self._assert_success(db_map.add_alternative_item(name="alt 1"))
+            alternative_2 = self._assert_success(db_map.add_alternative_item(name="alt 2"))
+            self.assertTrue(alternative_1.is_valid())
+            self.assertTrue(alternative_2.is_valid())
+            removed_items, errors = db_map.remove_items("alternative", alternative_1["id"], alternative_2["id"])
+            self.assertTrue(all(not error for error in errors))
+            self.assertCountEqual(removed_items, [alternative_1, alternative_2])
+            self.assertFalse(alternative_1.is_valid())
+            self.assertFalse(alternative_2.is_valid())
+
+    def test_restore_items(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            alternative_1 = self._assert_success(db_map.add_alternative_item(name="alt 1"))
+            alternative_2 = self._assert_success(db_map.add_alternative_item(name="alt 2"))
+            self.assertTrue(alternative_1.is_valid())
+            self.assertTrue(alternative_2.is_valid())
+            removed_items, errors = db_map.remove_items("alternative", alternative_1["id"], alternative_2["id"])
+            self.assertTrue(all(not error for error in errors))
+            self.assertCountEqual(removed_items, [alternative_1, alternative_2])
+            self.assertFalse(alternative_1.is_valid())
+            self.assertFalse(alternative_2.is_valid())
+            restored_items, errors = db_map.restore_items("alternative", alternative_1["id"], alternative_2["id"])
+            self.assertTrue(all(not error for error in errors))
+            self.assertCountEqual(removed_items, [alternative_1, alternative_2])
+            self.assertTrue(alternative_1.is_valid())
+            self.assertTrue(alternative_2.is_valid())
+
 
 class TestDatabaseMappingLegacy(unittest.TestCase):
     """'Backward compatibility' tests, i.e. pre-entity tests converted to work with the entity structure."""


### PR DESCRIPTION
`DatabaseMapping.restore_items()` now returns restored items and errors like `DatabaseMapping.remove_items()` does.

Re spine-tools/Spine-Toolbox#2861

## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black
- [ ] Unit tests pass
