### PR TITLE
Add import mappings for entity alternative

### DIFF
--- a/spinedb_api/export_mapping/export_mapping.py
+++ b/spinedb_api/export_mapping/export_mapping.py
@@ -749,7 +749,7 @@ class EntityGroupMapping(ExportMapping):
 
 
 class EntityGroupEntityMapping(ExportMapping):
-    """Maps entities in objectentity groups.
+    """Maps entities in object entity groups.
 
     Cannot be used as the topmost mapping; one of the parents must be :class:`EntityGroupMapping`.
     """

--- a/spinedb_api/import_functions.py
+++ b/spinedb_api/import_functions.py
@@ -111,7 +111,7 @@ def get_data_for_import(
     entity_classes=(),
     entities=(),
     entity_groups=(),
-    entity_alternatives=(),  # TODO
+    entity_alternatives=(),
     parameter_definitions=(),
     parameter_values=(),
     parameter_value_lists=(),

--- a/spinedb_api/import_mapping/generator.py
+++ b/spinedb_api/import_mapping/generator.py
@@ -166,6 +166,7 @@ def get_mapped_data(
     _make_entity_classes(mapped_data)
     _make_entities(mapped_data)
     _make_entity_metadata(mapped_data)
+    _make_entity_alternatives(mapped_data)
     _make_parameter_values(mapped_data, unparse_value)
     _make_parameter_value_metadata(mapped_data)
     return mapped_data, errors
@@ -288,6 +289,12 @@ def _make_entities(mapped_data):
     if rows is None:
         return
     mapped_data["entities"] = list(rows)
+
+
+def _make_entity_alternatives(mapped_data):
+    if "entity_alternatives" not in mapped_data:
+        return
+    mapped_data["entity_alternatives"] = list(mapped_data["entity_alternatives"])
 
 
 def _make_parameter_values(mapped_data, unparse_value):

--- a/spinedb_api/import_mapping/import_mapping.py
+++ b/spinedb_api/import_mapping/import_mapping.py
@@ -463,6 +463,33 @@ class EntityGroupMapping(ImportEntitiesMixin, ImportMapping):
         raise KeyFix(ImportKey.MEMBER_NAME)
 
 
+class EntityAlternativeActivityMapping(ImportMapping):
+    """Maps activity flags for entity alternative.
+
+    Cannot be used as the topmost mapping; must have :class:`EntityMapping` or :class:`ElementMapping`,
+    and :class:`AlternativeMapping` as parents.
+    """
+
+    MAP_TYPE = "EntityAlternativeActivity"
+
+    def _import_row(self, source_data, state, mapped_data):
+        if source_data is None or source_data == "":
+            return
+        entity_class_name = state[ImportKey.ENTITY_CLASS_NAME]
+        if state[ImportKey.DIMENSION_COUNT]:
+            entity_byname = state[ImportKey.ELEMENT_NAMES]
+        else:
+            entity_byname = (state[ImportKey.ENTITY_NAME],)
+        alternative_name = state[ImportKey.ALTERNATIVE_NAME]
+        if isinstance(source_data, str):
+            active = string_to_bool(source_data)
+        else:
+            active = bool(source_data)
+        mapped_data.setdefault("entity_alternatives", {})[
+            entity_class_name, entity_byname, alternative_name, active
+        ] = None
+
+
 class DimensionMapping(ImportMapping):
     """Maps dimensions.
 
