### PR TITLE
Prevent Traceback in import_mapping.EntityAlternativeActivityMapping

### DIFF
--- a/spinedb_api/import_mapping/import_mapping.py
+++ b/spinedb_api/import_mapping/import_mapping.py
@@ -13,7 +13,6 @@
 
 from enum import auto, Enum, unique
 
-from spinedb_api.helpers import string_to_bool
 from spinedb_api.mapping import Mapping, Position, unflatten, is_pivoted
 from spinedb_api.exception import InvalidMappingComponent
 
@@ -481,12 +480,8 @@ class EntityAlternativeActivityMapping(ImportMapping):
         else:
             entity_byname = (state[ImportKey.ENTITY_NAME],)
         alternative_name = state[ImportKey.ALTERNATIVE_NAME]
-        if isinstance(source_data, str):
-            active = string_to_bool(source_data)
-        else:
-            active = bool(source_data)
         mapped_data.setdefault("entity_alternatives", {})[
-            entity_class_name, entity_byname, alternative_name, active
+            entity_class_name, entity_byname, alternative_name, source_data
         ] = None
 
 

--- a/tests/import_mapping/test_generator.py
+++ b/tests/import_mapping/test_generator.py
@@ -847,6 +847,39 @@ class TestGetMappedData(unittest.TestCase):
             },
         )
 
+    def test_import_entity_alternatives_errors_gracefully_when_activity_cannot_be_converted_to_bool(self):
+        header = ["entity", "alternative", "active"]
+        data_source = iter([["o1", "Base", "xoxoxo"]])
+        mappings = [
+            [
+                {"map_type": "EntityClass", "position": "hidden", "value": "Object"},
+                {"map_type": "Entity", "position": 0},
+                {"map_type": "Alternative", "position": 1},
+                {"map_type": "EntityAlternativeActivity", "position": 2},
+            ]
+        ]
+        convert_function_specs = {0: "string", 1: "string", 2: "string"}
+        convert_functions = {column: value_to_convert_spec(spec) for column, spec in convert_function_specs.items()}
+        mapped_data, errors = get_mapped_data(data_source, mappings, header, column_convert_fns=convert_functions)
+        self.assertEqual(
+            errors,
+            [
+                "Can't convert xoxoxo to entity alternative activity boolean for '('o1',)' in "
+                "'Object' with alternative 'Base'"
+            ],
+        )
+        self.assertEqual(
+            mapped_data,
+            {
+                "alternatives": {"Base"},
+                "entity_classes": [("Object",)],
+                "entities": [
+                    ("Object", "o1"),
+                ],
+                "entity_alternatives": [],
+            },
+        )
+
     def test_import_entity_alternatives_with_multidimensional_entities(self):
         header = ["element 1", "element 2", "alternative", "active"]
         data_source = iter([["o1", "p1", "Base", "true"], ["o1", "p1", "alt1", "false"], ["o1", "p2", "alt1", "true"]])


### PR DESCRIPTION
There was a Traceback that crashed the import process if the activity value couldn't be converted to boolean. We now convert the activities to booleans later in the import process where we can handle the situation more gracefully giving even a proper error message.

No associated issue

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
