### PR TITLE
Cache Map dimensions to JSON blob

### DIFF
--- a/benchmarks/entity_class_mapping_import_row.py
+++ b/benchmarks/entity_class_mapping_import_row.py
@@ -3,7 +3,7 @@ This benchmark tests the performance of import-mapping multidimensional entity c
 """
 
 import time
-from typing import Callable,Dict, List
+from typing import Callable, Dict, List
 
 import pyperf
 from spinedb_api import get_mapped_data
@@ -27,7 +27,9 @@ def import_entity_classes(
     return duration
 
 
-def make_input_table(size: int, name_1: Callable[[int], str], name_2:  Callable[[int], str], name_3:  Callable[[int], str]):
+def make_input_table(
+    size: int, name_1: Callable[[int], str], name_2: Callable[[int], str], name_3: Callable[[int], str]
+):
     table: List[List[str]] = []
     for i in range(size):
         dim_1 = name_1(i)

--- a/benchmarks/from_database_to_dimension_count_with_nested_map_type.py
+++ b/benchmarks/from_database_to_dimension_count_with_nested_map_type.py
@@ -1,0 +1,46 @@
+"""
+This benchmark tests the performance of from_database_to_dimension_count() for nested maps.
+"""
+
+import time
+import pyperf
+from spinedb_api import Map, to_database
+from spinedb_api.parameter_value import from_database_to_dimension_count
+
+MAP_DEPTH = 3
+MAP_LENGTH = 24
+
+
+def build_map() -> bytes:
+    xs = list(map(float, range(MAP_LENGTH)))
+    ys = list(xs)
+    depth = MAP_DEPTH
+    while True:
+        depth -= 1
+        if depth == 0:
+            return to_database(Map(xs, ys))[0]
+        else:
+            ys = [Map(xs, ys) for _ in range(MAP_LENGTH)]
+
+
+def dimension_count(loops: int, unparsed_map: bytes) -> float:
+    duration = 0.0
+    map_type = Map.type_()
+    for _ in range(loops):
+        start = time.perf_counter()
+        rank = from_database_to_dimension_count(unparsed_map, map_type)
+        duration += time.perf_counter() - start
+        assert rank == MAP_DEPTH
+    return duration
+
+
+def run_benchmark(file_name: str) -> None:
+    runner = pyperf.Runner()
+    unparsed_map = build_map()
+    benchmark = runner.bench_time_func("from_database[DateTime]", dimension_count, unparsed_map)
+    if file_name:
+        pyperf.add_runs(file_name, benchmark)
+
+
+if __name__ == "__main__":
+    run_benchmark("")

--- a/benchmarks/update_default_value_to_same_value.py
+++ b/benchmarks/update_default_value_to_same_value.py
@@ -2,6 +2,7 @@
 This benchmark tests the performance of updating a parameter definition item when
 the default value is somewhat complex Map and the update does not change anything.
 """
+
 import time
 from typing import Optional
 import pyperf

--- a/spinedb_api/export_mapping/export_mapping.py
+++ b/spinedb_api/export_mapping/export_mapping.py
@@ -1093,7 +1093,7 @@ class ParameterValueTypeMapping(ParameterValueMapping):
     def _data(self, db_row):
         type_ = db_row.type
         if type_ == "map":
-            return f"{map_dimensions(from_database(db_row.value, type_))}d_map"
+            return f"{from_database_to_dimension_count(db_row.value, type_)}d_map"
         if type_ in ("time_series", "time_pattern", "array"):
             return type_
         return "single_value"

--- a/tests/test_parameter_value.py
+++ b/tests/test_parameter_value.py
@@ -680,7 +680,7 @@ class TestParameterValue(unittest.TestCase):
         map_value = Map(["a", "b"], [1.1, 2.2])
         db_value, value_type = to_database(map_value)
         raw = json.loads(db_value)
-        self.assertEqual(raw, {"index_type": "str", "data": [["a", 1.1], ["b", 2.2]]})
+        self.assertEqual(raw, {"index_type": "str", "rank": 1, "data": [["a", 1.1], ["b", 2.2]]})
         self.assertEqual(value_type, "map")
 
     def test_Map_to_database_with_index_names(self):
@@ -695,8 +695,18 @@ class TestParameterValue(unittest.TestCase):
             {
                 "index_type": "str",
                 "index_name": "index",
+                "rank": 2,
                 "data": [
-                    ["A", {"type": "map", "index_type": "str", "index_name": "nested index", "data": [["a", 0.3]]}]
+                    [
+                        "A",
+                        {
+                            "type": "map",
+                            "index_type": "str",
+                            "index_name": "nested index",
+                            "rank": 1,
+                            "data": [["a", 0.3]],
+                        },
+                    ]
                 ],
             },
         )
@@ -712,6 +722,7 @@ class TestParameterValue(unittest.TestCase):
         raw = json.loads(db_value)
         expected = {
             "index_type": "str",
+            "rank": 2,
             "data": [
                 ["a", {"type": "time_series", "data": {"2020-01-01T12:00:00": 2.3, "2020-01-02T12:00:00": 4.5}}],
                 ["b", {"type": "time_series", "data": {"2020-01-01T12:00:00": -4.5, "2020-01-02T12:00:00": -2.3}}],
@@ -729,10 +740,16 @@ class TestParameterValue(unittest.TestCase):
             raw,
             {
                 "index_type": "date_time",
+                "rank": 2,
                 "data": [
                     [
                         "2020-01-01T13:00:00",
-                        {"type": "map", "index_type": "duration", "data": [["2M", {"type": "duration", "data": "5D"}]]},
+                        {
+                            "type": "map",
+                            "index_type": "duration",
+                            "rank": 1,
+                            "data": [["2M", {"type": "duration", "data": "5D"}]],
+                        },
                     ]
                 ],
             },


### PR DESCRIPTION
`to_database()` now writes Maps' dimensions or 'rank' into the binary blob allowing checking the rank without needing to parse and iterate over the entire Map. This mostly affects export mappings making exporting Map values slightly faster, especially when filtering by the parameter value type.

The new 'rank' field is optional.

No associated issue

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
