### PR TITLE
Fix parameter type export mappings

### DIFF
--- a/spinedb_api/export_mapping/export_mapping.py
+++ b/spinedb_api/export_mapping/export_mapping.py
@@ -928,6 +928,10 @@ class ParameterDefaultValueTypeMapping(ParameterDefaultValueMapping):
 
     MAP_TYPE = "ParameterDefaultValueType"
 
+    def __init__(self, position, value=None, header="", filter_re=""):
+        filter_re = filter_re.replace("single_value", "float|str|bool")
+        super().__init__(position, value, header, filter_re)
+
     def _data(self, db_row):
         type_ = db_row.default_type
         if type_ == "map":
@@ -1089,6 +1093,10 @@ class ParameterValueTypeMapping(ParameterValueMapping):
     """
 
     MAP_TYPE = "ParameterValueType"
+
+    def __init__(self, position, value=None, header="", filter_re=""):
+        filter_re = filter_re.replace("single_value", "float|str|bool")
+        super().__init__(position, value, header, filter_re)
 
     def _data(self, db_row):
         type_ = db_row.type

--- a/spinedb_api/export_mapping/export_mapping.py
+++ b/spinedb_api/export_mapping/export_mapping.py
@@ -22,7 +22,7 @@ from ..parameter_value import (
     from_database,
     from_database_to_dimension_count,
     from_database_to_single_value,
-    map_dimensions,
+    type_for_scalar,
 )
 from .group_functions import NoGroup
 
@@ -931,10 +931,10 @@ class ParameterDefaultValueTypeMapping(ParameterDefaultValueMapping):
     def _data(self, db_row):
         type_ = db_row.default_type
         if type_ == "map":
-            return f"{map_dimensions(from_database(db_row.default_value, type_))}d_map"
+            return f"{from_database_to_dimension_count(db_row.default_value, type_)}d_map"
         if type_ in ("time_series", "time_pattern", "array"):
             return type_
-        return "single_value"
+        return type_ if type_ else type_for_scalar(from_database(db_row.default_value, db_row.default_type))
 
     def _title_state(self, db_row):
         return {
@@ -1096,7 +1096,7 @@ class ParameterValueTypeMapping(ParameterValueMapping):
             return f"{from_database_to_dimension_count(db_row.value, type_)}d_map"
         if type_ in ("time_series", "time_pattern", "array"):
             return type_
-        return type_
+        return type_ if type_ else type_for_scalar(from_database(db_row.value, db_row.type))
 
     def _title_state(self, db_row):
         return {"type_and_dimensions": (db_row.type, from_database_to_dimension_count(db_row.value, db_row.type))}

--- a/spinedb_api/spine_io/exporters/writer.py
+++ b/spinedb_api/spine_io/exporters/writer.py
@@ -9,10 +9,7 @@
 # Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
-"""
-Module contains the :class:`Writer` base class and functions to write tabular data.
-
-"""
+""" Module contains the :class:`Writer` base class and functions to write tabular data. """
 from contextlib import contextmanager
 from copy import copy
 from sqlalchemy.exc import OperationalError

--- a/tests/export_mapping/test_settings.py
+++ b/tests/export_mapping/test_settings.py
@@ -119,7 +119,7 @@ class TestEntityClassDimensionParameterDefaultValueExport(unittest.TestCase):
             index_positions=None,
             highlight_position=0,
         )
-        expected = [["rc", "p11", "oc1", "oc2", 2.3, "single_value"], ["rc", "p12", "oc1", "oc2", 5.0, "single_value"]]
+        expected = [["rc", "p11", "oc1", "oc2", 2.3, "float"], ["rc", "p12", "oc1", "oc2", 5.0, "float"]]
         self.assertEqual(list(rows(root_mapping, self._db_map)), expected)
 
 


### PR DESCRIPTION
`ParameterValueTypeMapping` and `ParameterDefaultValueTypeMapping` now return the real scalar type even if it is not present in the database. We do not enforce the type information, yet, so there are such databases out there.


No associated issue

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