@@ -905,8 +932,8 @@ def _default_entity_class_mapping():
         EntityClassMapping: root mapping
     """
     root_mapping = EntityClassMapping(Position.hidden)
-    object_mapping = root_mapping.child = EntityMapping(Position.hidden)
-    object_mapping.child = EntityMetadataMapping(Position.hidden)
+    entity_mapping = root_mapping.child = EntityMapping(Position.hidden)
+    entity_mapping.child = EntityMetadataMapping(Position.hidden)
     return root_mapping
 
 
@@ -984,9 +1011,11 @@ def from_dict(serialized):
             EntityGroupMapping,
             DimensionMapping,
             ElementMapping,
+            EntityAlternativeActivityMapping,
             ParameterDefinitionMapping,
             ParameterDefaultValueMapping,
             ParameterDefaultValueTypeMapping,
+            DefaultValueIndexNameMapping,
             ParameterDefaultValueIndexMapping,
             ExpandedParameterDefaultValueMapping,
             ParameterValueMapping,

--- a/spinedb_api/import_mapping/import_mapping_compat.py
+++ b/spinedb_api/import_mapping/import_mapping_compat.py
@@ -202,12 +202,13 @@ def parameter_mapping_from_dict(map_dict):
         return param_def_mapping
     alternative_name = map_dict.get("alternative_name")
     parameter_value_metadata = map_dict.get("parameter_value_metadata")
-    param_def_mapping.child = alt_mapping = AlternativeMapping(*_pos_and_val(alternative_name))
-    alt_mapping.child = param_val_metadata_mapping = ParameterValueMetadataMapping(
+    alt_mapping = AlternativeMapping(*_pos_and_val(alternative_name))
+    alt_mapping.child = param_def_mapping
+    param_def_mapping.child = param_val_metadata_mapping = ParameterValueMetadataMapping(
         *_pos_and_val(parameter_value_metadata)
     )
     param_val_metadata_mapping.child = parameter_value_mapping_from_dict(map_dict.get("value"))
-    return param_def_mapping
+    return alt_mapping
 
 
 def parameter_default_value_mapping_from_dict(default_value_dict):

--- a/tests/import_mapping/test_generator.py
+++ b/tests/import_mapping/test_generator.py
@@ -766,6 +766,126 @@ class TestGetMappedData(unittest.TestCase):
             {"alternatives": {"some_name", "other_name"}},
         )
 
+    def test_import_entity_alternatives_with_activity_string(self):
+        header = ["entity", "alternative", "active"]
+        data_source = iter([["o1", "Base", "yes"], ["o1", "alt1", "no"], ["o1", "alt2", ""]])
+        mappings = [
+            [
+                {"map_type": "EntityClass", "position": "hidden", "value": "Object"},
+                {"map_type": "Entity", "position": 0},
+                {"map_type": "Alternative", "position": 1},
+                {"map_type": "EntityAlternativeActivity", "position": 2},
+            ]
+        ]
+        convert_function_specs = {0: "string", 1: "string", 2: "string"}
+        convert_functions = {column: value_to_convert_spec(spec) for column, spec in convert_function_specs.items()}
+        mapped_data, errors = get_mapped_data(data_source, mappings, header, column_convert_fns=convert_functions)
+        self.assertEqual(errors, [])
+        self.assertEqual(
+            mapped_data,
+            {
+                "alternatives": {"Base", "alt1", "alt2"},
+                "entity_classes": [("Object",)],
+                "entities": [
+                    ("Object", "o1"),
+                ],
+                "entity_alternatives": [("Object", ("o1",), "Base", True), ("Object", ("o1",), "alt1", False)],
+            },
+        )
+
+    def test_import_entity_alternatives_with_activity_boolean(self):
+        header = ["entity", "alternative", "active"]
+        data_source = iter([["o1", "Base", True], ["o1", "alt1", False], ["o1", "alt2", None]])
+        mappings = [
+            [
+                {"map_type": "EntityClass", "position": "hidden", "value": "Object"},
+                {"map_type": "Entity", "position": 0},
+                {"map_type": "Alternative", "position": 1},
+                {"map_type": "EntityAlternativeActivity", "position": 2},
+            ]
+        ]
+        convert_function_specs = {0: "string", 1: "string", 2: "boolean"}
+        convert_functions = {column: value_to_convert_spec(spec) for column, spec in convert_function_specs.items()}
+        mapped_data, errors = get_mapped_data(data_source, mappings, header, column_convert_fns=convert_functions)
+        self.assertEqual(errors, [])
+        self.assertEqual(
+            mapped_data,
+            {
+                "alternatives": {"Base", "alt1", "alt2"},
+                "entity_classes": [("Object",)],
+                "entities": [
+                    ("Object", "o1"),
+                ],
+                "entity_alternatives": [("Object", ("o1",), "Base", True), ("Object", ("o1",), "alt1", False)],
+            },
+        )
+
+    def test_import_entity_alternatives_with_activity_integer(self):
+        header = ["entity", "alternative", "active"]
+        data_source = iter([["o1", "Base", 1], ["o1", "alt1", 0], ["o1", "alt2", None]])
+        mappings = [
+            [
+                {"map_type": "EntityClass", "position": "hidden", "value": "Object"},
+                {"map_type": "Entity", "position": 0},
+                {"map_type": "Alternative", "position": 1},
+                {"map_type": "EntityAlternativeActivity", "position": 2},
+            ]
+        ]
+        convert_function_specs = {0: "string", 1: "string", 2: "float"}
+        convert_functions = {column: value_to_convert_spec(spec) for column, spec in convert_function_specs.items()}
+        mapped_data, errors = get_mapped_data(data_source, mappings, header, column_convert_fns=convert_functions)
+        self.assertEqual(errors, [])
+        self.assertEqual(
+            mapped_data,
+            {
+                "alternatives": {"Base", "alt1", "alt2"},
+                "entity_classes": [("Object",)],
+                "entities": [
+                    ("Object", "o1"),
+                ],
+                "entity_alternatives": [("Object", ("o1",), "Base", True), ("Object", ("o1",), "alt1", False)],
+            },
+        )
+
+    def test_import_entity_alternatives_with_multidimensional_entities(self):
+        header = ["element 1", "element 2", "alternative", "active"]
+        data_source = iter([["o1", "p1", "Base", "true"], ["o1", "p1", "alt1", "false"], ["o1", "p2", "alt1", "true"]])
+        mappings = [
+            [
+                {"map_type": "EntityClass", "position": "hidden", "value": "Widget__Gadget"},
+                {"map_type": "Dimension", "position": "hidden", "value": "Widget"},
+                {"map_type": "Dimension", "position": "hidden", "value": "Gadget"},
+                {"map_type": "Entity", "position": "hidden", "value": "relationship"},
+                {"map_type": "Element", "position": 0, "import_objects": True},
+                {"map_type": "Element", "position": 1, "import_objects": True},
+                {"map_type": "Alternative", "position": 2},
+                {"map_type": "EntityAlternativeActivity", "position": 3},
+            ]
+        ]
+        convert_function_specs = {0: "string", 1: "string", 2: "string", 3: "string"}
+        convert_functions = {column: value_to_convert_spec(spec) for column, spec in convert_function_specs.items()}
+        mapped_data, errors = get_mapped_data(data_source, mappings, header, column_convert_fns=convert_functions)
+        self.assertEqual(errors, [])
+        self.assertEqual(
+            mapped_data,
+            {
+                "alternatives": {"Base", "alt1"},
+                "entity_classes": [("Widget",), ("Gadget",), ("Widget__Gadget", ("Widget", "Gadget"))],
+                "entities": [
+                    ("Widget", "o1"),
+                    ("Gadget", "p1"),
+                    ("Widget__Gadget", ("o1", "p1")),
+                    ("Gadget", "p2"),
+                    ("Widget__Gadget", ("o1", "p2")),
+                ],
+                "entity_alternatives": [
+                    ("Widget__Gadget", ("o1", "p1"), "Base", True),
+                    ("Widget__Gadget", ("o1", "p1"), "alt1", False),
+                    ("Widget__Gadget", ("o1", "p2"), "alt1", True),
+                ],
+            },
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/import_mapping/test_import_mapping.py
+++ b/tests/import_mapping/test_import_mapping.py
@@ -274,8 +274,8 @@ class TestImportMappingLegacy(unittest.TestCase):
             {"map_type": "EntityClass", "position": 0},
             {"map_type": "Entity", "position": 1},
             {"map_type": "EntityMetadata", "position": "hidden"},
-            {"map_type": "ParameterDefinition", "position": 2},
             {"map_type": "Alternative", "position": "hidden"},
+            {"map_type": "ParameterDefinition", "position": 2},
             {"map_type": "ParameterValueMetadata", "position": "hidden"},
             {"map_type": "ParameterValue", "position": 3},
         ]
@@ -321,8 +321,8 @@ class TestImportMappingLegacy(unittest.TestCase):
             {"map_type": "Element", "position": 0},
             {"map_type": "Element", "position": 1},
             {"map_type": "EntityMetadata", "position": "hidden"},
-            {"map_type": "ParameterDefinition", "position": "hidden", "value": "pname"},
             {"map_type": "Alternative", "position": "hidden"},
+            {"map_type": "ParameterDefinition", "position": "hidden", "value": "pname"},
             {"map_type": "ParameterValueMetadata", "position": "hidden"},
             {"map_type": "ParameterValue", "position": 2},
         ]
@@ -368,8 +368,8 @@ class TestImportMappingLegacy(unittest.TestCase):
             {"map_type": "Entity", "position": "hidden"},
             {"map_type": "Element", "position": "hidden"},
             {"map_type": "EntityMetadata", "position": "hidden"},
-            {"map_type": "ParameterDefinition", "position": "hidden", "value": "pname"},
             {"map_type": "Alternative", "position": "hidden"},
+            {"map_type": "ParameterDefinition", "position": "hidden", "value": "pname"},
             {"map_type": "ParameterValueMetadata", "position": "hidden"},
             {"map_type": "ParameterValueType", "position": "hidden", "value": "array"},
             {"map_type": "IndexName", "position": "hidden"},
@@ -592,9 +592,10 @@ class TestMappingIsValid(unittest.TestCase):
     def test_valid_object_parameter_value_mapping(self):
         cls_mapping = import_mapping_from_dict({"map_type": "ObjectClass"})
         object_mapping = cls_mapping.flatten()[-2]
-        cls_mapping.flatten()[-1].child = param_def_mapping = parameter_mapping_from_dict(
+        cls_mapping.flatten()[-1].child = alternative_mapping = parameter_mapping_from_dict(
             {"map_type": "ParameterValue"}
         )
+        param_def_mapping = alternative_mapping.child
         value_mapping = cls_mapping.flatten()[-1]
         cls_mapping.position = 0
         object_mapping.position = 1
@@ -694,9 +695,10 @@ class TestMappingIsValid(unittest.TestCase):
         cls_mapping = import_mapping_from_dict({"map_type": "RelationshipClass"})
         obj_cls_mapping = cls_mapping.child
         object_mapping = cls_mapping.flatten()[-2]
-        cls_mapping.flatten()[-1].child = param_def_mapping = parameter_mapping_from_dict(
+        cls_mapping.flatten()[-1].child = alternative_mapping = parameter_mapping_from_dict(
             {"map_type": "ParameterValue"}
         )
+        param_def_mapping = alternative_mapping.child
         value_mapping = cls_mapping.flatten()[-1]
         cls_mapping.position = 0
         obj_cls_mapping.position = 1


### PR DESCRIPTION
Added `import_mapping.EntityAlternativeActivityMapping` that allows importing entity alternatives. To facilitate its use in Importer, parameter mappings now have `AlternativeMapping` as the root mapping replacing `ParameterDefinitionMapping`. This should not have other effects as the order is not important in this case.

Re spine-tools/Spine-Toolbox#2748

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
