### PR TITLE
Revert scenario alternative specific fix from PR #418

### DIFF
--- a/spinedb_api/db_mapping_base.py
+++ b/spinedb_api/db_mapping_base.py
@@ -183,9 +183,7 @@ class DatabaseMappingBase:
             else:
                 for item in mapped_table.values():
                     item.validate()
-                    if item.status == Status.to_remove:
-                        if item_type != "scenario_alternative" and not item.has_valid_id:
-                            continue
+                    if item.status == Status.to_remove and item.has_valid_id:
                         to_remove.append(item)
             if to_add or to_update or to_remove:
                 dirty_items.append((item_type, (to_add, to_update, to_remove)))

--- a/tests/test_DatabaseMapping.py
+++ b/tests/test_DatabaseMapping.py
@@ -1205,6 +1205,22 @@ class TestDatabaseMapping(AssertSuccessTestCase):
                 db_map.get_list_value_item(parameter_value_list_name="list_of_values", index=0)
                 self.assertEqual(len(value_list._mapped_item._referrers), 1)
 
+    def test_remove_scenario_alternative_from_middle(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(db_map.add_scenario_item(name="Scenario"))
+            self._assert_success(db_map.add_alternative_item(name="alt1"))
+            self._assert_success(db_map.add_scenario_alternative_item(scenario_name="Scenario", alternative_name="Base", rank=0))
+            self._assert_success(db_map.add_scenario_alternative_item(scenario_name="Scenario", alternative_name="alt1", rank=1))
+            db_map.commit_session("Add scenario with two alternatives")
+            scenario_alternatives = db_map.query(db_map.scenario_alternative_sq).all()
+            self.assertEqual(len(scenario_alternatives), 2)
+            db_map.get_scenario_alternative_item(scenario_name="Scenario", alternative_name="alt1", rank=1).remove()
+            db_map.get_scenario_alternative_item(scenario_name="Scenario", alternative_name="Base", rank=0).remove()
+            self._assert_success(db_map.add_scenario_alternative_item(scenario_name="Scenario", alternative_name="alt1", rank=0))
+            db_map.commit_session("Remove first alternative from scenario")
+            scenario_alternatives = db_map.query(db_map.scenario_alternative_sq).all()
+            self.assertEqual(len(scenario_alternatives), 1)
+
 
 class TestDatabaseMappingLegacy(unittest.TestCase):
     """'Backward compatibility' tests, i.e. pre-entity tests converted to work with the entity structure."""


### PR DESCRIPTION
PR #427 contains a more general fix to the issue without introducing item type specific hacks into `DatabaseMappingBase`.

Re spine-tools/Spine-Toolbox#2830

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [ ] Unit tests pass
