### PR TITLE
Fix readding removed items

### DIFF
--- a/tests/test_DatabaseMapping.py
+++ b/tests/test_DatabaseMapping.py
@@ -1164,30 +1164,29 @@ class TestDatabaseMapping(AssertSuccessTestCase):
             self.assertTrue(alternative_1.is_valid())
             self.assertTrue(alternative_2.is_valid())
 
-    def test_remove_value_list_then_recreate_it(self):
+    def test_remove_value_list_after_fetch_more_then_recreate_it(self):
         with TemporaryDirectory() as temp_dir:
             url = "sqlite:///" + os.path.join(temp_dir, "db.sqlite")
             with DatabaseMapping(url, create=True) as db_map:
-                self._assert_success(db_map.add_parameter_value_list_item(name="list of values"))
+                self._assert_success(db_map.add_parameter_value_list_item(name="yes_no"))
                 value, value_type = to_database("yes")
-                list_value = self._assert_success(
-                    db_map.add_list_value_item(
-                        parameter_value_list_name="list of values", index=0, value=value, type=value_type
-                    )
-                )
-                self.assertEqual(list_value["parsed_value"], "yes")
-                db_map.commit_session("Add value list.")
-            with DatabaseMapping(url) as db_map:
-                db_map.fetch_all("list_value")
-                value_list = db_map.get_parameter_value_list_item(name="list of values")
-                value_list.remove()
-                self._assert_success(db_map.add_parameter_value_list_item(name="list of values"))
                 self._assert_success(
                     db_map.add_list_value_item(
-                        parameter_value_list_name="list of values", index=0, value=value, type=value_type
+                        parameter_value_list_name="yes_no", index=0, value=value, type=value_type
                     )
                 )
                 db_map.commit_session("Add value list.")
+            with DatabaseMapping(url) as db_map:
+                db_map.fetch_more("parameter_value_list")
+                value_list = db_map.get_parameter_value_list_item(name="yes_no")
+                value_list.remove()
+                self._assert_success(db_map.add_parameter_value_list_item(name="yes_no"))
+                self._assert_success(
+                    db_map.add_list_value_item(
+                        parameter_value_list_name="yes_no", index=0, value=value, type=value_type
+                    )
+                )
+                db_map.commit_session("Readd value list.")
 
     def test_add_referrer_called_only_once_for_fetched_items(self):
         with TemporaryDirectory() as temp_dir:
@@ -1195,7 +1194,7 @@ class TestDatabaseMapping(AssertSuccessTestCase):
             with DatabaseMapping(url, create=True) as db_map:
                 self._assert_success(db_map.add_parameter_value_list_item(name="list of values"))
                 value, value_type = to_database("yes")
-                list_value = self._assert_success(
+                self._assert_success(
                     db_map.add_list_value_item(
                         parameter_value_list_name="list of values", index=0, value=value, type=value_type
                     )


### PR DESCRIPTION
This PR fixes a bug where recreating removed parameter value list in Toolbox would fail to commit due to "unique constraint failed" error.

No associated issue.

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [ ] Unit tests pass
