### PR TITLE
Add parameter_type table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- parameter_type table was added to the database. It defines valid value types for a parameter definition.
+  The types are not currently enforced.
+
 ### Changed
 
 - DB server version was bumped from 7 to 8 due to the changes below.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -97,6 +97,7 @@ autoapi_ignore = [
     '*/spinedb_api/import_mapping/*',
     '*/spinedb_api/spine_io/*',
     '*/spinedb_api/compatibility*',
+    '*/spinedb_api/db_mapping_helpers*',
     '*/spinedb_api/exception*',
     '*/spinedb_api/export_functions*',
     '*/spinedb_api/helpers*',

--- a/spinedb_api/alembic/versions/c55527151b29_add_parameter_type_table.py
+++ b/spinedb_api/alembic/versions/c55527151b29_add_parameter_type_table.py
@@ -1,0 +1,36 @@
+"""add parameter type table
+
+Revision ID: c55527151b29
+Revises: ca7a13da8ff6
+Create Date: 2024-07-08 08:57:42.268563
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "c55527151b29"
+down_revision = "ca7a13da8ff6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "parameter_type",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column(
+            "parameter_definition_id",
+            sa.Integer,
+            sa.ForeignKey("parameter_definition.id", onupdate="CASCADE", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("rank", sa.Integer, nullable=False),
+        sa.Column("type", sa.String(255), nullable=False),
+        sa.UniqueConstraint("parameter_definition_id", "type", "rank"),
+    )
+
+
+def downgrade():
+    pass

--- a/spinedb_api/db_mapping.py
+++ b/spinedb_api/db_mapping.py
@@ -113,6 +113,7 @@ class DatabaseMapping(DatabaseMappingQueryMixin, DatabaseMappingCommitMixin, Dat
         "parameter_value_list": "parameter_value_list_sq",
         "list_value": "list_value_sq",
         "parameter_definition": "parameter_definition_sq",
+        "parameter_type": "parameter_type_sq",
         "parameter_value": "parameter_value_sq",
         "metadata": "metadata_sq",
         "entity_metadata": "entity_metadata_sq",

--- a/spinedb_api/db_mapping_base.py
+++ b/spinedb_api/db_mapping_base.py
@@ -647,6 +647,7 @@ class _MappedTable(dict):
         item = self._make_and_add_item(item)
         self.add_unique(item)
         item.status = Status.to_add
+        item.added_to_mapped_table()
         return item
 
     def update_item(self, item):
@@ -789,7 +790,7 @@ class MappedItemBase(dict):
 
     @property
     def removed(self):
-        """Returns whether or not this item has been removed.
+        """Returns whether this item has been removed.
 
         Returns:
             bool
@@ -1214,6 +1215,7 @@ class MappedItemBase(dict):
     def __getattr__(self, name):
         """Overridden to return the dictionary key named after the attribute, or None if it doesn't exist."""
         # FIXME: We should try and get rid of this one
+
         return self.get(name)
 
     def __getitem__(self, key):
@@ -1289,6 +1291,9 @@ class MappedItemBase(dict):
             self._status = Status.committed
             self._status_when_removed = Status.to_add
 
+    def added_to_mapped_table(self):
+        """Called after the item has been added to a mapped table as a new item (not after fetching etc.)."""
+
 
 class PublicItem:
     def __init__(self, db_map, mapped_item):
@@ -1335,7 +1340,7 @@ class PublicItem:
         return self._mapped_item._extended()
 
     def update(self, **kwargs):
-        self._db_map.update_item(self.item_type, id=self["id"], **kwargs)
+        return self._db_map.update_item(self.item_type, id=self["id"], **kwargs)
 
     def remove(self):
         return self._db_map.remove_item(self.item_type, self["id"])

--- a/spinedb_api/db_mapping_base.py
+++ b/spinedb_api/db_mapping_base.py
@@ -740,7 +740,7 @@ class MappedItemBase(dict):
         self._status_when_removed = None
         self._status_when_committed = None
         self._backup = None
-        self.public_item = PublicItem(self._db_map, self)
+        self.public_item = PublicItem(self)
 
     def handle_refetch(self):
         """Called when an equivalent item is fetched from the DB.
@@ -760,6 +760,11 @@ class MappedItemBase(dict):
             set(str)
         """
         return set(ref_type for ref_type, _ref_key in cls._references.values())
+
+    @property
+    def db_map(self) -> DatabaseMappingBase:
+        """Returns the database mapping of the item."""
+        return self._db_map
 
     @property
     def status(self):
@@ -1296,13 +1301,20 @@ class MappedItemBase(dict):
 
 
 class PublicItem:
-    def __init__(self, db_map, mapped_item):
-        self._db_map = db_map
+    def __init__(self, mapped_item):
         self._mapped_item = mapped_item
 
     @property
     def item_type(self):
         return self._mapped_item.item_type
+
+    @property
+    def mapped_item(self):
+        return self._mapped_item
+
+    @property
+    def db_map(self):
+        return self._mapped_item.db_map
 
     def __getitem__(self, key):
         return self._mapped_item[key]
@@ -1340,14 +1352,14 @@ class PublicItem:
         return self._mapped_item._extended()
 
     def update(self, **kwargs):
-        return self._db_map.update_item(self.item_type, id=self["id"], **kwargs)
+        return self._mapped_item.db_map.update_item(self.item_type, id=self["id"], **kwargs)
 
     def remove(self):
-        return self._db_map.remove_item(self.item_type, self["id"])
+        return self._mapped_item.db_map.remove_item(self.item_type, self["id"])
 
     def restore(self):
         if not self._mapped_item.has_valid_id:
-            mapped_table = self._db_map.mapped_table(self.item_type)
+            mapped_table = self._mapped_item.db_map.mapped_table(self.item_type)
             existing_item = mapped_table.find_item_by_unique_key(self, fetch=False, valid_only=False)
             if existing_item:
                 if not existing_item.removed:
@@ -1356,7 +1368,7 @@ class PublicItem:
                 mapped_table.remove_unique(existing_item)
                 self._mapped_item.validate_id()
                 mapped_table.add_unique(self._mapped_item)
-        return self._db_map.restore_item(self.item_type, self["id"])
+        return self._mapped_item.db_map.restore_item(self.item_type, self["id"])
 
     def add_update_callback(self, callback):
         self._mapped_item.update_callbacks.add(callback)

--- a/spinedb_api/db_mapping_helpers.py
+++ b/spinedb_api/db_mapping_helpers.py
@@ -1,0 +1,77 @@
+######################################################################################################################
+# Copyright (C) 2017-2022 Spine project consortium
+# Copyright Spine Database API contributors
+# This file is part of Spine Database API.
+# Spine Database API is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+# General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+# Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+######################################################################################################################
+"""
+This module defines functions, classes and other utilities
+that may be useful with :class:`.db_mapping.DatabaseMapping`.
+"""
+from spinedb_api.db_mapping_base import PublicItem
+from spinedb_api.mapped_items import ParameterDefinitionItem
+from spinedb_api.parameter_value import UNPARSED_NULL_VALUE, Map, from_database_to_dimension_count, type_for_value
+
+# Here goes stuff that depends on `database_mapping`, `mapped_items` etc.
+# and thus cannot go to `helpers` due to circular imports.
+
+
+def type_check_args(value_item):
+    """Generates arguments compatible for is_parameter_type_valid()
+
+    Args:
+        value_item (PublicItem or ParameterDefinitionItem or ParameterValueItem): mapped value item
+
+    Returns:
+        tuple: arguments for is_parameter_type_valid()
+    """
+    mapped_item = value_item.mapped_item if isinstance(value_item, PublicItem) else value_item
+    database_value = mapped_item[mapped_item.value_key]
+    value_type = mapped_item[mapped_item.type_key]
+    parsed_value = mapped_item["parsed_value"] if mapped_item.has_value_been_parsed() else None
+    if isinstance(mapped_item, ParameterDefinitionItem):
+        definition = mapped_item
+    else:
+        # We may have a situation during cascade_restore where a value exists
+        # but its definition has not yet been restored, thus skip_removed=False.
+        # This 'incomplete' state is accessible from restore_callbacks.
+        definition = mapped_item.db_map.get_parameter_definition_item(
+            id=value_item["parameter_definition_id"], skip_removed=False
+        )
+    type_ids = definition["parameter_type_id_list"]
+    parameter_types = ()
+    if type_ids:
+        type_table = mapped_item.db_map.mapped_table("parameter_type")
+        for type_id in type_ids:
+            type_item = type_table.find_item_by_id(type_id)
+            parameter_types = parameter_types + ((type_item["type"], type_item["rank"]),)
+    return parameter_types, database_value, parsed_value, value_type
+
+
+def is_parameter_type_valid(parameter_types, database_value, value, value_type):
+    """Tests whether given parameter type and value are valid.
+
+    Args:
+        parameter_types (Iterable): tuples of parameter types and ranks
+        database_value (bytes, optional): unparsed value blob
+        value (Any, optional): parsed value if available
+        value_type (str, optional): value's type
+
+    Returns:
+        bool: True if value is of valid type, False otherwise
+    """
+    if not parameter_types or database_value is None or database_value == UNPARSED_NULL_VALUE:
+        return True
+    if value_type is not None:
+        if not any(value_type == type_and_rank[0] for type_and_rank in parameter_types):
+            return False
+        if value_type != Map.type_():
+            return True
+        rank = from_database_to_dimension_count(database_value, value_type)
+        return any(rank == type_and_rank[1] for type_and_rank in parameter_types if type_and_rank[0] == Map.type_())
+    return any(type_for_value(value) == type_and_rank for type_and_rank in parameter_types)

--- a/spinedb_api/export_functions.py
+++ b/spinedb_api/export_functions.py
@@ -10,6 +10,8 @@
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
 """ Functions for exporting data from a Spine database in a standard format. """
+from collections import defaultdict
+from functools import partial
 from operator import itemgetter
 from sqlalchemy.util import KeyedTuple
 from .helpers import Asterisk
@@ -24,6 +26,7 @@ def export_data(
     entity_group_ids=Asterisk,
     parameter_value_list_ids=Asterisk,
     parameter_definition_ids=Asterisk,
+    parameter_type_ids=Asterisk,
     parameter_value_ids=Asterisk,
     alternative_ids=Asterisk,
     scenario_ids=Asterisk,
@@ -43,6 +46,7 @@ def export_data(
         entity_group_ids (Iterable, optional): If given, only exports groups with these ids
         parameter_value_list_ids (Iterable, optional): If given, only exports lists with these ids
         parameter_definition_ids (Iterable, optional): If given, only exports parameter definitions with these ids
+        parameter_type_ids (Iterable or Asterisk): If given, only exports parameter types with these ids
         parameter_value_ids (Iterable, optional): If given, only exports parameter values with these ids
         alternative_ids (Iterable, optional): If given, only exports alternatives with these ids
         scenario_ids (Iterable, optional): If given, only exports scenarios with these ids
@@ -64,6 +68,7 @@ def export_data(
         "parameter_definitions": export_parameter_definitions(
             db_map, parameter_definition_ids, parse_value=parse_value
         ),
+        "parameter_types": export_parameter_types(db_map, parameter_type_ids),
         "parameter_values": export_parameter_values(db_map, parameter_value_ids, parse_value=parse_value),
         "alternatives": export_alternatives(db_map, alternative_ids),
         "scenarios": export_scenarios(db_map, scenario_ids),
@@ -161,6 +166,13 @@ def export_parameter_definitions(db_map, ids=Asterisk, parse_value=from_database
             x.description,
         )
         for x in _get_items(db_map, "parameter_definition", ids)
+    )
+
+
+def export_parameter_types(db_map, ids=Asterisk):
+    return sorted(
+        (x.entity_class_name, x.parameter_definition_name, x.type, x.rank)
+        for x in _get_items(db_map, "parameter_type", ids)
     )
 
 

--- a/spinedb_api/helpers.py
+++ b/spinedb_api/helpers.py
@@ -503,6 +503,20 @@ def create_spine_metadata():
         UniqueConstraint("id", "parameter_value_list_id"),
     )
     Table(
+        "parameter_type",
+        meta,
+        Column("id", Integer, primary_key=True),
+        Column(
+            "parameter_definition_id",
+            Integer,
+            ForeignKey("parameter_definition.id", onupdate="CASCADE", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        Column("rank", Integer, nullable=False),
+        Column("type", String(255), nullable=False),
+        UniqueConstraint("parameter_definition_id", "type", "rank"),
+    )
+    Table(
         "parameter_tag",
         meta,
         Column("id", Integer, primary_key=True),

--- a/spinedb_api/import_functions.py
+++ b/spinedb_api/import_functions.py
@@ -12,12 +12,23 @@
 
 """
 Functions for importing data into a Spine database in a standard format.
-This functionaly is equivalent to the one provided by :meth:`.DatabaseMapping.add_update_item`,
+This functionality is equivalent to the one provided by :meth:`.DatabaseMapping.add_update_item`,
 but the syntax is a little more compact.
 """
 from collections import defaultdict
+from contextlib import suppress
+from functools import partial
+from itertools import takewhile
 from .helpers import _parse_metadata
-from .parameter_value import fix_conflict, to_database
+from .parameter_value import (
+    RANK_1_TYPES,
+    Array,
+    TimePattern,
+    TimeSeries,
+    fancy_type_to_type_and_rank,
+    fix_conflict,
+    to_database,
+)
 
 
 def import_data(db_map, unparse_value=to_database, on_conflict="merge", **kwargs):
@@ -69,34 +80,19 @@ def import_data(db_map, unparse_value=to_database, on_conflict="merge", **kwargs
             )
 
     Args:
-        db_map (spinedb_api.DiffDatabaseMapping): database mapping
+        db_map (DatabaseMapping): database mapping
+        unparse_value (Callable): function to call to parse parameter values
         on_conflict (str): Conflict resolution strategy for :func:`parameter_value.fix_conflict`
-        entity_classes (list(tuple(str,tuple,str,int)): tuples of
-            (name, dimension name tuple, description, display icon integer)
-        parameter_definitions (list(tuple(str,str,str,str)):
-            tuples of (class name, parameter name, default value, parameter value list name, description)
-        entities: (list(tuple(str,str or tuple(str)): tuples of (class name, entity name or element name list)
-        entity_alternatives: (list(tuple(str,str or tuple(str),str,bool): tuples of
-            (class name, entity name or element name list, alternative name, activity)
-        entity_groups (list(tuple(str,str,str))): tuples of (class name, group entity name, member entity name)
-        parameter_values (list(tuple(str,str or tuple(str),str,str|numeric,str]):
-            tuples of (class name, entity name or element name list, parameter name, value, alternative name)
-        alternatives (list(str,str)): tuples of (name, description)
-        scenarios (list(str,str)): tuples of (name, description)
-        scenario_alternatives (list(str,str,str)): tuples of
-            (scenario name, alternative name, preceeding alternative name)
-        parameter_value_lists (list(str,str|numeric)): tuples of (list name, value)
+        **kwargs: data to import
 
     Returns:
-        int: number of items imported
-        list: errors
+        tuple: number of items imported and list of errors
     """
     all_errors = []
     num_imports = 0
-    for item_type, items in get_data_for_import(db_map, unparse_value=unparse_value, on_conflict=on_conflict, **kwargs):
-        if isinstance(items, tuple):
-            items, input_errors = items
-            all_errors.extend(input_errors)
+    for item_type, items in get_data_for_import(
+        db_map, all_errors, unparse_value=unparse_value, on_conflict=on_conflict, **kwargs
+    ):
         added, updated, errors = db_map.add_update_items(item_type, *items, strict=False)
         num_imports += len(added + updated)
         all_errors.extend(errors)
@@ -105,6 +101,7 @@ def import_data(db_map, unparse_value=to_database, on_conflict="merge", **kwargs
 
 def get_data_for_import(
     db_map,
+    all_errors,
     unparse_value=to_database,
     on_conflict="merge",
     entity_classes=(),
@@ -112,6 +109,7 @@ def get_data_for_import(
     entity_groups=(),
     entity_alternatives=(),
     parameter_definitions=(),
+    parameter_types=(),
     parameter_values=(),
     parameter_value_lists=(),
     alternatives=(),
@@ -144,12 +142,16 @@ def get_data_for_import(
     """Yields data to import into a Spine DB.
 
     Args:
-        db_map (spinedb_api.DiffDatabaseMapping): database mapping
+        db_map (DatabaseMapping): database mapping
+        all_errors (list of str): errors encountered during import
+        unparse_value (Callable): function to call when parsing parameter values
         on_conflict (str): Conflict resolution strategy for :func:`~spinedb_api.parameter_value.fix_conflict`
         entity_classes (list(tuple(str,tuple,str,int)): tuples of
             (name, dimension name tuple, description, display icon integer)
         parameter_definitions (list(tuple(str,str,str,str)):
             tuples of (class name, parameter name, default value, parameter value list name)
+        parameter_types (list(tuple(str,str,str))):
+            tuples of (class name, parameter name, type, preceding type)
         entities: (list(tuple(str,str or tuple(str)): tuples of (class name, entity name or element name list)
         entity_alternatives: (list(tuple(str,str or tuple(str),str,bool): tuples of
             (class name, entity name or element name list, alternative name, activity)
@@ -159,8 +161,14 @@ def get_data_for_import(
         alternatives (list(str,str)): tuples of (name, description)
         scenarios (list(str,str)): tuples of (name, description)
         scenario_alternatives (list(str,str,str)): tuples of
-            (scenario name, alternative name, preceeding alternative name)
+            (scenario name, alternative name, preceding alternative name)
         parameter_value_lists (list(str,str|numeric)): tuples of (list name, value)
+        metadata (list(tuple(str,str))): tuples of (name, value)
+        entity_metadata (list(tuple(str,tuple,str,str))):
+            tuples of (class name, entity byname, metadata name, value)
+        parameter_value_metadata (list(tuple(str,tuple,str,str,str,str))):
+            tuples of (class name, entity byname, parameter name, metadata name, value, alternative name)
+        superclass_subclasses (list(tuple(str,str))): tuples of (superclass name, subclass name)
 
     Yields:
         str: item type
@@ -168,86 +176,102 @@ def get_data_for_import(
     """
     # NOTE: The order is important, because of references. E.g., we want to import alternatives before parameter_values
     if alternatives:
-        yield ("alternative", _get_alternatives_for_import(db_map, alternatives))
+        yield ("alternative", _get_alternatives_for_import(alternatives))
     if scenarios:
-        yield ("scenario", _get_scenarios_for_import(db_map, scenarios))
+        yield ("scenario", _get_scenarios_for_import(scenarios))
     if scenario_alternatives:
-        yield ("scenario_alternative", _get_scenario_alternatives_for_import(db_map, scenario_alternatives))
+        yield ("scenario_alternative", _get_scenario_alternatives_for_import(db_map, scenario_alternatives, all_errors))
     if entity_classes:
-        for bucket in _get_entity_classes_for_import(db_map, entity_classes):
+        for bucket in _get_entity_classes_for_import(entity_classes):
             yield ("entity_class", bucket)
     if object_classes:  # Legacy
-        yield from get_data_for_import(db_map, entity_classes=_object_classes_to_entity_classes(object_classes))
+        yield from get_data_for_import(
+            db_map, all_errors, entity_classes=_object_classes_to_entity_classes(object_classes)
+        )
     if relationship_classes:  # Legacy
-        yield from get_data_for_import(db_map, entity_classes=relationship_classes)
+        yield from get_data_for_import(db_map, all_errors, entity_classes=relationship_classes)
     if superclass_subclasses:
-        yield ("superclass_subclass", _get_superclass_subclasses_for_import(db_map, superclass_subclasses))
+        yield ("superclass_subclass", _get_superclass_subclasses_for_import(superclass_subclasses))
     if entities:
-        for bucket in _get_entities_for_import(db_map, entities):
+        for bucket in _get_entities_for_import(entities):
             yield ("entity", bucket)
     if objects:  # Legacy
-        yield from get_data_for_import(db_map, entities=objects)
+        yield from get_data_for_import(db_map, all_errors, entities=objects)
     if relationships:  # Legacy
-        yield from get_data_for_import(db_map, entities=relationships)
+        yield from get_data_for_import(db_map, all_errors, entities=relationships)
     if entity_alternatives:
-        yield ("entity_alternative", _get_entity_alternatives_for_import(db_map, entity_alternatives))
+        yield ("entity_alternative", _get_entity_alternatives_for_import(entity_alternatives))
     if entity_groups:
-        yield ("entity_group", _get_entity_groups_for_import(db_map, entity_groups))
+        yield ("entity_group", _get_entity_groups_for_import(entity_groups))
     if object_groups:  # Legacy
-        yield from get_data_for_import(db_map, entity_groups=object_groups)
+        yield from get_data_for_import(db_map, all_errors, entity_groups=object_groups)
     if parameter_value_lists:
-        yield ("parameter_value_list", _get_parameter_value_lists_for_import(db_map, parameter_value_lists))
+        yield ("parameter_value_list", _get_parameter_value_lists_for_import(parameter_value_lists))
         yield ("list_value", _get_list_values_for_import(db_map, parameter_value_lists, unparse_value))
     if parameter_definitions:
         yield (
             "parameter_definition",
-            _get_parameter_definitions_for_import(db_map, parameter_definitions, unparse_value),
+            _get_parameter_definitions_for_import(parameter_definitions, unparse_value),
         )
     if object_parameters:  # Legacy
-        yield from get_data_for_import(db_map, unparse_value=unparse_value, parameter_definitions=object_parameters)
+        yield from get_data_for_import(
+            db_map, all_errors, unparse_value=unparse_value, parameter_definitions=object_parameters
+        )
     if relationship_parameters:  # Legacy
         yield from get_data_for_import(
-            db_map, unparse_value=unparse_value, parameter_definitions=relationship_parameters
+            db_map, all_errors, unparse_value=unparse_value, parameter_definitions=relationship_parameters
         )
+    if parameter_types:
+        yield ("parameter_type", _get_parameter_types_for_import(parameter_types, all_errors))
     if parameter_values:
         yield (
             "parameter_value",
-            _get_parameter_values_for_import(db_map, parameter_values, unparse_value, on_conflict),
+            _get_parameter_values_for_import(db_map, parameter_values, all_errors, unparse_value, on_conflict),
         )
     if object_parameter_values:  # Legacy
         yield from get_data_for_import(
-            db_map, unparse_value=unparse_value, on_conflict=on_conflict, parameter_values=object_parameter_values
+            db_map,
+            all_errors,
+            unparse_value=unparse_value,
+            on_conflict=on_conflict,
+            parameter_values=object_parameter_values,
         )
     if relationship_parameter_values:  # Legacy
         yield from get_data_for_import(
-            db_map, unparse_value=unparse_value, on_conflict=on_conflict, parameter_values=relationship_parameter_values
+            db_map,
+            all_errors,
+            unparse_value=unparse_value,
+            on_conflict=on_conflict,
+            parameter_values=relationship_parameter_values,
         )
     if metadata:
-        yield ("metadata", _get_metadata_for_import(db_map, metadata))
+        yield ("metadata", _get_metadata_for_import(metadata))
     if entity_metadata:
-        yield ("metadata", _get_metadata_for_import(db_map, (ent_metadata[2] for ent_metadata in entity_metadata)))
-        yield ("entity_metadata", _get_entity_metadata_for_import(db_map, entity_metadata))
+        yield ("metadata", _get_metadata_for_import((ent_metadata[2] for ent_metadata in entity_metadata)))
+        yield ("entity_metadata", _get_entity_metadata_for_import(entity_metadata))
     if parameter_value_metadata:
         yield (
             "metadata",
-            _get_metadata_for_import(db_map, (pval_metadata[3] for pval_metadata in parameter_value_metadata)),
+            _get_metadata_for_import((pval_metadata[3] for pval_metadata in parameter_value_metadata)),
         )
         yield ("parameter_value_metadata", _get_parameter_value_metadata_for_import(db_map, parameter_value_metadata))
     if object_metadata:  # Legacy
-        yield from get_data_for_import(db_map, entity_metadata=object_metadata)
+        yield from get_data_for_import(db_map, all_errors, entity_metadata=object_metadata)
     if relationship_metadata:  # Legacy
-        yield from get_data_for_import(db_map, entity_metadata=relationship_metadata)
+        yield from get_data_for_import(db_map, all_errors, entity_metadata=relationship_metadata)
     if object_parameter_value_metadata:  # Legacy
-        yield from get_data_for_import(db_map, parameter_value_metadata=object_parameter_value_metadata)
+        yield from get_data_for_import(db_map, all_errors, parameter_value_metadata=object_parameter_value_metadata)
     if relationship_parameter_value_metadata:  # Legacy
-        yield from get_data_for_import(db_map, parameter_value_metadata=relationship_parameter_value_metadata)
+        yield from get_data_for_import(
+            db_map, all_errors, parameter_value_metadata=relationship_parameter_value_metadata
+        )
 
 
 def import_superclass_subclasses(db_map, data):
     """Imports superclass_subclasses into a Spine database using a standard format.
 
     Args:
-        db_map (spinedb_api.DiffDatabaseMapping): database mapping
+        db_map (DatabaseMapping): database mapping
         data (list(tuple(str,tuple,str,int)): tuples of (superclass name, subclass name)
 
     Returns:
@@ -261,7 +285,7 @@ def import_entity_classes(db_map, data):
     """Imports entity classes into a Spine database using a standard format.
 
     Args:
-        db_map (spinedb_api.DiffDatabaseMapping): database mapping
+        db_map (DatabaseMapping): database mapping
         data (list(tuple(str,tuple,str,int,bool)): tuples of
             (name, dimension name tuple, description, display icon integer, active by default flag)
 
@@ -276,7 +300,7 @@ def import_entities(db_map, data):
     """Imports entities into a Spine database using a standard format.
 
     Args:
-        db_map (spinedb_api.DiffDatabaseMapping): database mapping
+        db_map (DatabaseMapping): database mapping
         data: (list(tuple(str,str or tuple(str)): tuples of (class name, entity name or element name list)
 
     Returns:
@@ -290,7 +314,7 @@ def import_entity_alternatives(db_map, data):
     """Imports entity alternatives into a Spine database using a standard format.
 
     Args:
-        db_map (spinedb_api.DiffDatabaseMapping): database mapping
+        db_map (DatabaseMapping): database mapping
         data: (list(tuple(str,str or tuple(str),str,bool): tuples of
             (class name, entity name or element name list, alternative name, activity)
 
@@ -305,7 +329,7 @@ def import_entity_groups(db_map, data):
     """Imports entity groups into a Spine database using a standard format.
 
     Args:
-        db_map (spinedb_api.DiffDatabaseMapping): database mapping
+        db_map (DatabaseMapping): database mapping
         data (list(tuple(str,str,str))): tuples of (class name, group entity name, member entity name)
 
     Returns:
@@ -319,9 +343,10 @@ def import_parameter_definitions(db_map, data, unparse_value=to_database):
     """Imports parameter definitions into a Spine database using a standard format.
 
     Args:
-        db_map (spinedb_api.DiffDatabaseMapping): database mapping
+        db_map (DatabaseMapping): database mapping
         data (list(tuple(str,str,str,str)):
             tuples of (class name, parameter name, default value, parameter value list name)
+        unparse_value (Callable): function to parse parameter values
 
     Returns:
         int: number of items imported
@@ -330,13 +355,30 @@ def import_parameter_definitions(db_map, data, unparse_value=to_database):
     return import_data(db_map, parameter_definitions=data, unparse_value=unparse_value)
 
 
+def import_parameter_types(db_map, data, unparse_value=to_database):
+    """Imports parameter types into a Spine database using a standard format.
+
+    Args:
+        db_map (DatabaseMapping): database mapping
+        data (Iterable of Iterable):
+            Iterable of (class name, parameter name, type, [succeeding type])
+        unparse_value (Callable): function to parse parameter values
+
+    Returns:
+        int: number of items imported
+        list: errors
+    """
+    return import_data(db_map, parameter_types=data, unparse_value=unparse_value)
+
+
 def import_parameter_values(db_map, data, unparse_value=to_database, on_conflict="merge"):
     """Imports parameter values into a Spine database using a standard format.
 
     Args:
-        db_map (spinedb_api.DiffDatabaseMapping): database mapping
+        db_map (DatabaseMapping): database mapping
         data (list(tuple(str,str or tuple(str),str,str|numeric,str]):
             tuples of (class name, entity name or element name list, parameter name, value, alternative name)
+        unparse_value (Callable): function to parse parameter values
         on_conflict (str): Conflict resolution strategy for :func:`~spinedb_api.parameter_value.fix_conflict`
 
     Returns:
@@ -350,7 +392,7 @@ def import_alternatives(db_map, data):
     """Imports alternatives into a Spine database using a standard format.
 
     Args:
-        db_map (spinedb_api.DiffDatabaseMapping): database mapping
+        db_map (DatabaseMapping): database mapping
         data (list(str,str)): tuples of (name, description)
 
     Returns:
@@ -364,7 +406,7 @@ def import_scenarios(db_map, data):
     """Imports scenarios into a Spine database using a standard format.
 
     Args:
-        db_map (spinedb_api.DiffDatabaseMapping): database mapping
+        db_map (DatabaseMapping): database mapping
         data (list(str, bool, str)): tuples of (name, <unused_bool>, description)
 
     Returns:
@@ -378,8 +420,8 @@ def import_scenario_alternatives(db_map, data):
     """Imports scenario alternatives into a Spine database using a standard format.
 
     Args:
-        db_map (spinedb_api.DiffDatabaseMapping): database mapping
-        data (list(str,str,str)): tuples of (scenario name, alternative name, preceeding alternative name)
+        db_map (DatabaseMapping): database mapping
+        data (list(str,str,str)): tuples of (scenario name, alternative name, [succeeding alternative name])
 
     Returns:
         int: number of items imported
@@ -392,8 +434,9 @@ def import_parameter_value_lists(db_map, data, unparse_value=to_database):
     """Imports parameter value lists into a Spine database using a standard format.
 
     Args:
-        db_map (spinedb_api.DiffDatabaseMapping): database mapping
+        db_map (DatabaseMapping): database mapping
         data (list(str,str|numeric)): tuples of (list name, value)
+        unparse_value (Callable): function to parse parameter values
 
     Returns:
         int: number of items imported
@@ -406,7 +449,7 @@ def import_metadata(db_map, data):
     """Imports metadata into a Spine database using a standard format.
 
     Args:
-        db_map (spinedb_api.DiffDatabaseMapping): database mapping
+        db_map (DatabaseMapping): database mapping
         data (list(tuple(str,str))): tuples of (entry name, value)
 
     Returns:
@@ -468,7 +511,7 @@ def import_relationship_parameter_value_metadata(db_map, data):
     return import_data(db_map, relationship_parameter_value_metadata=data)
 
 
-def _get_entity_classes_for_import(db_map, data):
+def _get_entity_classes_for_import(data):
     dim_name_list_by_name = {}
     items = []
     key = ("name", "dimension_name_list", "description", "display_icon", "active_by_default")
@@ -491,12 +534,12 @@ def _get_entity_classes_for_import(db_map, data):
     return (items_by_ref_count[ref_count] for ref_count in sorted(items_by_ref_count))
 
 
-def _get_superclass_subclasses_for_import(db_map, data):
+def _get_superclass_subclasses_for_import(data):
     key = ("superclass_name", "subclass_name")
     return (dict(zip(key, x)) for x in data)
 
 
-def _get_entities_for_import(db_map, data):
+def _get_entities_for_import(data):
     items_by_el_count = {}
     key = ("entity_class_name", "entity_byname", "description")
     for class_name, name_or_el_name_list, *optionals in data:
@@ -511,7 +554,7 @@ def _get_entities_for_import(db_map, data):
     return (items_by_el_count[el_count] for el_count in sorted(items_by_el_count))
 
 
-def _get_entity_alternatives_for_import(db_map, data):
+def _get_entity_alternatives_for_import(data):
     for class_name, entity_name_or_element_name_list, alternative, active in data:
         is_zero_dim = isinstance(entity_name_or_element_name_list, str)
         entity_byname = (entity_name_or_element_name_list,) if is_zero_dim else entity_name_or_element_name_list
@@ -519,12 +562,12 @@ def _get_entity_alternatives_for_import(db_map, data):
         yield dict(zip(key, (class_name, entity_byname, alternative, active)))
 
 
-def _get_entity_groups_for_import(db_map, data):
+def _get_entity_groups_for_import(data):
     key = ("entity_class_name", "group_name", "member_name")
     return (dict(zip(key, x)) for x in data)
 
 
-def _get_parameter_definitions_for_import(db_map, data, unparse_value):
+def _get_parameter_definitions_for_import(data, unparse_value):
     key = ("entity_class_name", "name", "default_value", "default_type", "parameter_value_list_name", "description")
     for class_name, parameter_name, *optionals in data:
         if not optionals:
@@ -535,10 +578,8 @@ def _get_parameter_definitions_for_import(db_map, data, unparse_value):
         yield dict(zip(key, (class_name, parameter_name, value, type_, *optionals)))
 
 
-def _get_parameter_values_for_import(db_map, data, unparse_value, on_conflict):
+def _get_parameter_values_for_import(db_map, data, all_errors, unparse_value, on_conflict):
     seen = set()
-    errors = []
-    items = []
     key = ("entity_class_name", "entity_byname", "parameter_definition_name", "alternative_name", "value", "type")
     for class_name, entity_byname, parameter_name, value, *optionals in data:
         if isinstance(entity_byname, str):
@@ -549,7 +590,7 @@ def _get_parameter_values_for_import(db_map, data, unparse_value, on_conflict):
         unique_values = (class_name, entity_byname, parameter_name, alternative_name)
         if unique_values in seen:
             dupe = dict(zip(key, unique_values))
-            errors.append(
+            all_errors.append(
                 f"attempting to import more than one parameter_value with {dupe} - only first will be considered"
             )
             continue
@@ -560,21 +601,20 @@ def _get_parameter_values_for_import(db_map, data, unparse_value, on_conflict):
         if pv:
             value, type_ = fix_conflict((value, type_), (pv["value"], pv["type"]), on_conflict)
         item.update({"value": value, "type": type_})
-        items.append(item)
-    return items, errors
+        yield item
 
 
-def _get_alternatives_for_import(db_map, data):
+def _get_alternatives_for_import(data):
     key = ("name", "description")
     return ({"name": x} if isinstance(x, str) else dict(zip(key, x)) for x in data)
 
 
-def _get_scenarios_for_import(db_map, data):
+def _get_scenarios_for_import(data):
     key = ("name", "active", "description")
     return ({"name": x} if isinstance(x, str) else dict(zip(key, x)) for x in data)
 
 
-def _get_scenario_alternatives_for_import(db_map, data):
+def _get_scenario_alternatives_for_import(db_map, data, all_errors):
     # FIXME: maybe when updating, we only want to match by (scen_name, alt_name) and not by (scen_name, rank)
     alt_name_list_by_scen_name = {}
     succ_by_pred_by_scen_name = defaultdict(dict)
@@ -598,20 +638,17 @@ def _get_scenario_alternatives_for_import(db_map, data):
             if not some_added:
                 break
         alternative_name_list.pop(-1)  # Remove the None
-    items = (
-        {"scenario_name": scen_name, "alternative_name": alt_name, "rank": k + 1}
-        for scen_name, alternative_name_list in alt_name_list_by_scen_name.items()
-        for k, alt_name in enumerate(alternative_name_list)
-    )
-    errors = (
-        f"can't insert alternative '{pred}' before '{succ}' because the latter is not in scenario '{scen_name}'"
+    all_errors += [
+        f"can't insert alternative '{pred}' before '{succ}' because the latter is not in scenario '{scen}'"
         for scen, succ_by_pred in succ_by_pred_by_scen_name.items()
         for pred, succ in succ_by_pred.items()
-    )
-    return items, errors
+    ]
+    for scen_name, alternative_name_list in alt_name_list_by_scen_name.items():
+        for k, alt_name in enumerate(alternative_name_list):
+            yield {"scenario_name": scen_name, "alternative_name": alt_name, "rank": k + 1}
 
 
-def _get_parameter_value_lists_for_import(db_map, data):
+def _get_parameter_value_lists_for_import(data):
     return ({"name": x} for x in {x[0]: None for x in data})
 
 
@@ -635,13 +672,36 @@ def _get_list_values_for_import(db_map, data, unparse_value):
         yield {"parameter_value_list_name": list_name, "value": value, "type": type_, "index": index}
 
 
-def _get_metadata_for_import(db_map, data):
+def _get_parameter_types_for_import(data, all_errors):
+    for class_name, definition_name, parameter_type, *optionals in data:
+        if not optionals:
+            if parameter_type == "map":
+                all_errors.append(f"Missing rank for map type for parameter {definition_name} in class {class_name}")
+                continue
+            try:
+                parameter_type, rank = fancy_type_to_type_and_rank(parameter_type)
+            except ValueError:
+                all_errors.append(
+                    f"Failed to read rank from type '{parameter_type}' for parameter {definition_name} in class {class_name}"
+                )
+                continue
+        else:
+            rank = optionals[0]
+        yield {
+            "entity_class_name": class_name,
+            "parameter_definition_name": definition_name,
+            "type": parameter_type,
+            "rank": rank,
+        }
+
+
+def _get_metadata_for_import(data):
     for metadata in data:
         for name, value in _parse_metadata(metadata):
             yield {"name": name, "value": value}
 
 
-def _get_entity_metadata_for_import(db_map, data):
+def _get_entity_metadata_for_import(data):
     key = ("entity_class_name", "entity_byname", "metadata_name", "metadata_value")
     for class_name, entity_byname, metadata in data:
         if isinstance(entity_byname, str):

--- a/spinedb_api/import_mapping/import_mapping.py
+++ b/spinedb_api/import_mapping/import_mapping.py
@@ -549,6 +549,23 @@ class ParameterDefinitionMapping(ImportMapping):
             mapped_data.setdefault("parameter_definitions", dict())[parameter_definition_key] = definition_extras
 
 
+class ParameterTypeMapping(ImportMapping):
+    """Maps parameter types.
+
+    Cannot be used as the topmost mapping; must have a parameter definition mapping as one of parents.
+    """
+
+    MAP_TYPE = "ParameterType"
+
+    def _import_row(self, source_data, state, mapped_data):
+        parameter_type = str(source_data)
+        if not parameter_type:
+            return
+        entity_class = state[ImportKey.ENTITY_CLASS_NAME]
+        parameter = state[ImportKey.PARAMETER_NAME]
+        mapped_data.setdefault("parameter_types", []).append((entity_class, parameter, parameter_type))
+
+
 class ParameterDefaultValueMapping(ImportMapping):
     """Maps scalar (non-indexed) default values
 
@@ -1007,6 +1024,7 @@ def from_dict(serialized):
             ElementMapping,
             EntityAlternativeActivityMapping,
             ParameterDefinitionMapping,
+            ParameterTypeMapping,
             ParameterDefaultValueMapping,
             ParameterDefaultValueTypeMapping,
             DefaultValueIndexNameMapping,

--- a/spinedb_api/mapped_items.py
+++ b/spinedb_api/mapped_items.py
@@ -12,8 +12,18 @@
 
 from operator import itemgetter
 from .db_mapping_base import MappedItemBase
+from .exception import SpineDBAPIError
 from .helpers import name_from_dimensions, name_from_elements
-from .parameter_value import ParameterValueFormatError, from_database, to_database
+from .parameter_value import (
+    RANK_1_TYPES,
+    VALUE_TYPES,
+    Map,
+    ParameterValueFormatError,
+    fancy_type_to_type_and_rank,
+    from_database,
+    to_database,
+    type_and_rank_to_fancy_type,
+)
 
 
 def item_factory(item_type):
@@ -25,6 +35,7 @@ def item_factory(item_type):
         "entity_alternative": EntityAlternativeItem,
         "entity_group": EntityGroupItem,
         "parameter_definition": ParameterDefinitionItem,
+        "parameter_type": ParameterTypeItem,
         "parameter_value": ParameterValueItem,
         "parameter_value_list": ParameterValueListItem,
         "list_value": ListValueItem,
@@ -473,6 +484,7 @@ class ParameterDefinitionItem(ParameterItemBase):
     fields = {
         "entity_class_name": {"type": str, "value": "The entity class name."},
         "name": {"type": str, "value": "The parameter name."},
+        "parameter_type_list": {"type": tuple, "value": "List of valid value types.", "optional": True},
         "default_value": {"type": bytes, "value": "The default value.", "optional": True},
         "default_type": {"type": str, "value": "The default value type.", "optional": True},
         "parameter_value_list_name": {
@@ -502,6 +514,10 @@ class ParameterDefinitionItem(ParameterItemBase):
         "parameter_value_list_id": (("parameter_value_list_name",), "id"),
     }
 
+    def __init__(self, db_map, item_type, **kwargs):
+        super().__init__(db_map, item_type, **kwargs)
+        self._init_type_list = kwargs.get("parameter_type_list")
+
     @property
     def _value_key(self):
         return "default_value"
@@ -511,6 +527,11 @@ class ParameterDefinitionItem(ParameterItemBase):
         return "default_type"
 
     def __getitem__(self, key):
+        if key == "parameter_type_id_list":
+            return tuple(x["id"] for x in self._sorted_parameter_types())
+        if key == "parameter_type_list":
+            self._db_map.do_fetch_all("parameter_type")
+            return tuple(type_and_rank_to_fancy_type(x["type"], x["rank"]) for x in self._sorted_parameter_types())
         if key == "value_list_id":
             return super().__getitem__("parameter_value_list_id")
         if key == "parameter_value_list_id":
@@ -525,7 +546,25 @@ class ParameterDefinitionItem(ParameterItemBase):
             return dict.get(self, key)
         return super().__getitem__(key)
 
+    def _sorted_parameter_types(self):
+        self._db_map.do_fetch_all("parameter_type")
+        return sorted(
+            (
+                x
+                for x in self._db_map.mapped_table("parameter_type").valid_values()
+                if x["parameter_definition_id"] == self["id"]
+            ),
+            key=lambda i: (i["type"], i["rank"]),
+        )
+
+    def _asdict(self):
+        d = super()._asdict()
+        if "parameter_type_list" not in d:
+            d["parameter_type_list"] = self.__getitem__("parameter_type_list")
+        return d
+
     def merge(self, other):
+        errors = []
         other_parameter_value_list_id = other.get("parameter_value_list_id")
         if (
             other_parameter_value_list_id is not None
@@ -536,14 +575,146 @@ class ParameterDefinitionItem(ParameterItemBase):
             )
         ):
             del other["parameter_value_list_id"]
-            error = "can't modify the parameter value list of a parameter that already has values"
-        else:
-            error = ""
+            errors.append("can't modify the parameter value list of a parameter that already has values")
+        other_type_list = other.get("parameter_type_list")
+        if other_type_list is not None and other_type_list != self.__getitem__("parameter_type_list"):
+            try:
+                self._make_new_type_items(other_type_list)
+            except SpineDBAPIError as type_error:
+                errors.append(str(type_error))
+                del other["parameter_type_list"]
         merged, super_error = super().merge(other)
-        return merged, " and ".join([x for x in (super_error, error) if x])
+        if super_error:
+            errors.insert(0, super_error)
+        return merged, " and ".join([x for x in errors if x])
+
+    def _make_new_type_items(self, new_type_list):
+        new_types = set(new_type_list)
+        current_types = set(self["parameter_type_list"])
+        items_to_add = []
+        type_table = self._db_map.mapped_table("parameter_type")
+        class_name = self["entity_class_name"]
+        parameter_name = self["name"]
+        for type_to_add in new_types - current_types:
+            type_, rank = fancy_type_to_type_and_rank(type_to_add)
+            type_item, error = type_table.checked_item_and_error(
+                {
+                    "entity_class_name": class_name,
+                    "parameter_definition_name": parameter_name,
+                    "type": type_,
+                    "rank": rank,
+                }
+            )
+            if error:
+                raise SpineDBAPIError(error)
+            items_to_add.append(type_item)
+        return items_to_add
+
+    def _update_types(self, new_type_list, type_items_to_add):
+        new_types = set(new_type_list)
+        current_types = set(self["parameter_type_list"])
+        type_table = self._db_map.mapped_table("parameter_type")
+        class_name = self["entity_class_name"]
+        parameter_name = self["name"]
+        types_to_remove = current_types - new_types
+        for type_to_remove in types_to_remove:
+            type_, rank = fancy_type_to_type_and_rank(type_to_remove)
+            type_item = type_table.find_item_by_unique_key(
+                {
+                    "entity_class_name": class_name,
+                    "parameter_definition_name": parameter_name,
+                    "type": type_,
+                    "rank": rank,
+                }
+            )
+            type_item.cascade_remove()
+        for type_to_add in type_items_to_add:
+            type_table.add_item(type_to_add)
 
     def _value_not_in_list_error(self, parsed_value, list_name):
         return f"default value {parsed_value} of {self['name']} is not in {list_name}"
+
+    def added_to_mapped_table(self):
+        if self._init_type_list is None:
+            return
+        type_table = self._db_map.mapped_table("parameter_type")
+        for fancy_type in self._init_type_list:
+            type_, rank = fancy_type_to_type_and_rank(fancy_type)
+            item = type_table.add_item(
+                {
+                    "entity_class_id": self["entity_class_id"],
+                    "parameter_definition_id": self["id"],
+                    "type": type_,
+                    "rank": rank,
+                }
+            )
+            if not item:
+                raise RuntimeError()
+        self._init_type_list = None
+
+    def cascade_update(self):
+        updated_type_list = self.pop("_updated_parameter_type_list", None)
+        if updated_type_list is None:
+            return
+        new_type_items = self._make_new_type_items(updated_type_list)
+        self._update_types(updated_type_list, new_type_items)
+        super().cascade_update()
+
+    def update(self, other):
+        other_type_list = other.pop("parameter_type_list", None)
+        if other_type_list is not None and other_type_list != self["parameter_type_list"]:
+            other["_updated_parameter_type_list"] = other_type_list
+        super().update(other)
+
+
+class ParameterTypeItem(MappedItemBase):
+    fields = {
+        "entity_class_name": {"type": str, "value": "The entity class name."},
+        "parameter_definition_name": {"type": str, "value": "The parameter name."},
+        "rank": {"type": int, "value": "The rank of the type."},
+        "type": {"type": str, "value": "The value type."},
+    }
+    unique_keys = (("entity_class_name", "parameter_definition_name", "type", "rank"),)
+    corresponding_unique_id_keys = {
+        "entity_class_name": "entity_class_id",
+        "parameter_definition_name": "parameter_definition_id",
+    }
+    _references = {"entity_class_id": ("entity_class", "id"), "parameter_definition_id": ("parameter_definition", "id")}
+    _external_fields = {
+        "entity_class_id": ("parameter_definition_id", "entity_class_id"),
+        "entity_class_name": ("entity_class_id", "name"),
+        "parameter_definition_name": ("parameter_definition_id", "name"),
+    }
+    _alt_references = {
+        ("entity_class_name",): ("entity_class", ("name",)),
+        (
+            "entity_class_name",
+            "parameter_definition_name",
+        ): ("parameter_definition", ("entity_class_name", "name")),
+    }
+    _internal_fields = {
+        "parameter_definition_id": (
+            (
+                "entity_class_name",
+                "parameter_definition_name",
+            ),
+            "id",
+        ),
+    }
+
+    def first_invalid_key(self):
+        invalid_key = super().first_invalid_key()
+        if invalid_key is not None:
+            return invalid_key
+        value_type = self["type"]
+        if value_type not in VALUE_TYPES:
+            return "type"
+        rank = self["rank"]
+        if value_type == Map.type_():
+            return "rank" if rank < 1 else None
+        if value_type in RANK_1_TYPES:
+            return "rank" if rank != 1 else None
+        return "rank" if rank != 0 else None
 
 
 class ParameterValueItem(ParameterItemBase):
@@ -708,7 +879,7 @@ class ScenarioAlternativeItem(MappedItemBase):
     def __getitem__(self, key):
         # The 'before' is to be interpreted as, this scenario alternative goes *before* the before_alternative.
         # Since ranks go from 1 to the alternative count, the first alternative will have the second as the 'before',
-        # the second will have the third, etc, and the last will have None.
+        # the second will have the third, etc., and the last will have None.
         # Note that alternatives with higher ranks overwrite the values of those with lower ranks.
         if key == "before_alternative_name":
             return self._get_ref("alternative", {"id": self["before_alternative_id"]}, strong=False).get("name")

--- a/spinedb_api/temp_id.py
+++ b/spinedb_api/temp_id.py
@@ -28,6 +28,10 @@ class TempId:
         return TempId(id_, item_type, temp_id_lookup)
 
     @property
+    def item_type(self):
+        return self._item_type
+
+    @property
     def private_id(self):
         return self._id
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -10,7 +10,4 @@
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
 
-"""
-Unit tests package for :mod:`spinedb_api`.
-
-"""
+""" Unit tests package for :mod:`spinedb_api`. """

--- a/tests/import_mapping/test_generator.py
+++ b/tests/import_mapping/test_generator.py
@@ -918,6 +918,43 @@ class TestGetMappedData(unittest.TestCase):
             },
         )
 
+    def test_import_parameter_types(self):
+        data_source = iter(
+            [
+                ["Widget", "x", "float"],
+                ["Widget", "x", "bool"],
+                ["Gadget", "p", "time_pattern"],
+                ["Gadget", "q", "str"],
+                ["Gadget", "p", "date_time"],
+                ["Object", "w", ""],
+            ]
+        )
+        mappings = [
+            [
+                {"map_type": "EntityClass", "position": 0},
+                {"map_type": "ParameterDefinition", "position": 1},
+                {"map_type": "ParameterType", "position": 2},
+            ]
+        ]
+        convert_function_specs = {0: "string", 1: "string", 2: "string"}
+        convert_functions = {column: value_to_convert_spec(spec) for column, spec in convert_function_specs.items()}
+        mapped_data, errors = get_mapped_data(data_source, mappings, column_convert_fns=convert_functions)
+        self.assertEqual(errors, [])
+        self.assertEqual(
+            mapped_data,
+            {
+                "entity_classes": [("Widget",), ("Gadget",), ("Object",)],
+                "parameter_definitions": [("Widget", "x"), ("Gadget", "p"), ("Gadget", "q"), ("Object", "w")],
+                "parameter_types": [
+                    ("Widget", "x", "float"),
+                    ("Widget", "x", "bool"),
+                    ("Gadget", "p", "time_pattern"),
+                    ("Gadget", "q", "str"),
+                    ("Gadget", "p", "date_time"),
+                ],
+            },
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/mock_helpers.py
+++ b/tests/mock_helpers.py
@@ -1,5 +1,6 @@
 ######################################################################################################################
 # Copyright (C) 2017-2022 Spine project consortium
+# Copyright Spine Database API contributors
 # This file is part of Spine Database API.
 # Spine Database API is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
 # General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your

--- a/tests/test_db_mapping_base.py
+++ b/tests/test_db_mapping_base.py
@@ -1,5 +1,6 @@
 ######################################################################################################################
 # Copyright (C) 2017-2022 Spine project consortium
+# Copyright Spine Database API contributors
 # This file is part of Spine Database API.
 # Spine Database API is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
 # General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your

--- a/tests/test_db_mapping_helpers.py
+++ b/tests/test_db_mapping_helpers.py
@@ -1,0 +1,166 @@
+######################################################################################################################
+# Copyright (C) 2017-2022 Spine project consortium
+# Copyright Spine Database API contributors
+# This file is part of Spine Database API.
+# Spine Database API is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+# General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+# Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+######################################################################################################################
+import unittest
+from spinedb_api import (
+    Array,
+    DatabaseMapping,
+    DateTime,
+    Duration,
+    Map,
+    TimePattern,
+    TimeSeriesFixedResolution,
+    to_database,
+)
+from spinedb_api.db_mapping_helpers import is_parameter_type_valid, type_check_args
+from tests.mock_helpers import AssertSuccessTestCase
+
+
+class TestTypeCheckArgs(AssertSuccessTestCase):
+    def test_none_value(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(db_map.add_entity_class_item(name="Star"))
+            definition = self._assert_success(
+                db_map.add_parameter_definition_item(name="mass", entity_class_name="Star")
+            )
+            args = type_check_args(definition)
+            self.assertEqual(args, ((), None, None, None))
+            self.assertTrue(is_parameter_type_valid(*args))
+            self._assert_success(db_map.add_entity_item(name="Vega", entity_class_name="Star"))
+            x, value_type = to_database(None)
+            value = self._assert_success(
+                db_map.add_parameter_value_item(
+                    entity_class_name="Star",
+                    entity_byname=("Vega",),
+                    parameter_definition_name="mass",
+                    alternative_name="Base",
+                    value=x,
+                    type=value_type,
+                )
+            )
+            args = type_check_args(value)
+            self.assertEqual(args, ((), b"null", None, None))
+            self.assertTrue(is_parameter_type_valid(*args))
+
+    def test_non_empty_parameter_type_list(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(db_map.add_entity_class_item(name="Star"))
+            definition = self._assert_success(
+                db_map.add_parameter_definition_item(
+                    name="mass", entity_class_name="Star", parameter_type_list=("bool", "2d_map")
+                )
+            )
+            args = type_check_args(definition)
+            self.assertEqual(args, ((("bool", 0), ("map", 2)), None, None, None))
+            self.assertTrue(is_parameter_type_valid(*args))
+            self._assert_success(db_map.add_entity_item(name="Vega", entity_class_name="Star"))
+            x, value_type = to_database(None)
+            value = self._assert_success(
+                db_map.add_parameter_value_item(
+                    entity_class_name="Star",
+                    entity_byname=("Vega",),
+                    parameter_definition_name="mass",
+                    alternative_name="Base",
+                    value=x,
+                    type=value_type,
+                )
+            )
+            self.assertEqual(type_check_args(value), ((("bool", 0), ("map", 2)), b"null", None, None))
+            self.assertTrue(is_parameter_type_valid(*args))
+
+    def test_with_value(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(db_map.add_entity_class_item(name="Star"))
+            x, value_type = to_database(2.3)
+            definition = self._assert_success(
+                db_map.add_parameter_definition_item(
+                    name="mass", entity_class_name="Star", default_value=x, default_type=value_type
+                )
+            )
+            args = type_check_args(definition)
+            self.assertEqual(args, ((), x, None, value_type))
+            self.assertEqual(definition["parsed_value"], 2.3)
+            args = type_check_args(definition)
+            self.assertEqual(args, ((), x, 2.3, value_type))
+            self.assertTrue(is_parameter_type_valid(*args))
+            self._assert_success(db_map.add_entity_item(name="Vega", entity_class_name="Star"))
+            value = self._assert_success(
+                db_map.add_parameter_value_item(
+                    entity_class_name="Star",
+                    entity_byname=("Vega",),
+                    parameter_definition_name="mass",
+                    alternative_name="Base",
+                    value=x,
+                    type=value_type,
+                )
+            )
+            args = type_check_args(value)
+            self.assertEqual(args, ((), x, None, value_type))
+            self.assertEqual(value["parsed_value"], 2.3)
+            args = type_check_args(value)
+            self.assertEqual(args, ((), x, 2.3, value_type))
+            self.assertTrue(is_parameter_type_valid(*args))
+
+
+class TestIsParameterTypeValid(AssertSuccessTestCase):
+    def test_none_is_always_valid(self):
+        self.assertTrue(is_parameter_type_valid((), None, None, None))
+        value, value_type = to_database(None)
+        self.assertTrue(is_parameter_type_valid((), value, None, value_type))
+        self.assertTrue(is_parameter_type_valid(("duration", "time_series"), value, None, value_type))
+
+    def test_valid_types_are_valid(self):
+        def assert_test(value, rank):
+            db_value, value_type = to_database(value)
+            self.assertTrue(is_parameter_type_valid(((value_type, rank),), db_value, None, value_type))
+            self.assertTrue(is_parameter_type_valid(((value_type, rank),), db_value, value, value_type))
+
+        values = {
+            0: (2.3, "I'm a string", True, Duration("12M"), DateTime("2024-07-25T12:00:00")),
+            1: (
+                Array([1.0]),
+                TimePattern(["M1-12"], [1.0]),
+                TimeSeriesFixedResolution("2024-07-25T12:00:00", "1h", [1.0], False, False),
+            ),
+            2: (Map(["a", "b"], [1.0, Map(["c"], [2.0])]),),
+        }
+        for rank, xs in values.items():
+            for x in xs:
+                with self.subTest(value=x):
+                    assert_test(x, rank)
+
+    def test_invalid_types_are_invalid(self):
+        def assert_test(value, rank):
+            db_value, value_type = to_database(value)
+            test_type = "float" if value_type != "float" else "bool"
+            self.assertFalse(is_parameter_type_valid(((test_type, rank),), db_value, None, value_type))
+            if value_type == "map":
+                test_rank = rank + 1
+                self.assertFalse(is_parameter_type_valid(((value_type, test_rank),), db_value, None, value_type))
+            self.assertFalse(is_parameter_type_valid(((test_type, rank),), db_value, value, value_type))
+
+        values = {
+            0: (2.3, "I'm a string", True, Duration("12M"), DateTime("2024-07-25T12:00:00")),
+            1: (
+                Array([1.0]),
+                TimePattern(["M1-12"], [1.0]),
+                TimeSeriesFixedResolution("2024-07-25T12:00:00", "1h", [1.0], False, False),
+            ),
+            2: (Map(["a", "b"], [1.0, Map(["c"], [2.0])]),),
+        }
+        for rank, xs in values.items():
+            for x in xs:
+                with self.subTest(value=x):
+                    assert_test(x, rank)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -73,7 +73,7 @@ class TestRemoveCredentialsFromUrl(unittest.TestCase):
 class TestGetHeadAlembicVersion(unittest.TestCase):
     def test_returns_latest_version(self):
         # This test must be updated each time new migration script is added.
-        self.assertEqual(get_head_alembic_version(), "ca7a13da8ff6")
+        self.assertEqual(get_head_alembic_version(), "c55527151b29")
 
 
 class TestStringToBool(unittest.TestCase):

--- a/tests/test_import_functions.py
+++ b/tests/test_import_functions.py
@@ -67,282 +67,255 @@ def _assert_same_elements(test, obs_vals, exp_vals):
     test.assertEqual(obs_vals, exp_vals)
 
 
-def create_db_map():
-    db_url = "sqlite://"
-    return DatabaseMapping(db_url, username="UnitTest", create=True)
+class ImportsTestCase(unittest.TestCase):
+    def _assert_success(self, import_result):
+        num_imports, errors = import_result
+        self.assertEqual(errors, [])
+        return num_imports
 
 
-class TestIntegrationImportData(unittest.TestCase):
+class TestIntegrationImportData(ImportsTestCase):
     def test_import_data_integration(self):
-        database_url = "sqlite://"
-        db_map = DatabaseMapping(database_url, username="IntegrationTest", create=True)
+        with DatabaseMapping("sqlite://", username="IntegrationTest", create=True) as db_map:
+            object_c = ["example_class", "other_class"]  # 2 items
+            objects = [["example_class", "example_object"], ["other_class", "other_object"]]  # 2 items
+            relationship_c = [["example_rel_class", ["example_class", "other_class"]]]  # 1 item
+            relationships = [["example_rel_class", ["example_object", "other_object"]]]  # 1 item
+            obj_parameters = [["example_class", "example_parameter"]]  # 1 item
+            rel_parameters = [["example_rel_class", "rel_parameter"]]  # 1 item
+            object_p_values = [["example_class", "example_object", "example_parameter", 3.14]]  # 1 item
+            rel_p_values = [["example_rel_class", ["example_object", "other_object"], "rel_parameter", 2.718]]  # 1
+            alternatives = [["example_alternative", "An example"]]
+            scenarios = [["example_scenario", True, "An example"]]
+            scenario_alternatives = [["example_scenario", "example_alternative"]]
 
-        object_c = ["example_class", "other_class"]  # 2 items
-        objects = [["example_class", "example_object"], ["other_class", "other_object"]]  # 2 items
-        relationship_c = [["example_rel_class", ["example_class", "other_class"]]]  # 1 item
-        relationships = [["example_rel_class", ["example_object", "other_object"]]]  # 1 item
-        obj_parameters = [["example_class", "example_parameter"]]  # 1 item
-        rel_parameters = [["example_rel_class", "rel_parameter"]]  # 1 item
-        object_p_values = [["example_class", "example_object", "example_parameter", 3.14]]  # 1 item
-        rel_p_values = [["example_rel_class", ["example_object", "other_object"], "rel_parameter", 2.718]]  # 1
-        alternatives = [["example_alternative", "An example"]]
-        scenarios = [["example_scenario", True, "An example"]]
-        scenario_alternatives = [["example_scenario", "example_alternative"]]
-
-        num_imports, errors = import_data(
-            db_map,
-            object_classes=object_c,
-            relationship_classes=relationship_c,
-            object_parameters=obj_parameters,
-            relationship_parameters=rel_parameters,
-            objects=objects,
-            relationships=relationships,
-            object_parameter_values=object_p_values,
-            relationship_parameter_values=rel_p_values,
-            alternatives=alternatives,
-            scenarios=scenarios,
-            scenario_alternatives=scenario_alternatives,
-        )
-        db_map.close()
+            num_imports = self._assert_success(import_data(
+                db_map,
+                object_classes=object_c,
+                relationship_classes=relationship_c,
+                object_parameters=obj_parameters,
+                relationship_parameters=rel_parameters,
+                objects=objects,
+                relationships=relationships,
+                object_parameter_values=object_p_values,
+                relationship_parameter_values=rel_p_values,
+                alternatives=alternatives,
+                scenarios=scenarios,
+                scenario_alternatives=scenario_alternatives,
+            ))
         self.assertEqual(num_imports, 13)
-        self.assertFalse(errors)
 
 
-class TestImportObjectClass(unittest.TestCase):
+class TestImportObjectClass(ImportsTestCase):
     def test_import_object_class(self):
-        db_map = create_db_map()
-        _, errors = import_object_classes(db_map, ["new_class"])
-        self.assertFalse(errors)
-        db_map.commit_session("test")
-        self.assertIn("new_class", [oc.name for oc in db_map.query(db_map.object_class_sq)])
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(import_object_classes(db_map, ["new_class"]))
+            db_map.commit_session("test")
+            self.assertEqual(["new_class"], [oc.name for oc in db_map.query(db_map.object_class_sq)])
 
 
-class TestImportObject(unittest.TestCase):
+class TestImportObject(ImportsTestCase):
     def test_import_valid_objects(self):
-        db_map = create_db_map()
-        import_object_classes(db_map, ["object_class"])
-        _, errors = import_objects(db_map, [["object_class", "new_object"]])
-        self.assertFalse(errors)
-        db_map.commit_session("test")
-        self.assertIn("new_object", [o.name for o in db_map.query(db_map.object_sq)])
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            import_object_classes(db_map, ["object_class"])
+            _, errors = import_objects(db_map, [["object_class", "new_object"]])
+            self.assertFalse(errors)
+            db_map.commit_session("test")
+            self.assertIn("new_object", [o.name for o in db_map.query(db_map.object_sq)])
 
     def test_import_object_with_invalid_object_class_name(self):
-        db_map = create_db_map()
-        _, errors = import_objects(db_map, [["nonexistent_class", "new_object"]])
-        self.assertTrue(errors)
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            _, errors = import_objects(db_map, [["nonexistent_class", "new_object"]])
+            self.assertTrue(errors)
 
     def test_import_two_objects_with_same_name(self):
-        db_map = create_db_map()
-        import_object_classes(db_map, ["object_class1", "object_class2"])
-        _, errors = import_objects(db_map, [["object_class1", "object"], ["object_class2", "object"]])
-        self.assertFalse(errors)
-        db_map.commit_session("test")
-        objects = {
-            o.class_name: o.name
-            for o in db_map.query(
-                db_map.object_sq.c.name.label("name"), db_map.object_class_sq.c.name.label("class_name")
-            )
-        }
-        expected = {"object_class1": "object", "object_class2": "object"}
-        self.assertEqual(objects, expected)
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            import_object_classes(db_map, ["object_class1", "object_class2"])
+            _, errors = import_objects(db_map, [["object_class1", "object"], ["object_class2", "object"]])
+            self.assertFalse(errors)
+            db_map.commit_session("test")
+            objects = {
+                o.class_name: o.name
+                for o in db_map.query(
+                    db_map.object_sq.c.name.label("name"), db_map.object_class_sq.c.name.label("class_name")
+                )
+            }
+            expected = {"object_class1": "object", "object_class2": "object"}
+            self.assertEqual(objects, expected)
 
     def test_import_existing_object(self):
-        db_map = create_db_map()
-        import_object_classes(db_map, ["object_class"])
-        import_objects(db_map, [["object_class", "object"]])
-        db_map.commit_session("test")
-        self.assertIn("object", [o.name for o in db_map.query(db_map.object_sq)])
-        _, errors = import_objects(db_map, [["object_class", "object"]])
-        self.assertFalse(errors)
-        self.assertIn("object", [o.name for o in db_map.query(db_map.object_sq)])
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            import_object_classes(db_map, ["object_class"])
+            import_objects(db_map, [["object_class", "object"]])
+            db_map.commit_session("test")
+            self.assertIn("object", [o.name for o in db_map.query(db_map.object_sq)])
+            _, errors = import_objects(db_map, [["object_class", "object"]])
+            self.assertFalse(errors)
+            self.assertIn("object", [o.name for o in db_map.query(db_map.object_sq)])
 
 
-class TestImportRelationshipClass(unittest.TestCase):
+class TestImportRelationshipClass(ImportsTestCase):
     def test_import_valid_relationship_class(self):
-        db_map = create_db_map()
-        import_object_classes(db_map, ["object_class1", "object_class2"])
-        _, errors = import_relationship_classes(db_map, [["relationship_class", ["object_class1", "object_class2"]]])
-        self.assertFalse(errors)
-        db_map.commit_session("test")
-        relationship_classes = {
-            rc.name: rc.object_class_name_list for rc in db_map.query(db_map.wide_relationship_class_sq)
-        }
-        expected = {"relationship_class": "object_class1,object_class2"}
-        self.assertEqual(relationship_classes, expected)
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            import_object_classes(db_map, ["object_class1", "object_class2"])
+            _, errors = import_relationship_classes(db_map, [["relationship_class", ["object_class1", "object_class2"]]])
+            self.assertFalse(errors)
+            db_map.commit_session("test")
+            relationship_classes = {
+                rc.name: rc.object_class_name_list for rc in db_map.query(db_map.wide_relationship_class_sq)
+            }
+            expected = {"relationship_class": "object_class1,object_class2"}
+            self.assertEqual(relationship_classes, expected)
 
     def test_import_relationship_class_with_invalid_object_class_name(self):
-        db_map = create_db_map()
-        import_object_classes(db_map, ["object_class"])
-        _, errors = import_relationship_classes(db_map, [["relationship_class", ["object_class", "nonexistent"]]])
-        self.assertTrue(errors)
-        db_map.commit_session("test")
-        self.assertFalse(db_map.query(db_map.wide_relationship_class_sq).all())
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            import_object_classes(db_map, ["object_class"])
+            _, errors = import_relationship_classes(db_map, [["relationship_class", ["object_class", "nonexistent"]]])
+            self.assertTrue(errors)
+            db_map.commit_session("test")
+            self.assertFalse(db_map.query(db_map.wide_relationship_class_sq).all())
 
     def test_import_relationship_class_name_twice(self):
-        db_map = create_db_map()
-        import_object_classes(db_map, ["object_class1", "object_class2"])
-        _, errors = import_relationship_classes(
-            db_map, [["new_rc", ["object_class1", "object_class2"]], ["new_rc", ["object_class1", "object_class2"]]]
-        )
-        self.assertFalse(errors)
-        db_map.commit_session("test")
-        relationship_classes = {
-            rc.name: rc.object_class_name_list for rc in db_map.query(db_map.wide_relationship_class_sq)
-        }
-        expected = {"new_rc": "object_class1,object_class2"}
-        self.assertEqual(relationship_classes, expected)
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            import_object_classes(db_map, ["object_class1", "object_class2"])
+            _, errors = import_relationship_classes(
+                db_map, [["new_rc", ["object_class1", "object_class2"]], ["new_rc", ["object_class1", "object_class2"]]]
+            )
+            self.assertFalse(errors)
+            db_map.commit_session("test")
+            relationship_classes = {
+                rc.name: rc.object_class_name_list for rc in db_map.query(db_map.wide_relationship_class_sq)
+            }
+            expected = {"new_rc": "object_class1,object_class2"}
+            self.assertEqual(relationship_classes, expected)
 
     def test_import_existing_relationship_class(self):
-        db_map = create_db_map()
-        import_object_classes(db_map, ["object_class1", "object_class2"])
-        import_relationship_classes(db_map, [["rc", ["object_class1", "object_class2"]]])
-        _, errors = import_relationship_classes(db_map, [["rc", ["object_class1", "object_class2"]]])
-        self.assertFalse(errors)
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            import_object_classes(db_map, ["object_class1", "object_class2"])
+            import_relationship_classes(db_map, [["rc", ["object_class1", "object_class2"]]])
+            _, errors = import_relationship_classes(db_map, [["rc", ["object_class1", "object_class2"]]])
+            self.assertFalse(errors)
 
     def test_import_relationship_class_with_one_object_class_as_None(self):
-        db_map = create_db_map()
-        import_object_classes(db_map, ["object_class1"])
-        _, errors = import_relationship_classes(db_map, [["new_rc", ["object_class", None]]])
-        self.assertTrue(errors)
-        db_map.commit_session("test")
-        self.assertFalse([rc for rc in db_map.query(db_map.wide_relationship_class_sq)])
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            import_object_classes(db_map, ["object_class1"])
+            _, errors = import_relationship_classes(db_map, [["new_rc", ["object_class", None]]])
+            self.assertTrue(errors)
+            db_map.commit_session("test")
+            self.assertFalse([rc for rc in db_map.query(db_map.wide_relationship_class_sq)])
 
 
-class TestImportObjectClassParameter(unittest.TestCase):
+class TestImportObjectClassParameter(ImportsTestCase):
     def test_import_valid_object_class_parameter(self):
-        db_map = create_db_map()
-        import_object_classes(db_map, ["object_class"])
-        _, errors = import_object_parameters(db_map, [["object_class", "new_parameter"]])
-        self.assertFalse(errors)
-        db_map.commit_session("test")
-        self.assertIn("new_parameter", [p.name for p in db_map.query(db_map.parameter_definition_sq)])
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            import_object_classes(db_map, ["object_class"])
+            _, errors = import_object_parameters(db_map, [["object_class", "new_parameter"]])
+            self.assertFalse(errors)
+            db_map.commit_session("test")
+            self.assertIn("new_parameter", [p.name for p in db_map.query(db_map.parameter_definition_sq)])
 
     def test_import_parameter_with_invalid_object_class_name(self):
-        db_map = create_db_map()
-        _, errors = import_object_parameters(db_map, [["nonexistent_object_class", "new_parameter"]])
-        self.assertTrue(errors)
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            _, errors = import_object_parameters(db_map, [["nonexistent_object_class", "new_parameter"]])
+            self.assertTrue(errors)
 
     def test_import_object_class_parameter_name_twice(self):
-        db_map = create_db_map()
-        import_object_classes(db_map, ["object_class1", "object_class2"])
-        _, errors = import_object_parameters(
-            db_map, [["object_class1", "new_parameter"], ["object_class2", "new_parameter"]]
-        )
-        self.assertFalse(errors)
-        db_map.commit_session("test")
-        definitions = {
-            definition.object_class_name: definition.parameter_name
-            for definition in db_map.query(db_map.object_parameter_definition_sq)
-        }
-        expected = {"object_class1": "new_parameter", "object_class2": "new_parameter"}
-        self.assertEqual(definitions, expected)
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            import_object_classes(db_map, ["object_class1", "object_class2"])
+            _, errors = import_object_parameters(
+                db_map, [["object_class1", "new_parameter"], ["object_class2", "new_parameter"]]
+            )
+            self.assertFalse(errors)
+            db_map.commit_session("test")
+            definitions = {
+                definition.object_class_name: definition.parameter_name
+                for definition in db_map.query(db_map.object_parameter_definition_sq)
+            }
+            expected = {"object_class1": "new_parameter", "object_class2": "new_parameter"}
+            self.assertEqual(definitions, expected)
 
     def test_import_existing_object_class_parameter(self):
-        db_map = create_db_map()
-        import_object_classes(db_map, ["object_class"])
-        import_object_parameters(db_map, [["object_class", "parameter"]])
-        db_map.commit_session("test")
-        self.assertIn("parameter", [p.name for p in db_map.query(db_map.parameter_definition_sq)])
-        _, errors = import_object_parameters(db_map, [["object_class", "parameter"]])
-        self.assertIn("parameter", [p.name for p in db_map.query(db_map.parameter_definition_sq)])
-        self.assertFalse(errors)
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            import_object_classes(db_map, ["object_class"])
+            import_object_parameters(db_map, [["object_class", "parameter"]])
+            db_map.commit_session("test")
+            self.assertIn("parameter", [p.name for p in db_map.query(db_map.parameter_definition_sq)])
+            _, errors = import_object_parameters(db_map, [["object_class", "parameter"]])
+            self.assertIn("parameter", [p.name for p in db_map.query(db_map.parameter_definition_sq)])
+            self.assertFalse(errors)
 
     def test_import_object_class_parameter_with_null_default_value_and_db_server_unparsing(self):
-        db_map = DatabaseMapping("sqlite://", create=True)
-        import_object_classes(db_map, ["object_class"])
-        _, errors = import_object_parameters(
-            db_map, [["object_class", "parameter", [None, None]]], unparse_value=_unparse_value
-        )
-        self.assertEqual(errors, [])
-        db_map.commit_session("Add test data.")
-        parameters = db_map.query(db_map.object_parameter_definition_sq).all()
-        self.assertEqual(len(parameters), 1)
-        self.assertIsNone(parameters[0].default_value)
-        self.assertIsNone(parameters[0].default_type)
-        db_map.close()
-
-
-class TestImportRelationshipClassParameter(unittest.TestCase):
-    def test_import_valid_relationship_class_parameter(self):
-        db_map = create_db_map()
-        import_object_classes(db_map, ["object_class1", "object_class2"])
-        import_relationship_classes(db_map, [["relationship_class", ["object_class1", "object_class2"]]])
-        _, errors = import_relationship_parameters(db_map, [["relationship_class", "new_parameter"]])
-        self.assertFalse(errors)
-        db_map.commit_session("test")
-        definitions = {
-            d.class_name: d.name
-            for d in db_map.query(
-                db_map.relationship_parameter_definition_sq.c.parameter_name.label("name"),
-                db_map.relationship_class_sq.c.name.label("class_name"),
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            import_object_classes(db_map, ["object_class"])
+            _, errors = import_object_parameters(
+                db_map, [["object_class", "parameter", [None, None]]], unparse_value=_unparse_value
             )
-        }
-        expected = {"relationship_class": "new_parameter"}
-        self.assertEqual(definitions, expected)
-        db_map.close()
+            self.assertEqual(errors, [])
+            db_map.commit_session("Add test data.")
+            parameters = db_map.query(db_map.object_parameter_definition_sq).all()
+            self.assertEqual(len(parameters), 1)
+            self.assertIsNone(parameters[0].default_value)
+            self.assertIsNone(parameters[0].default_type)
+
+
+class TestImportRelationshipClassParameter(ImportsTestCase):
+    def test_import_valid_relationship_class_parameter(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            import_object_classes(db_map, ["object_class1", "object_class2"])
+            import_relationship_classes(db_map, [["relationship_class", ["object_class1", "object_class2"]]])
+            _, errors = import_relationship_parameters(db_map, [["relationship_class", "new_parameter"]])
+            self.assertFalse(errors)
+            db_map.commit_session("test")
+            definitions = {
+                d.class_name: d.name
+                for d in db_map.query(
+                    db_map.relationship_parameter_definition_sq.c.parameter_name.label("name"),
+                    db_map.relationship_class_sq.c.name.label("class_name"),
+                )
+            }
+            expected = {"relationship_class": "new_parameter"}
+            self.assertEqual(definitions, expected)
 
     def test_import_parameter_with_invalid_relationship_class_name(self):
-        db_map = create_db_map()
-        _, errors = import_relationship_parameters(db_map, [["nonexistent_relationship_class", "new_parameter"]])
-        self.assertTrue(errors)
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            _, errors = import_relationship_parameters(db_map, [["nonexistent_relationship_class", "new_parameter"]])
+            self.assertTrue(errors)
 
     def test_import_relationship_class_parameter_name_twice(self):
-        db_map = create_db_map()
-        import_object_classes(db_map, ["object_class1", "object_class2"])
-        import_relationship_classes(
-            db_map,
-            [
-                ["relationship_class1", ["object_class1", "object_class2"]],
-                ["relationship_class2", ["object_class2", "object_class1"]],
-            ],
-        )
-        _, errors = import_relationship_parameters(
-            db_map, [["relationship_class1", "new_parameter"], ["relationship_class2", "new_parameter"]]
-        )
-        self.assertFalse(errors)
-        db_map.commit_session("test")
-        definitions = {
-            d.class_name: d.name
-            for d in db_map.query(
-                db_map.relationship_parameter_definition_sq.c.parameter_name.label("name"),
-                db_map.relationship_class_sq.c.name.label("class_name"),
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            import_object_classes(db_map, ["object_class1", "object_class2"])
+            import_relationship_classes(
+                db_map,
+                [
+                    ["relationship_class1", ["object_class1", "object_class2"]],
+                    ["relationship_class2", ["object_class2", "object_class1"]],
+                ],
             )
-        }
-        expected = {"relationship_class1": "new_parameter", "relationship_class2": "new_parameter"}
-        self.assertEqual(definitions, expected)
-        db_map.close()
+            _, errors = import_relationship_parameters(
+                db_map, [["relationship_class1", "new_parameter"], ["relationship_class2", "new_parameter"]]
+            )
+            self.assertFalse(errors)
+            db_map.commit_session("test")
+            definitions = {
+                d.class_name: d.name
+                for d in db_map.query(
+                    db_map.relationship_parameter_definition_sq.c.parameter_name.label("name"),
+                    db_map.relationship_class_sq.c.name.label("class_name"),
+                )
+            }
+            expected = {"relationship_class1": "new_parameter", "relationship_class2": "new_parameter"}
+            self.assertEqual(definitions, expected)
 
     def test_import_existing_relationship_class_parameter(self):
-        db_map = create_db_map()
-        import_object_classes(db_map, ["object_class1", "object_class2"])
-        import_relationship_classes(db_map, [["relationship_class", ["object_class1", "object_class2"]]])
-        import_relationship_parameters(db_map, [["relationship_class", "new_parameter"]])
-        _, errors = import_relationship_parameters(db_map, [["relationship_class", "new_parameter"]])
-        self.assertFalse(errors)
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            import_object_classes(db_map, ["object_class1", "object_class2"])
+            import_relationship_classes(db_map, [["relationship_class", ["object_class1", "object_class2"]]])
+            import_relationship_parameters(db_map, [["relationship_class", "new_parameter"]])
+            _, errors = import_relationship_parameters(db_map, [["relationship_class", "new_parameter"]])
+            self.assertFalse(errors)
 
 
-class TestImportEntityClasses(unittest.TestCase):
-    def _assert_success(self, result):
-        items, errors = result
-        self.assertEqual(errors, [])
-        return items
-
+class TestImportEntityClasses(ImportsTestCase):
     def test_import_object_class_with_all_optional_data(self):
         with DatabaseMapping("sqlite://", create=True) as db_map:
             self._assert_success(
@@ -373,766 +346,698 @@ class TestImportEntityClasses(unittest.TestCase):
             self.assertCountEqual(data, expected)
 
 
-class TestImportEntity(unittest.TestCase):
+class TestImportEntity(ImportsTestCase):
     def test_import_multi_d_entity_twice(self):
-        db_map = DatabaseMapping("sqlite://", create=True)
-        import_data(
-            db_map,
-            entity_classes=(
-                ("object_class1",),
-                ("object_class2",),
-                ("relationship_class", ("object_class1", "object_class2")),
-            ),
-            entities=(
-                ("object_class1", "object1"),
-                ("object_class2", "object2"),
-                ("relationship_class", ("object1", "object2")),
-            ),
-        )
-        count, errors = import_data(db_map, entities=(("relationship_class", ("object1", "object2")),))
-        self.assertEqual(count, 0)
-        self.assertEqual(errors, [])
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            import_data(
+                db_map,
+                entity_classes=(
+                    ("object_class1",),
+                    ("object_class2",),
+                    ("relationship_class", ("object_class1", "object_class2")),
+                ),
+                entities=(
+                    ("object_class1", "object1"),
+                    ("object_class2", "object2"),
+                    ("relationship_class", ("object1", "object2")),
+                ),
+            )
+            count, errors = import_data(db_map, entities=(("relationship_class", ("object1", "object2")),))
+            self.assertEqual(count, 0)
+            self.assertEqual(errors, [])
 
 
-class TestImportRelationship(unittest.TestCase):
-    @staticmethod
-    def populate(db_map):
-        import_object_classes(db_map, ["object_class1", "object_class2"])
-        import_objects(db_map, [["object_class1", "object1"], ["object_class2", "object2"]])
+class TestImportRelationship(ImportsTestCase):
+    def populate(self, db_map):
+        self._assert_success(import_object_classes(db_map, ["object_class1", "object_class2"]))
+        self._assert_success(import_objects(db_map, [["object_class1", "object1"], ["object_class2", "object2"]]))
 
     def test_import_relationships(self):
-        db_map = DatabaseMapping("sqlite://", create=True)
-        import_object_classes(db_map, ("object_class",))
-        import_objects(db_map, (("object_class", "object"),))
-        import_relationship_classes(db_map, (("relationship_class", ("object_class",)),))
-        _, errors = import_relationships(db_map, (("relationship_class", ("object",)),))
-        self.assertFalse(errors)
-        db_map.commit_session("test")
-        self.assertIn("object__", [r.name for r in db_map.query(db_map.relationship_sq)])
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(import_object_classes(db_map, ("object_class",)))
+            self._assert_success(import_objects(db_map, (("object_class", "object"),)))
+            self._assert_success(import_relationship_classes(db_map, (("relationship_class", ("object_class",)),)))
+            self._assert_success(import_relationships(db_map, (("relationship_class", ("object",)),)))
+            db_map.commit_session("test")
+            self.assertIn("object__", [r.name for r in db_map.query(db_map.relationship_sq)])
 
     def test_import_valid_relationship(self):
-        db_map = create_db_map()
-        self.populate(db_map)
-        import_relationship_classes(db_map, [["relationship_class", ["object_class1", "object_class2"]]])
-        _, errors = import_relationships(db_map, [["relationship_class", ["object1", "object2"]]])
-        self.assertFalse(errors)
-        db_map.commit_session("test")
-        self.assertIn("object1__object2", [r.name for r in db_map.query(db_map.relationship_sq)])
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self.populate(db_map)
+            self._assert_success(import_relationship_classes(db_map, [["relationship_class", ["object_class1", "object_class2"]]]))
+            self._assert_success(import_relationships(db_map, [["relationship_class", ["object1", "object2"]]]))
+            db_map.commit_session("test")
+            self.assertIn("object1__object2", [r.name for r in db_map.query(db_map.relationship_sq)])
 
     def test_import_valid_relationship_with_object_name_in_multiple_classes(self):
-        db_map = create_db_map()
-        self.populate(db_map)
-        import_objects(db_map, [["object_class1", "duplicate"], ["object_class2", "duplicate"]])
-        import_relationship_classes(db_map, [["relationship_class", ["object_class1", "object_class2"]]])
-        _, errors = import_relationships(db_map, [["relationship_class", ["duplicate", "object2"]]])
-        self.assertFalse(errors)
-        db_map.commit_session("test")
-        self.assertIn("duplicate__object2", [r.name for r in db_map.query(db_map.relationship_sq)])
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self.populate(db_map)
+            self._assert_success(import_objects(db_map, [["object_class1", "duplicate"], ["object_class2", "duplicate"]]))
+            self._assert_success(import_relationship_classes(db_map, [["relationship_class", ["object_class1", "object_class2"]]]))
+            self._assert_success(import_relationships(db_map, [["relationship_class", ["duplicate", "object2"]]]))
+            db_map.commit_session("test")
+            self.assertIn("duplicate__object2", [r.name for r in db_map.query(db_map.relationship_sq)])
 
     def test_import_relationship_with_invalid_class_name(self):
-        db_map = create_db_map()
-        self.populate(db_map)
-        _, errors = import_relationships(db_map, [["nonexistent_relationship_class", ["object1", "object2"]]])
-        self.assertTrue(errors)
-        db_map.commit_session("test")
-        self.assertFalse([r.name for r in db_map.query(db_map.relationship_sq)])
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self.populate(db_map)
+            _, errors = import_relationships(db_map, [["nonexistent_relationship_class", ["object1", "object2"]]])
+            self.assertTrue(errors)
+            db_map.commit_session("test")
+            self.assertFalse([r.name for r in db_map.query(db_map.relationship_sq)])
 
     def test_import_relationship_with_invalid_object_name(self):
-        db_map = create_db_map()
-        self.populate(db_map)
-        import_relationship_classes(db_map, [["relationship_class", ["object_class1", "object_class2"]]])
-        _, errors = import_relationships(db_map, [["relationship_class", ["nonexistent_object", "object2"]]])
-        self.assertTrue(errors)
-        db_map.commit_session("test")
-        self.assertFalse([r.name for r in db_map.query(db_map.relationship_sq)])
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self.populate(db_map)
+            self._assert_success(import_relationship_classes(db_map, [["relationship_class", ["object_class1", "object_class2"]]]))
+            _, errors = import_relationships(db_map, [["relationship_class", ["nonexistent_object", "object2"]]])
+            self.assertTrue(errors)
+            db_map.commit_session("test")
+            self.assertFalse([r.name for r in db_map.query(db_map.relationship_sq)])
 
     def test_import_existing_relationship(self):
-        db_map = create_db_map()
-        self.populate(db_map)
-        import_relationship_classes(db_map, [["relationship_class", ["object_class1", "object_class2"]]])
-        import_relationships(db_map, [["relationship_class", ["object1", "object2"]]])
-        db_map.commit_session("test")
-        self.assertIn("object1__object2", [r.name for r in db_map.query(db_map.relationship_sq)])
-        _, errors = import_relationships(db_map, [["relationship_class", ["object1", "object2"]]])
-        self.assertFalse(errors)
-        self.assertIn("object1__object2", [r.name for r in db_map.query(db_map.relationship_sq)])
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self.populate(db_map)
+            self._assert_success(import_relationship_classes(db_map, [["relationship_class", ["object_class1", "object_class2"]]]))
+            self._assert_success(import_relationships(db_map, [["relationship_class", ["object1", "object2"]]]))
+            db_map.commit_session("test")
+            self.assertIn("object1__object2", [r.name for r in db_map.query(db_map.relationship_sq)])
+            self._assert_success(import_relationships(db_map, [["relationship_class", ["object1", "object2"]]]))
+            self.assertIn("object1__object2", [r.name for r in db_map.query(db_map.relationship_sq)])
 
     def test_import_relationship_with_one_None_object(self):
-        db_map = create_db_map()
-        self.populate(db_map)
-        import_relationship_classes(db_map, [["relationship_class", ["object_class1", "object_class2"]]])
-        _, errors = import_relationships(db_map, [["relationship_class", [None, "object2"]]])
-        self.assertTrue(errors)
-        db_map.commit_session("test")
-        self.assertFalse([r.name for r in db_map.query(db_map.relationship_sq)])
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self.populate(db_map)
+            import_relationship_classes(db_map, [["relationship_class", ["object_class1", "object_class2"]]])
+            _, errors = import_relationships(db_map, [["relationship_class", [None, "object2"]]])
+            self.assertTrue(errors)
+            db_map.commit_session("test")
+            self.assertFalse([r.name for r in db_map.query(db_map.relationship_sq)])
 
     def test_import_multi_d_entity_with_elements_from_superclass(self):
-        db_map = create_db_map()
-        import_data(
-            db_map,
-            entity_classes=[
-                ["object_class1", []],
-                ["object_class2", []],
-                ["superclass", []],
-                ["relationship_class1", ["superclass", "superclass"]],
-            ],
-            superclass_subclasses=[["superclass", "object_class1"], ["superclass", "object_class2"]],
-            entities=[["object_class1", "object1"], ["object_class2", "object2"]],
-        )
-        _, errors = import_data(db_map, entities=[["relationship_class1", ["object1", "object2"]]])
-        self.assertFalse(errors)
-        db_map.commit_session("test")
-        entities = {
-            tuple(r.element_name_list.split(",")) if r.element_name_list else r.name: r.name
-            for r in db_map.query(db_map.wide_entity_sq)
-        }
-        self.assertTrue("object1" in entities)
-        self.assertTrue("object2" in entities)
-        self.assertTrue(("object1", "object2") in entities)
-        self.assertEqual(len(entities), 3)
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(import_data(
+                db_map,
+                entity_classes=[
+                    ["object_class1", []],
+                    ["object_class2", []],
+                    ["superclass", []],
+                    ["relationship_class1", ["superclass", "superclass"]],
+                ],
+                superclass_subclasses=[["superclass", "object_class1"], ["superclass", "object_class2"]],
+                entities=[["object_class1", "object1"], ["object_class2", "object2"]],
+            ))
+            self._assert_success(import_data(db_map, entities=[["relationship_class1", ["object1", "object2"]]]))
+            db_map.commit_session("test")
+            entities = {
+                tuple(r.element_name_list.split(",")) if r.element_name_list else r.name: r.name
+                for r in db_map.query(db_map.wide_entity_sq)
+            }
+            self.assertTrue("object1" in entities)
+            self.assertTrue("object2" in entities)
+            self.assertTrue(("object1", "object2") in entities)
+            self.assertEqual(len(entities), 3)
 
     def test_import_multi_d_entity_with_elements_from_superclass_fails_with_wrong_dimension_count(self):
-        db_map = create_db_map()
-        import_data(
-            db_map,
-            entity_classes=[
-                ["object_class1", []],
-                ["object_class2", []],
-                ["superclass", []],
-                ["relationship_class1", ["superclass", "superclass"]],
-            ],
-            superclass_subclasses=[["superclass", "object_class1"], ["superclass", "object_class2"]],
-            entities=[["object_class1", "object1"], ["object_class2", "object2"]],
-        )
-        _, errors = import_data(db_map, entities=[["relationship_class1", ["object1"]]])
-        self.assertEqual(len(errors), 1)
-        self.assertIn("too few elements", errors[0])
-        _, errors = import_data(db_map, entities=[["relationship_class1", ["object1", "object2", "object1"]]])
-        self.assertEqual(len(errors), 1)
-        self.assertIn("too many elements", errors[0])
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(import_data(
+                db_map,
+                entity_classes=[
+                    ["object_class1", []],
+                    ["object_class2", []],
+                    ["superclass", []],
+                    ["relationship_class1", ["superclass", "superclass"]],
+                ],
+                superclass_subclasses=[["superclass", "object_class1"], ["superclass", "object_class2"]],
+                entities=[["object_class1", "object1"], ["object_class2", "object2"]],
+            ))
+            _, errors = import_data(db_map, entities=[["relationship_class1", ["object1"]]])
+            self.assertEqual(len(errors), 1)
+            self.assertIn("too few elements", errors[0])
+            _, errors = import_data(db_map, entities=[["relationship_class1", ["object1", "object2", "object1"]]])
+            self.assertEqual(len(errors), 1)
+            self.assertIn("too many elements", errors[0])
 
     def test_import_multi_d_entity_with_multi_d_elements(self):
-        db_map = create_db_map()
-        self.populate(db_map)
-        import_data(
-            db_map,
-            entity_classes=[
-                ["relationship_class1", ["object_class1", "object_class2"]],
-                ["relationship_class2", ["object_class2", "object_class1"]],
-                ["meta_relationship_class", ["relationship_class1", "relationship_class2"]],
-            ],
-            entities=[["relationship_class1", ["object1", "object2"]], ["relationship_class2", ["object2", "object1"]]],
-        )
-        _, errors = import_data(
-            db_map, entities=[["meta_relationship_class", ["object1", "object2", "object2", "object1"]]]
-        )
-        self.assertFalse(errors)
-        db_map.commit_session("test")
-        entities = {
-            tuple(r.element_name_list.split(",")) if r.element_name_list else r.name: r.name
-            for r in db_map.query(db_map.wide_entity_sq)
-        }
-        self.assertTrue("object1" in entities)
-        self.assertTrue("object2" in entities)
-        self.assertTrue(("object1", "object2") in entities)
-        self.assertTrue(("object2", "object1") in entities)
-        self.assertTrue((entities["object1", "object2"], entities["object2", "object1"]) in entities)
-        self.assertEqual(len(entities), 5)
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self.populate(db_map)
+            self._assert_success(import_data(
+                db_map,
+                entity_classes=[
+                    ["relationship_class1", ["object_class1", "object_class2"]],
+                    ["relationship_class2", ["object_class2", "object_class1"]],
+                    ["meta_relationship_class", ["relationship_class1", "relationship_class2"]],
+                ],
+                entities=[["relationship_class1", ["object1", "object2"]], ["relationship_class2", ["object2", "object1"]]],
+            ))
+            self._assert_success(import_data(
+                db_map, entities=[["meta_relationship_class", ["object1", "object2", "object2", "object1"]]]
+            ))
+            db_map.commit_session("test")
+            entities = {
+                tuple(r.element_name_list.split(",")) if r.element_name_list else r.name: r.name
+                for r in db_map.query(db_map.wide_entity_sq)
+            }
+            self.assertTrue("object1" in entities)
+            self.assertTrue("object2" in entities)
+            self.assertTrue(("object1", "object2") in entities)
+            self.assertTrue(("object2", "object1") in entities)
+            self.assertTrue((entities["object1", "object2"], entities["object2", "object1"]) in entities)
+            self.assertEqual(len(entities), 5)
 
     def test_import_multi_d_entity_with_multi_d_elements_from_superclass(self):
-        db_map = create_db_map()
-        self.populate(db_map)
-        import_data(
-            db_map,
-            entity_classes=[
-                ["relationship_class1", ["object_class1", "object_class2"]],
-                ["relationship_class2", ["object_class2", "object_class1"]],
-                ["superclass", []],
-            ],
-            superclass_subclasses=[["superclass", "relationship_class1"], ["superclass", "relationship_class2"]],
-        )
-        import_data(
-            db_map,
-            entity_classes=[["meta_relationship_class", ["superclass", "superclass"]]],
-            entities=[["relationship_class1", ["object1", "object2"]], ["relationship_class2", ["object2", "object1"]]],
-        )
-        _, errors = import_data(
-            db_map, entities=[["meta_relationship_class", ["object1", "object2", "object2", "object1"]]]
-        )
-        self.assertFalse(errors)
-        db_map.commit_session("test")
-        entities = {
-            tuple(r.element_name_list.split(",")) if r.element_name_list else r.name: r.name
-            for r in db_map.query(db_map.wide_entity_sq)
-        }
-        self.assertTrue("object1" in entities)
-        self.assertTrue("object2" in entities)
-        self.assertTrue(("object1", "object2") in entities)
-        self.assertTrue(("object2", "object1") in entities)
-        self.assertTrue((entities["object1", "object2"], entities["object2", "object1"]) in entities)
-        self.assertEqual(len(entities), 5)
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self.populate(db_map)
+            self._assert_success(import_data(
+                db_map,
+                entity_classes=[
+                    ["relationship_class1", ["object_class1", "object_class2"]],
+                    ["relationship_class2", ["object_class2", "object_class1"]],
+                    ["superclass", []],
+                ],
+                superclass_subclasses=[["superclass", "relationship_class1"], ["superclass", "relationship_class2"]],
+            ))
+            self._assert_success(import_data(
+                db_map,
+                entity_classes=[["meta_relationship_class", ["superclass", "superclass"]]],
+                entities=[["relationship_class1", ["object1", "object2"]], ["relationship_class2", ["object2", "object1"]]],
+            ))
+            self._assert_success(import_data(
+                db_map, entities=[["meta_relationship_class", ["object1", "object2", "object2", "object1"]]]
+            ))
+            db_map.commit_session("test")
+            entities = {
+                tuple(r.element_name_list.split(",")) if r.element_name_list else r.name: r.name
+                for r in db_map.query(db_map.wide_entity_sq)
+            }
+            self.assertTrue("object1" in entities)
+            self.assertTrue("object2" in entities)
+            self.assertTrue(("object1", "object2") in entities)
+            self.assertTrue(("object2", "object1") in entities)
+            self.assertTrue((entities["object1", "object2"], entities["object2", "object1"]) in entities)
+            self.assertEqual(len(entities), 5)
 
     def test_import_multi_d_entity_with_multi_d_elements_from_superclass_fails_with_wrong_dimension_count(self):
-        db_map = create_db_map()
-        self.populate(db_map)
-        import_data(
-            db_map,
-            entity_classes=[
-                ["relationship_class1", ["object_class1", "object_class2"]],
-                ["relationship_class2", ["object_class2", "object_class1"]],
-                ["superclass", []],
-            ],
-            superclass_subclasses=[["superclass", "relationship_class1"], ["superclass", "relationship_class2"]],
-        )
-        import_data(
-            db_map,
-            entity_classes=[["meta_relationship_class", ["superclass", "superclass"]]],
-            entities=[["relationship_class1", ["object1", "object2"]], ["relationship_class2", ["object2", "object1"]]],
-        )
-        _, errors = import_data(db_map, entities=[["meta_relationship_class", ["object1", "object2", "object2"]]])
-        self.assertEqual(len(errors), 1)
-        self.assertIn("too few elements", errors[0])
-        _, errors = import_data(
-            db_map, entities=[["meta_relationship_class", ["object1", "object2", "object2", "object1", "object1"]]]
-        )
-        self.assertEqual(len(errors), 1)
-        self.assertIn("too many elements", errors[0])
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self.populate(db_map)
+            self._assert_success(import_data(
+                db_map,
+                entity_classes=[
+                    ["relationship_class1", ["object_class1", "object_class2"]],
+                    ["relationship_class2", ["object_class2", "object_class1"]],
+                    ["superclass", []],
+                ],
+                superclass_subclasses=[["superclass", "relationship_class1"], ["superclass", "relationship_class2"]],
+            ))
+            self._assert_success(import_data(
+                db_map,
+                entity_classes=[["meta_relationship_class", ["superclass", "superclass"]]],
+                entities=[["relationship_class1", ["object1", "object2"]], ["relationship_class2", ["object2", "object1"]]],
+            ))
+            _, errors = import_data(db_map, entities=[["meta_relationship_class", ["object1", "object2", "object2"]]])
+            self.assertEqual(len(errors), 1)
+            self.assertIn("too few elements", errors[0])
+            _, errors = import_data(
+                db_map, entities=[["meta_relationship_class", ["object1", "object2", "object2", "object1", "object1"]]]
+            )
+            self.assertEqual(len(errors), 1)
+            self.assertIn("too many elements", errors[0])
 
 
-class TestImportParameterDefinition(unittest.TestCase):
-    def setUp(self):
-        self._db_map = DatabaseMapping("sqlite://", create=True)
-
-    def tearDown(self):
-        self._db_map.close()
-
+class TestImportParameterDefinition(ImportsTestCase):
     def test_import_object_parameter_definition(self):
-        import_object_classes(self._db_map, ["my_object_class"])
-        count, errors = import_object_parameters(self._db_map, (("my_object_class", "my_parameter"),))
-        self.assertEqual(errors, [])
-        self.assertEqual(count, 1)
-        self._db_map.commit_session("Add test data.")
-        parameter_definitions = [dict(row) for row in self._db_map.query(self._db_map.object_parameter_definition_sq)]
-        self.assertEqual(
-            parameter_definitions,
-            [
-                {
-                    "default_type": None,
-                    "default_value": None,
-                    "description": None,
-                    "entity_class_id": 1,
-                    "entity_class_name": "my_object_class",
-                    "id": 1,
-                    "object_class_id": 1,
-                    "object_class_name": "my_object_class",
-                    "parameter_name": "my_parameter",
-                    "value_list_id": None,
-                    "value_list_name": None,
-                }
-            ],
-        )
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(import_object_classes(db_map, ["my_object_class"]))
+            count = self._assert_success(import_object_parameters(db_map, (("my_object_class", "my_parameter"),)))
+            self.assertEqual(count, 1)
+            db_map.commit_session("Add test data.")
+            parameter_definitions = [dict(row) for row in db_map.query(db_map.object_parameter_definition_sq)]
+            self.assertEqual(
+                parameter_definitions,
+                [
+                    {
+                        "default_type": None,
+                        "default_value": None,
+                        "description": None,
+                        "entity_class_id": 1,
+                        "entity_class_name": "my_object_class",
+                        "id": 1,
+                        "object_class_id": 1,
+                        "object_class_name": "my_object_class",
+                        "parameter_name": "my_parameter",
+                        "value_list_id": None,
+                        "value_list_name": None,
+                    }
+                ],
+            )
 
     def test_import_object_parameter_definition_with_value_list(self):
-        import_object_classes(self._db_map, ["my_object_class"])
-        import_parameter_value_lists(self._db_map, (("my_list", 99.0),))
-        count, errors = import_object_parameters(self._db_map, (("my_object_class", "my_parameter", None, "my_list"),))
-        self.assertEqual(errors, [])
-        self.assertEqual(count, 1)
-        self._db_map.commit_session("Add test data.")
-        parameter_definitions = [dict(row) for row in self._db_map.query(self._db_map.object_parameter_definition_sq)]
-        self.assertEqual(
-            parameter_definitions,
-            [
-                {
-                    "default_type": None,
-                    "default_value": b"null",
-                    "description": None,
-                    "entity_class_id": 1,
-                    "entity_class_name": "my_object_class",
-                    "id": 1,
-                    "object_class_id": 1,
-                    "object_class_name": "my_object_class",
-                    "parameter_name": "my_parameter",
-                    "value_list_id": 1,
-                    "value_list_name": "my_list",
-                }
-            ],
-        )
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(import_object_classes(db_map, ["my_object_class"]))
+            self._assert_success(import_parameter_value_lists(db_map, (("my_list", 99.0),)))
+            count = self._assert_success(import_object_parameters(db_map, (("my_object_class", "my_parameter", None, "my_list"),)))
+            self.assertEqual(count, 1)
+            db_map.commit_session("Add test data.")
+            parameter_definitions = [dict(row) for row in db_map.query(db_map.object_parameter_definition_sq)]
+            self.assertEqual(
+                parameter_definitions,
+                [
+                    {
+                        "default_type": None,
+                        "default_value": b"null",
+                        "description": None,
+                        "entity_class_id": 1,
+                        "entity_class_name": "my_object_class",
+                        "id": 1,
+                        "object_class_id": 1,
+                        "object_class_name": "my_object_class",
+                        "parameter_name": "my_parameter",
+                        "value_list_id": 1,
+                        "value_list_name": "my_list",
+                    }
+                ],
+            )
 
     def test_import_object_parameter_definition_with_default_value_from_value_list(self):
-        import_object_classes(self._db_map, ["my_object_class"])
-        import_parameter_value_lists(self._db_map, (("my_list", 99.0),))
-        count, errors = import_object_parameters(self._db_map, (("my_object_class", "my_parameter", 99.0, "my_list"),))
-        self.assertEqual(errors, [])
-        self.assertEqual(count, 1)
-        self._db_map.commit_session("Add test data.")
-        parameter_definitions = [dict(row) for row in self._db_map.query(self._db_map.object_parameter_definition_sq)]
-        self.assertEqual(
-            parameter_definitions,
-            [
-                {
-                    "default_type": "float",
-                    "default_value": b"99.0",
-                    "description": None,
-                    "entity_class_id": 1,
-                    "entity_class_name": "my_object_class",
-                    "id": 1,
-                    "object_class_id": 1,
-                    "object_class_name": "my_object_class",
-                    "parameter_name": "my_parameter",
-                    "value_list_id": 1,
-                    "value_list_name": "my_list",
-                }
-            ],
-        )
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(import_object_classes(db_map, ["my_object_class"]))
+            self._assert_success(import_parameter_value_lists(db_map, (("my_list", 99.0),)))
+            count = self._assert_success(import_object_parameters(db_map, (("my_object_class", "my_parameter", 99.0, "my_list"),)))
+            self.assertEqual(count, 1)
+            db_map.commit_session("Add test data.")
+            parameter_definitions = [dict(row) for row in db_map.query(db_map.object_parameter_definition_sq)]
+            self.assertEqual(
+                parameter_definitions,
+                [
+                    {
+                        "default_type": "float",
+                        "default_value": b"99.0",
+                        "description": None,
+                        "entity_class_id": 1,
+                        "entity_class_name": "my_object_class",
+                        "id": 1,
+                        "object_class_id": 1,
+                        "object_class_name": "my_object_class",
+                        "parameter_name": "my_parameter",
+                        "value_list_id": 1,
+                        "value_list_name": "my_list",
+                    }
+                ],
+            )
 
     def test_import_object_parameter_definition_with_default_value_from_value_list_fails_gracefully(self):
-        import_object_classes(self._db_map, ["my_object_class"])
-        import_parameter_value_lists(self._db_map, (("my_list", 99.0),))
-        count, errors = import_object_parameters(self._db_map, (("my_object_class", "my_parameter", 23.0, "my_list"),))
-        self.assertEqual(errors, ["default value 23.0 of my_parameter is not in my_list"])
-        self.assertEqual(count, 0)
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(import_object_classes(db_map, ["my_object_class"]))
+            self._assert_success(import_parameter_value_lists(db_map, (("my_list", 99.0),)))
+            count, errors = import_object_parameters(db_map, (("my_object_class", "my_parameter", 23.0, "my_list"),))
+            self.assertEqual(errors, ["default value 23.0 of my_parameter is not in my_list"])
+            self.assertEqual(count, 0)
 
 
-class TestImportParameterValue(unittest.TestCase):
-    @staticmethod
-    def populate(db_map):
-        import_object_classes(db_map, ["object_class1", "object_class2"])
-        import_objects(db_map, [["object_class1", "object1"], ["object_class2", "object2"]])
-        import_object_parameters(db_map, [["object_class1", "parameter"]])
+class TestImportParameterValue(ImportsTestCase):
+    def populate(self, db_map):
+        self._assert_success(import_object_classes(db_map, ["object_class1", "object_class2"]))
+        self._assert_success(import_objects(db_map, [["object_class1", "object1"], ["object_class2", "object2"]]))
+        self._assert_success(import_object_parameters(db_map, [["object_class1", "parameter"]]))
 
-    @staticmethod
-    def populate_with_relationship(db_map):
-        TestImportParameterValue.populate(db_map)
-        import_relationship_classes(db_map, [["relationship_class", ["object_class1", "object_class2"]]])
-        import_relationship_parameters(db_map, [["relationship_class", "parameter"]])
-        import_relationships(db_map, [["relationship_class", ["object1", "object2"]]])
+    def populate_with_relationship(self, db_map):
+        self.populate(db_map)
+        self._assert_success(import_relationship_classes(db_map, [["relationship_class", ["object_class1", "object_class2"]]]))
+        self._assert_success(import_relationship_parameters(db_map, [["relationship_class", "parameter"]]))
+        self._assert_success(import_relationships(db_map, [["relationship_class", ["object1", "object2"]]]))
 
     def test_import_valid_object_parameter_value(self):
-        db_map = create_db_map()
-        self.populate(db_map)
-        _, errors = import_object_parameter_values(db_map, [["object_class1", "object1", "parameter", 1]])
-        self.assertFalse(errors)
-        db_map.commit_session("test")
-        values = {v.object_name: v.value for v in db_map.query(db_map.object_parameter_value_sq)}
-        expected = {"object1": b"1"}
-        self.assertEqual(values, expected)
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self.populate(db_map)
+            self._assert_success(import_object_parameter_values(db_map, [["object_class1", "object1", "parameter", 1]]))
+            db_map.commit_session("test")
+            values = {v.object_name: v.value for v in db_map.query(db_map.object_parameter_value_sq)}
+            expected = {"object1": b"1"}
+            self.assertEqual(values, expected)
 
     def test_import_valid_object_parameter_value_string(self):
-        db_map = create_db_map()
-        self.populate(db_map)
-        _, errors = import_object_parameter_values(db_map, [["object_class1", "object1", "parameter", "value_string"]])
-        self.assertFalse(errors)
-        db_map.commit_session("test")
-        values = {v.object_name: v.value for v in db_map.query(db_map.object_parameter_value_sq)}
-        expected = {"object1": b'"value_string"'}
-        self.assertEqual(values, expected)
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self.populate(db_map)
+            self._assert_success(import_object_parameter_values(db_map, [["object_class1", "object1", "parameter", "value_string"]]))
+            db_map.commit_session("test")
+            values = {v.object_name: v.value for v in db_map.query(db_map.object_parameter_value_sq)}
+            expected = {"object1": b'"value_string"'}
+            self.assertEqual(values, expected)
 
     def test_import_valid_object_parameter_value_with_duplicate_object_name(self):
-        db_map = create_db_map()
-        self.populate(db_map)
-        import_objects(db_map, [["object_class1", "duplicate_object"], ["object_class2", "duplicate_object"]])
-        _, errors = import_object_parameter_values(db_map, [["object_class1", "duplicate_object", "parameter", 1]])
-        self.assertFalse(errors)
-        db_map.commit_session("test")
-        values = {v.object_class_name: {v.object_name: v.value} for v in db_map.query(db_map.object_parameter_value_sq)}
-        expected = {"object_class1": {"duplicate_object": b"1"}}
-        self.assertEqual(values, expected)
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self.populate(db_map)
+            self._assert_success(import_objects(db_map, [["object_class1", "duplicate_object"], ["object_class2", "duplicate_object"]]))
+            self._assert_success(import_object_parameter_values(db_map, [["object_class1", "duplicate_object", "parameter", 1]]))
+            db_map.commit_session("test")
+            values = {v.object_class_name: {v.object_name: v.value} for v in db_map.query(db_map.object_parameter_value_sq)}
+            expected = {"object_class1": {"duplicate_object": b"1"}}
+            self.assertEqual(values, expected)
 
     def test_import_valid_object_parameter_value_with_duplicate_parameter_name(self):
-        db_map = create_db_map()
-        self.populate(db_map)
-        import_object_parameters(db_map, [["object_class2", "parameter"]])
-        _, errors = import_object_parameter_values(db_map, [["object_class1", "object1", "parameter", 1]])
-        self.assertFalse(errors)
-        db_map.commit_session("test")
-        values = {v.object_class_name: {v.object_name: v.value} for v in db_map.query(db_map.object_parameter_value_sq)}
-        expected = {"object_class1": {"object1": b"1"}}
-        self.assertEqual(values, expected)
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self.populate(db_map)
+            self._assert_success(import_object_parameters(db_map, [["object_class2", "parameter"]]))
+            self._assert_success(import_object_parameter_values(db_map, [["object_class1", "object1", "parameter", 1]]))
+            db_map.commit_session("test")
+            values = {v.object_class_name: {v.object_name: v.value} for v in db_map.query(db_map.object_parameter_value_sq)}
+            expected = {"object_class1": {"object1": b"1"}}
+            self.assertEqual(values, expected)
 
     def test_import_object_parameter_value_with_invalid_object(self):
-        db_map = create_db_map()
-        import_object_classes(db_map, ["object_class"])
-        import_object_parameters(db_map, [["object_class", "parameter"]])
-        _, errors = import_object_parameter_values(db_map, [["object_class", "nonexistent_object", "parameter", 1]])
-        self.assertTrue(errors)
-        db_map.commit_session("test")
-        self.assertFalse(db_map.query(db_map.object_parameter_value_sq).all())
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(import_object_classes(db_map, ["object_class"]))
+            self._assert_success(import_object_parameters(db_map, [["object_class", "parameter"]]))
+            _, errors = import_object_parameter_values(db_map, [["object_class", "nonexistent_object", "parameter", 1]])
+            self.assertTrue(errors)
+            db_map.commit_session("test")
+            self.assertFalse(db_map.query(db_map.object_parameter_value_sq).all())
 
     def test_import_object_parameter_value_with_invalid_parameter(self):
-        db_map = create_db_map()
-        import_object_classes(db_map, ["object_class"])
-        import_objects(db_map, ["object_class", "object"])
-        _, errors = import_object_parameter_values(db_map, [["object_class", "object", "nonexistent_parameter", 1]])
-        self.assertTrue(errors)
-        db_map.commit_session("test")
-        self.assertFalse(db_map.query(db_map.object_parameter_value_sq).all())
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(import_object_classes(db_map, ["object_class"]))
+            self._assert_success(import_objects(db_map, [["object_class", "object"]]))
+            _, errors = import_object_parameter_values(db_map, [["object_class", "object", "nonexistent_parameter", 1]])
+            self.assertTrue(errors)
+            db_map.commit_session("test")
+            self.assertFalse(db_map.query(db_map.object_parameter_value_sq).all())
 
     def test_import_existing_object_parameter_value_update_the_value(self):
-        db_map = create_db_map()
-        self.populate(db_map)
-        import_object_parameter_values(db_map, [["object_class1", "object1", "parameter", "initial_value"]])
-        _, errors = import_object_parameter_values(db_map, [["object_class1", "object1", "parameter", "new_value"]])
-        self.assertFalse(errors)
-        db_map.commit_session("test")
-        values = {v.object_name: v.value for v in db_map.query(db_map.object_parameter_value_sq)}
-        expected = {"object1": b'"new_value"'}
-        self.assertEqual(values, expected)
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self.populate(db_map)
+            self._assert_success(import_object_parameter_values(db_map, [["object_class1", "object1", "parameter", "initial_value"]]))
+            self._assert_success(import_object_parameter_values(db_map, [["object_class1", "object1", "parameter", "new_value"]]))
+            db_map.commit_session("test")
+            values = {v.object_name: v.value for v in db_map.query(db_map.object_parameter_value_sq)}
+            expected = {"object1": b'"new_value"'}
+            self.assertEqual(values, expected)
 
     def test_import_existing_object_parameter_value_on_conflict_keep(self):
-        db_map = create_db_map()
-        self.populate(db_map)
-        initial_value = {"type": "time_series", "data": [("2000-01-01T01:00", "1"), ("2000-01-01T02:00", "2")]}
-        new_value = {"type": "time_series", "data": [("2000-01-01T02:00", "3"), ("2000-01-01T03:00", "4")]}
-        import_object_parameter_values(db_map, [["object_class1", "object1", "parameter", initial_value]])
-        _, errors = import_object_parameter_values(
-            db_map, [["object_class1", "object1", "parameter", new_value]], on_conflict="keep"
-        )
-        self.assertFalse(errors)
-        db_map.commit_session("test")
-        pv = db_map.query(db_map.object_parameter_value_sq).filter_by(object_name="object1").first()
-        value = from_database(pv.value, pv.type)
-        self.assertEqual(["2000-01-01T01:00:00", "2000-01-01T02:00:00"], [str(x) for x in value.indexes])
-        self.assertEqual([1.0, 2.0], list(value.values))
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self.populate(db_map)
+            initial_value = {"type": "time_series", "data": [("2000-01-01T01:00", "1"), ("2000-01-01T02:00", "2")]}
+            new_value = {"type": "time_series", "data": [("2000-01-01T02:00", "3"), ("2000-01-01T03:00", "4")]}
+            self._assert_success(import_object_parameter_values(db_map, [["object_class1", "object1", "parameter", initial_value]]))
+            _, errors = import_object_parameter_values(
+                db_map, [["object_class1", "object1", "parameter", new_value]], on_conflict="keep"
+            )
+            self.assertFalse(errors)
+            db_map.commit_session("test")
+            pv = db_map.query(db_map.object_parameter_value_sq).filter_by(object_name="object1").first()
+            value = from_database(pv.value, pv.type)
+            self.assertEqual(["2000-01-01T01:00:00", "2000-01-01T02:00:00"], [str(x) for x in value.indexes])
+            self.assertEqual([1.0, 2.0], list(value.values))
 
     def test_import_existing_object_parameter_value_on_conflict_replace(self):
-        db_map = create_db_map()
-        self.populate(db_map)
-        initial_value = {"type": "time_series", "data": [("2000-01-01T01:00", "1"), ("2000-01-01T02:00", "2")]}
-        new_value = {"type": "time_series", "data": [("2000-01-01T02:00", "3"), ("2000-01-01T03:00", "4")]}
-        import_object_parameter_values(db_map, [["object_class1", "object1", "parameter", initial_value]])
-        _, errors = import_object_parameter_values(
-            db_map, [["object_class1", "object1", "parameter", new_value]], on_conflict="replace"
-        )
-        self.assertFalse(errors)
-        db_map.commit_session("test")
-        pv = db_map.query(db_map.object_parameter_value_sq).filter_by(object_name="object1").first()
-        value = from_database(pv.value, pv.type)
-        self.assertEqual(["2000-01-01T02:00:00", "2000-01-01T03:00:00"], [str(x) for x in value.indexes])
-        self.assertEqual([3.0, 4.0], list(value.values))
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self.populate(db_map)
+            initial_value = {"type": "time_series", "data": [("2000-01-01T01:00", "1"), ("2000-01-01T02:00", "2")]}
+            new_value = {"type": "time_series", "data": [("2000-01-01T02:00", "3"), ("2000-01-01T03:00", "4")]}
+            self._assert_success(import_object_parameter_values(db_map, [["object_class1", "object1", "parameter", initial_value]]))
+            self._assert_success(import_object_parameter_values(
+                db_map, [["object_class1", "object1", "parameter", new_value]], on_conflict="replace"
+            ))
+            db_map.commit_session("test")
+            pv = db_map.query(db_map.object_parameter_value_sq).filter_by(object_name="object1").first()
+            value = from_database(pv.value, pv.type)
+            self.assertEqual(["2000-01-01T02:00:00", "2000-01-01T03:00:00"], [str(x) for x in value.indexes])
+            self.assertEqual([3.0, 4.0], list(value.values))
 
     def test_import_existing_object_parameter_value_on_conflict_merge(self):
-        db_map = create_db_map()
-        self.populate(db_map)
-        initial_value = {"type": "time_series", "data": [("2000-01-01T01:00", "1"), ("2000-01-01T02:00", "2")]}
-        new_value = {"type": "time_series", "data": [("2000-01-01T02:00", "3"), ("2000-01-01T03:00", "4")]}
-        import_object_parameter_values(db_map, [["object_class1", "object1", "parameter", initial_value]])
-        _, errors = import_object_parameter_values(
-            db_map, [["object_class1", "object1", "parameter", new_value]], on_conflict="merge"
-        )
-        self.assertFalse(errors)
-        db_map.commit_session("test")
-        pv = db_map.query(db_map.object_parameter_value_sq).filter_by(object_name="object1").first()
-        value = from_database(pv.value, pv.type)
-        self.assertEqual(
-            ["2000-01-01T01:00:00", "2000-01-01T02:00:00", "2000-01-01T03:00:00"], [str(x) for x in value.indexes]
-        )
-        self.assertEqual([1.0, 3.0, 4.0], list(value.values))
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self.populate(db_map)
+            initial_value = {"type": "time_series", "data": [("2000-01-01T01:00", "1"), ("2000-01-01T02:00", "2")]}
+            new_value = {"type": "time_series", "data": [("2000-01-01T02:00", "3"), ("2000-01-01T03:00", "4")]}
+            self._assert_success(import_object_parameter_values(db_map, [["object_class1", "object1", "parameter", initial_value]]))
+            self._assert_success(import_object_parameter_values(
+                db_map, [["object_class1", "object1", "parameter", new_value]], on_conflict="merge"
+            ))
+            db_map.commit_session("test")
+            pv = db_map.query(db_map.object_parameter_value_sq).filter_by(object_name="object1").first()
+            value = from_database(pv.value, pv.type)
+            self.assertEqual(
+                ["2000-01-01T01:00:00", "2000-01-01T02:00:00", "2000-01-01T03:00:00"], [str(x) for x in value.indexes]
+            )
+            self.assertEqual([1.0, 3.0, 4.0], list(value.values))
 
     def test_import_existing_object_parameter_value_on_conflict_merge_map(self):
-        db_map = create_db_map()
-        self.populate(db_map)
-        initial_value = {
-            "type": "map",
-            "index_type": "str",
-            "data": {"xxx": {"type": "time_series", "data": [("2000-01-01T01:00", "1"), ("2000-01-01T02:00", "2")]}},
-        }
-        new_value = {
-            "type": "map",
-            "index_type": "str",
-            "data": {"xxx": {"type": "time_series", "data": [("2000-01-01T02:00", "3"), ("2000-01-01T03:00", "4")]}},
-        }
-        import_object_parameter_values(db_map, [["object_class1", "object1", "parameter", initial_value]])
-        _, errors = import_object_parameter_values(
-            db_map, [["object_class1", "object1", "parameter", new_value]], on_conflict="merge"
-        )
-        self.assertFalse(errors)
-        db_map.commit_session("test")
-        pv = db_map.query(db_map.object_parameter_value_sq).filter_by(object_name="object1").first()
-        map_ = from_database(pv.value, pv.type)
-        self.assertEqual(["xxx"], [str(x) for x in map_.indexes])
-        ts = map_.get_value("xxx")
-        self.assertEqual(
-            ["2000-01-01T01:00:00", "2000-01-01T02:00:00", "2000-01-01T03:00:00"], [str(x) for x in ts.indexes]
-        )
-        self.assertEqual([1.0, 3.0, 4.0], list(ts.values))
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self.populate(db_map)
+            initial_value = {
+                "type": "map",
+                "index_type": "str",
+                "data": {"xxx": {"type": "time_series", "data": [("2000-01-01T01:00", "1"), ("2000-01-01T02:00", "2")]}},
+            }
+            new_value = {
+                "type": "map",
+                "index_type": "str",
+                "data": {"xxx": {"type": "time_series", "data": [("2000-01-01T02:00", "3"), ("2000-01-01T03:00", "4")]}},
+            }
+            self._assert_success(import_object_parameter_values(db_map, [["object_class1", "object1", "parameter", initial_value]]))
+            self._assert_success(import_object_parameter_values(
+                db_map, [["object_class1", "object1", "parameter", new_value]], on_conflict="merge"
+            ))
+            db_map.commit_session("test")
+            pv = db_map.query(db_map.object_parameter_value_sq).filter_by(object_name="object1").first()
+            map_ = from_database(pv.value, pv.type)
+            self.assertEqual(["xxx"], [str(x) for x in map_.indexes])
+            ts = map_.get_value("xxx")
+            self.assertEqual(
+                ["2000-01-01T01:00:00", "2000-01-01T02:00:00", "2000-01-01T03:00:00"], [str(x) for x in ts.indexes]
+            )
+            self.assertEqual([1.0, 3.0, 4.0], list(ts.values))
 
     def test_import_duplicate_object_parameter_value(self):
-        db_map = create_db_map()
-        self.populate(db_map)
-        _, errors = import_object_parameter_values(
-            db_map,
-            [["object_class1", "object1", "parameter", "first"], ["object_class1", "object1", "parameter", "second"]],
-        )
-        self.assertTrue(errors)
-        db_map.commit_session("test")
-        values = {v.object_name: v.value for v in db_map.query(db_map.object_parameter_value_sq)}
-        expected = {"object1": b'"first"'}
-        self.assertEqual(values, expected)
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self.populate(db_map)
+            _, errors = import_object_parameter_values(
+                db_map,
+                [["object_class1", "object1", "parameter", "first"], ["object_class1", "object1", "parameter", "second"]],
+            )
+            self.assertTrue(errors)
+            db_map.commit_session("test")
+            values = {v.object_name: v.value for v in db_map.query(db_map.object_parameter_value_sq)}
+            expected = {"object1": b'"first"'}
+            self.assertEqual(values, expected)
 
     def test_import_object_parameter_value_with_alternative(self):
-        db_map = create_db_map()
-        self.populate(db_map)
-        import_alternatives(db_map, ["alternative"])
-        count, errors = import_object_parameter_values(
-            db_map, [["object_class1", "object1", "parameter", 1, "alternative"]]
-        )
-        self.assertFalse(errors)
-        self.assertEqual(count, 1)
-        db_map.commit_session("test")
-        values = {
-            v.object_name: (v.value, v.alternative_name) for v in db_map.query(db_map.object_parameter_value_sq).all()
-        }
-        expected = {"object1": (b"1", "alternative")}
-        self.assertEqual(values, expected)
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self.populate(db_map)
+            self._assert_success(import_alternatives(db_map, ["alternative"]))
+            count = self._assert_success(import_object_parameter_values(
+                db_map, [["object_class1", "object1", "parameter", 1, "alternative"]]
+            ))
+            self.assertEqual(count, 1)
+            db_map.commit_session("test")
+            values = {
+                v.object_name: (v.value, v.alternative_name) for v in db_map.query(db_map.object_parameter_value_sq).all()
+            }
+            expected = {"object1": (b"1", "alternative")}
+            self.assertEqual(values, expected)
 
     def test_import_object_parameter_value_fails_with_nonexistent_alternative(self):
-        db_map = create_db_map()
-        self.populate(db_map)
-        count, errors = import_object_parameter_values(
-            db_map, [["object_class1", "object1", "parameter", 1, "nonexistent_alternative"]]
-        )
-        self.assertTrue(errors)
-        self.assertEqual(count, 0)
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self.populate(db_map)
+            count, errors = import_object_parameter_values(
+                db_map, [["object_class1", "object1", "parameter", 1, "nonexistent_alternative"]]
+            )
+            self.assertTrue(errors)
+            self.assertEqual(count, 0)
 
     def test_import_parameter_values_from_committed_value_list(self):
-        db_map = create_db_map()
-        import_data(db_map, parameter_value_lists=(("values_1", 5.0),))
-        db_map.commit_session("test")
-        count, errors = import_data(
-            db_map,
-            object_classes=("object_class",),
-            object_parameters=(("object_class", "parameter", None, "values_1"),),
-            objects=(("object_class", "my_object"),),
-            object_parameter_values=(("object_class", "my_object", "parameter", 5.0),),
-        )
-        self.assertEqual(count, 4)
-        self.assertEqual(errors, [])
-        db_map.commit_session("test")
-        values = db_map.query(db_map.object_parameter_value_sq).all()
-        value = values[0]
-        self.assertEqual(from_database(value.value, value.type), 5.0)
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(import_data(db_map, parameter_value_lists=(("values_1", 5.0),)))
+            db_map.commit_session("test")
+            count = self._assert_success(import_data(
+                db_map,
+                object_classes=("object_class",),
+                object_parameters=(("object_class", "parameter", None, "values_1"),),
+                objects=(("object_class", "my_object"),),
+                object_parameter_values=(("object_class", "my_object", "parameter", 5.0),),
+            ))
+            self.assertEqual(count, 4)
+            db_map.commit_session("test")
+            values = db_map.query(db_map.object_parameter_value_sq).all()
+            value = values[0]
+            self.assertEqual(from_database(value.value, value.type), 5.0)
 
     def test_valid_object_parameter_value_from_value_list(self):
-        db_map = create_db_map()
-        import_parameter_value_lists(db_map, (("values_1", 5.0),))
-        import_object_classes(db_map, ("object_class",))
-        import_object_parameters(db_map, (("object_class", "parameter", None, "values_1"),))
-        import_objects(db_map, (("object_class", "my_object"),))
-        count, errors = import_object_parameter_values(db_map, (("object_class", "my_object", "parameter", 5.0),))
-        self.assertEqual(count, 1)
-        self.assertEqual(errors, [])
-        db_map.commit_session("test")
-        values = db_map.query(db_map.object_parameter_value_sq).all()
-        self.assertEqual(len(values), 1)
-        value = values[0]
-        self.assertEqual(from_database(value.value, value.type), 5.0)
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(import_parameter_value_lists(db_map, (("values_1", 5.0),)))
+            self._assert_success(import_object_classes(db_map, ("object_class",)))
+            self._assert_success(import_object_parameters(db_map, (("object_class", "parameter", None, "values_1"),)))
+            self._assert_success(import_objects(db_map, (("object_class", "my_object"),)))
+            count = self._assert_success(import_object_parameter_values(db_map, (("object_class", "my_object", "parameter", 5.0),)))
+            self.assertEqual(count, 1)
+            db_map.commit_session("test")
+            values = db_map.query(db_map.object_parameter_value_sq).all()
+            self.assertEqual(len(values), 1)
+            value = values[0]
+            self.assertEqual(from_database(value.value, value.type), 5.0)
 
     def test_non_existent_object_parameter_value_from_value_list_fails_gracefully(self):
-        db_map = create_db_map()
-        import_parameter_value_lists(db_map, (("values_1", 5.0),))
-        import_object_classes(db_map, ("object_class",))
-        import_object_parameters(db_map, (("object_class", "parameter", None, "values_1"),))
-        import_objects(db_map, (("object_class", "my_object"),))
-        count, errors = import_object_parameter_values(db_map, (("object_class", "my_object", "parameter", 2.3),))
-        self.assertEqual(count, 0)
-        self.assertEqual(len(errors), 1)
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(import_parameter_value_lists(db_map, (("values_1", 5.0),)))
+            self._assert_success(import_object_classes(db_map, ("object_class",)))
+            self._assert_success(import_object_parameters(db_map, (("object_class", "parameter", None, "values_1"),)))
+            self._assert_success(import_objects(db_map, (("object_class", "my_object"),)))
+            count, errors = import_object_parameter_values(db_map, (("object_class", "my_object", "parameter", 2.3),))
+            self.assertEqual(count, 0)
+            self.assertEqual(len(errors), 1)
 
     def test_import_valid_relationship_parameter_value(self):
-        db_map = create_db_map()
-        self.populate_with_relationship(db_map)
-        _, errors = import_relationship_parameter_values(
-            db_map, [["relationship_class", ["object1", "object2"], "parameter", 1]]
-        )
-        self.assertFalse(errors)
-        db_map.commit_session("test")
-        values = {v.object_name_list: v.value for v in db_map.query(db_map.relationship_parameter_value_sq)}
-        expected = {"object1,object2": b"1"}
-        self.assertEqual(values, expected)
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self.populate_with_relationship(db_map)
+            self._assert_success(import_relationship_parameter_values(
+                db_map, [["relationship_class", ["object1", "object2"], "parameter", 1]]
+            ))
+            db_map.commit_session("test")
+            values = {v.object_name_list: v.value for v in db_map.query(db_map.relationship_parameter_value_sq)}
+            expected = {"object1,object2": b"1"}
+            self.assertEqual(values, expected)
 
     def test_import_valid_relationship_parameter_value_with_duplicate_parameter_name(self):
-        db_map = create_db_map()
-        self.populate_with_relationship(db_map)
-        import_relationship_classes(db_map, [["relationship_class2", ["object_class2", "object_class1"]]])
-        import_relationship_parameters(db_map, [["relationship_class2", "parameter"]])
-        _, errors = import_relationship_parameter_values(
-            db_map, [["relationship_class", ["object1", "object2"], "parameter", 1]]
-        )
-        self.assertFalse(errors)
-        db_map.commit_session("test")
-        values = {v.object_name_list: v.value for v in db_map.query(db_map.relationship_parameter_value_sq)}
-        expected = {"object1,object2": b"1"}
-        self.assertEqual(values, expected)
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self.populate_with_relationship(db_map)
+            self._assert_success(import_relationship_classes(db_map, [["relationship_class2", ["object_class2", "object_class1"]]]))
+            self._assert_success(import_relationship_parameters(db_map, [["relationship_class2", "parameter"]]))
+            self._assert_success(import_relationship_parameter_values(
+                db_map, [["relationship_class", ["object1", "object2"], "parameter", 1]]
+            ))
+            db_map.commit_session("test")
+            values = {v.object_name_list: v.value for v in db_map.query(db_map.relationship_parameter_value_sq)}
+            expected = {"object1,object2": b"1"}
+            self.assertEqual(values, expected)
 
     def test_import_valid_relationship_parameter_value_with_duplicate_object_name(self):
-        db_map = create_db_map()
-        self.populate_with_relationship(db_map)
-        import_objects(db_map, [["object_class1", "duplicate_object"], ["object_class2", "duplicate_object"]])
-        import_relationships(db_map, [["relationship_class", ["duplicate_object", "duplicate_object"]]])
-        _, errors = import_relationship_parameter_values(
-            db_map, [["relationship_class", ["duplicate_object", "duplicate_object"], "parameter", 1]]
-        )
-        self.assertFalse(errors)
-        db_map.commit_session("test")
-        values = {v.object_name_list: v.value for v in db_map.query(db_map.relationship_parameter_value_sq)}
-        expected = {"duplicate_object,duplicate_object": b"1"}
-        self.assertEqual(values, expected)
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self.populate_with_relationship(db_map)
+            self._assert_success(import_objects(db_map, [["object_class1", "duplicate_object"], ["object_class2", "duplicate_object"]]))
+            self._assert_success(import_relationships(db_map, [["relationship_class", ["duplicate_object", "duplicate_object"]]]))
+            self._assert_success(import_relationship_parameter_values(
+                db_map, [["relationship_class", ["duplicate_object", "duplicate_object"], "parameter", 1]]
+            ))
+            db_map.commit_session("test")
+            values = {v.object_name_list: v.value for v in db_map.query(db_map.relationship_parameter_value_sq)}
+            expected = {"duplicate_object,duplicate_object": b"1"}
+            self.assertEqual(values, expected)
 
     def test_import_relationship_parameter_value_with_invalid_object(self):
-        db_map = create_db_map()
-        self.populate_with_relationship(db_map)
-        _, errors = import_relationship_parameter_values(
-            db_map, [["relationship_class", ["nonexistent_object", "object2"], "parameter", 1]]
-        )
-        self.assertTrue(errors)
-        db_map.commit_session("test")
-        self.assertFalse(db_map.query(db_map.relationship_parameter_value_sq).all())
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self.populate_with_relationship(db_map)
+            _, errors = import_relationship_parameter_values(
+                db_map, [["relationship_class", ["nonexistent_object", "object2"], "parameter", 1]]
+            )
+            self.assertTrue(errors)
+            db_map.commit_session("test")
+            self.assertFalse(db_map.query(db_map.relationship_parameter_value_sq).all())
 
     def test_import_relationship_parameter_value_with_invalid_relationship_class(self):
-        db_map = create_db_map()
-        self.populate_with_relationship(db_map)
-        _, errors = import_relationship_parameter_values(
-            db_map, [["nonexistent_class", ["object1", "object2"], "parameter", 1]]
-        )
-        self.assertTrue(errors)
-        db_map.commit_session("test")
-        self.assertFalse(db_map.query(db_map.relationship_parameter_value_sq).all())
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self.populate_with_relationship(db_map)
+            _, errors = import_relationship_parameter_values(
+                db_map, [["nonexistent_class", ["object1", "object2"], "parameter", 1]]
+            )
+            self.assertTrue(errors)
+            db_map.commit_session("test")
+            self.assertFalse(db_map.query(db_map.relationship_parameter_value_sq).all())
 
     def test_import_relationship_parameter_value_with_invalid_parameter(self):
-        db_map = create_db_map()
-        self.populate_with_relationship(db_map)
-        _, errors = import_relationship_parameter_values(
-            db_map, [["relationship_class", ["object1", "object2"], "nonexistent_parameter", 1]]
-        )
-        self.assertTrue(errors)
-        db_map.commit_session("test")
-        self.assertFalse(db_map.query(db_map.relationship_parameter_value_sq).all())
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self.populate_with_relationship(db_map)
+            _, errors = import_relationship_parameter_values(
+                db_map, [["relationship_class", ["object1", "object2"], "nonexistent_parameter", 1]]
+            )
+            self.assertTrue(errors)
+            db_map.commit_session("test")
+            self.assertFalse(db_map.query(db_map.relationship_parameter_value_sq).all())
 
     def test_import_existing_relationship_parameter_value(self):
-        db_map = create_db_map()
-        self.populate_with_relationship(db_map)
-        import_relationship_parameter_values(
-            db_map, [["relationship_class", ["object1", "object2"], "parameter", "initial_value"]]
-        )
-        _, errors = import_relationship_parameter_values(
-            db_map, [["relationship_class", ["object1", "object2"], "parameter", "new_value"]]
-        )
-        self.assertFalse(errors)
-        db_map.commit_session("test")
-        values = {v.object_name_list: v.value for v in db_map.query(db_map.relationship_parameter_value_sq)}
-        expected = {"object1,object2": b'"new_value"'}
-        self.assertEqual(values, expected)
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self.populate_with_relationship(db_map)
+            self._assert_success(import_relationship_parameter_values(
+                db_map, [["relationship_class", ["object1", "object2"], "parameter", "initial_value"]]
+            ))
+            self._assert_success(import_relationship_parameter_values(
+                db_map, [["relationship_class", ["object1", "object2"], "parameter", "new_value"]]
+            ))
+            db_map.commit_session("test")
+            values = {v.object_name_list: v.value for v in db_map.query(db_map.relationship_parameter_value_sq)}
+            expected = {"object1,object2": b'"new_value"'}
+            self.assertEqual(values, expected)
 
     def test_import_duplicate_relationship_parameter_value(self):
-        db_map = create_db_map()
-        self.populate_with_relationship(db_map)
-        _, errors = import_relationship_parameter_values(
-            db_map,
-            [
-                ["relationship_class", ["object1", "object2"], "parameter", "first"],
-                ["relationship_class", ["object1", "object2"], "parameter", "second"],
-            ],
-        )
-        self.assertTrue(errors)
-        db_map.commit_session("test")
-        values = {v.object_name_list: v.value for v in db_map.query(db_map.relationship_parameter_value_sq)}
-        expected = {"object1,object2": b'"first"'}
-        self.assertEqual(values, expected)
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self.populate_with_relationship(db_map)
+            _, errors = import_relationship_parameter_values(
+                db_map,
+                [
+                    ["relationship_class", ["object1", "object2"], "parameter", "first"],
+                    ["relationship_class", ["object1", "object2"], "parameter", "second"],
+                ],
+            )
+            self.assertTrue(errors)
+            db_map.commit_session("test")
+            values = {v.object_name_list: v.value for v in db_map.query(db_map.relationship_parameter_value_sq)}
+            expected = {"object1,object2": b'"first"'}
+            self.assertEqual(values, expected)
 
     def test_import_relationship_parameter_value_with_alternative(self):
-        db_map = create_db_map()
-        self.populate_with_relationship(db_map)
-        import_alternatives(db_map, ["alternative"])
-        count, errors = import_relationship_parameter_values(
-            db_map, [["relationship_class", ["object1", "object2"], "parameter", 1, "alternative"]]
-        )
-        self.assertFalse(errors)
-        self.assertEqual(count, 1)
-        db_map.commit_session("test")
-        values = {
-            v.object_name_list: (v.value, v.alternative_name)
-            for v in db_map.query(db_map.relationship_parameter_value_sq).all()
-        }
-        expected = {"object1,object2": (b"1", "alternative")}
-        self.assertEqual(values, expected)
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self.populate_with_relationship(db_map)
+            self._assert_success(import_alternatives(db_map, ["alternative"]))
+            count = self._assert_success(import_relationship_parameter_values(
+                db_map, [["relationship_class", ["object1", "object2"], "parameter", 1, "alternative"]]
+            ))
+            self.assertEqual(count, 1)
+            db_map.commit_session("test")
+            values = {
+                v.object_name_list: (v.value, v.alternative_name)
+                for v in db_map.query(db_map.relationship_parameter_value_sq).all()
+            }
+            expected = {"object1,object2": (b"1", "alternative")}
+            self.assertEqual(values, expected)
 
     def test_import_relationship_parameter_value_fails_with_nonexistent_alternative(self):
-        db_map = create_db_map()
-        self.populate(db_map)
-        count, errors = import_relationship_parameter_values(
-            db_map, [["relationship_class", ["object1", "object2"], "parameter", 1, "alternative"]]
-        )
-        self.assertTrue(errors)
-        self.assertEqual(count, 0)
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self.populate(db_map)
+            count, errors = import_relationship_parameter_values(
+                db_map, [["relationship_class", ["object1", "object2"], "parameter", 1, "alternative"]]
+            )
+            self.assertTrue(errors)
+            self.assertEqual(count, 0)
 
     def test_valid_relationship_parameter_value_from_value_list(self):
-        db_map = create_db_map()
-        import_parameter_value_lists(db_map, (("values_1", 5.0),))
-        import_object_classes(db_map, ("object_class",))
-        import_objects(db_map, (("object_class", "my_object"),))
-        import_relationship_classes(db_map, (("relationship_class", ("object_class",)),))
-        import_relationship_parameters(db_map, (("relationship_class", "parameter", None, "values_1"),))
-        import_relationships(db_map, (("relationship_class", ("my_object",)),))
-        count, errors = import_relationship_parameter_values(
-            db_map, (("relationship_class", ("my_object",), "parameter", 5.0),)
-        )
-        self.assertEqual(count, 1)
-        self.assertEqual(errors, [])
-        db_map.commit_session("test")
-        values = db_map.query(db_map.relationship_parameter_value_sq).all()
-        self.assertEqual(len(values), 1)
-        value = values[0]
-        self.assertEqual(from_database(value.value, value.type), 5.0)
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(import_parameter_value_lists(db_map, (("values_1", 5.0),)))
+            self._assert_success(import_object_classes(db_map, ("object_class",)))
+            self._assert_success(import_objects(db_map, (("object_class", "my_object"),)))
+            self._assert_success(import_relationship_classes(db_map, (("relationship_class", ("object_class",)),)))
+            self._assert_success(import_relationship_parameters(db_map, (("relationship_class", "parameter", None, "values_1"),)))
+            self._assert_success(import_relationships(db_map, (("relationship_class", ("my_object",)),)))
+            count = self._assert_success(import_relationship_parameter_values(
+                db_map, (("relationship_class", ("my_object",), "parameter", 5.0),)
+            ))
+            self.assertEqual(count, 1)
+            db_map.commit_session("test")
+            values = db_map.query(db_map.relationship_parameter_value_sq).all()
+            self.assertEqual(len(values), 1)
+            value = values[0]
+            self.assertEqual(from_database(value.value, value.type), 5.0)
 
     def test_non_existent_relationship_parameter_value_from_value_list_fails_gracefully(self):
-        db_map = create_db_map()
-        import_parameter_value_lists(db_map, (("values_1", 5.0),))
-        import_object_classes(db_map, ("object_class",))
-        import_objects(db_map, (("object_class", "my_object"),))
-        import_relationship_classes(db_map, (("relationship_class", ("object_class",)),))
-        import_relationship_parameters(db_map, (("relationship_class", "parameter", None, "values_1"),))
-        import_relationships(db_map, (("relationship_class", ("my_object",)),))
-        count, errors = import_relationship_parameter_values(
-            db_map, (("relationship_class", ("my_object",), "parameter", 2.3),)
-        )
-        self.assertEqual(count, 0)
-        self.assertEqual(len(errors), 1)
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(import_parameter_value_lists(db_map, (("values_1", 5.0),)))
+            self._assert_success(import_object_classes(db_map, ("object_class",)))
+            self._assert_success(import_objects(db_map, (("object_class", "my_object"),)))
+            self._assert_success(import_relationship_classes(db_map, (("relationship_class", ("object_class",)),)))
+            self._assert_success(import_relationship_parameters(db_map, (("relationship_class", "parameter", None, "values_1"),)))
+            self._assert_success(import_relationships(db_map, (("relationship_class", ("my_object",)),)))
+            count, errors = import_relationship_parameter_values(
+                db_map, (("relationship_class", ("my_object",), "parameter", 2.3),)
+            )
+            self.assertEqual(len(errors), 1)
+            self.assertEqual(count, 0)
 
     def test_unparse_value_imports_fields_correctly(self):
         with DatabaseMapping("sqlite:///", create=True) as db_map:
@@ -1161,8 +1066,7 @@ class TestImportParameterValue(unittest.TestCase):
                 "alternatives": [("Base", "Base alternative")],
             }
 
-            count, errors = import_data(db_map, **data, unparse_value=dump_db_value)
-            self.assertEqual(errors, [])
+            count = self._assert_success(import_data(db_map, **data, unparse_value=dump_db_value))
             self.assertEqual(count, 4)
             db_map.commit_session("add test data")
             value = db_map.query(db_map.entity_parameter_value_sq).one()
@@ -1179,260 +1083,232 @@ class TestImportParameterValue(unittest.TestCase):
             self.assertEqual(time_series, expected_result)
 
 
-class TestImportParameterValueList(unittest.TestCase):
-    def setUp(self):
-        self._db_map = DatabaseMapping("sqlite://", create=True)
-
-    def tearDown(self):
-        self._db_map.close()
-
+class TestImportParameterValueList(ImportsTestCase):
     def test_list_with_single_value(self):
-        count, errors = import_parameter_value_lists(self._db_map, (("list_1", 23.0),))
-        self.assertEqual(errors, [])
-        self.assertEqual(count, 2)
-        self._db_map.commit_session("test")
-        value_lists = self._db_map.query(self._db_map.parameter_value_list_sq).all()
-        list_values = self._db_map.query(self._db_map.list_value_sq).all()
-        self.assertEqual(len(value_lists), 1)
-        self.assertEqual(len(list_values), 1)
-        self.assertEqual(value_lists[0].name, "list_1")
-        self.assertEqual(from_database(list_values[0].value, list_values[0].type), 23.0)
-        self.assertEqual(list_values[0].index, 0)
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            count = self._assert_success(import_parameter_value_lists(db_map, (("list_1", 23.0),)))
+            self.assertEqual(count, 2)
+            db_map.commit_session("test")
+            value_lists = db_map.query(db_map.parameter_value_list_sq).all()
+            list_values = db_map.query(db_map.list_value_sq).all()
+            self.assertEqual(len(value_lists), 1)
+            self.assertEqual(len(list_values), 1)
+            self.assertEqual(value_lists[0].name, "list_1")
+            self.assertEqual(from_database(list_values[0].value, list_values[0].type), 23.0)
+            self.assertEqual(list_values[0].index, 0)
 
     def test_import_twelfth_value(self):
-        n_values = 11
-        initial_list = tuple(("list_1", 1.1 * i) for i in range(1, n_values + 1))
-        count, errors = import_parameter_value_lists(self._db_map, initial_list)
-        self.assertEqual(errors, [])
-        self.assertEqual(count, n_values + 1)
-        count, errors = import_parameter_value_lists(self._db_map, (("list_1", 23.0),))
-        self.assertEqual(errors, [])
-        self.assertEqual(count, 1)
-        self._db_map.commit_session("test")
-        value_lists = self._db_map.query(self._db_map.parameter_value_list_sq).all()
-        self.assertEqual(len(value_lists), 1)
-        self.assertEqual(value_lists[0].name, "list_1")
-        list_values = self._db_map.query(self._db_map.list_value_sq).all()
-        self.assertEqual(len(list_values), n_values + 1)
-        expected = {i: 1.1 * (i + 1) for i in range(n_values)}
-        expected[len(expected)] = 23.0
-        for row in list_values:
-            self.assertEqual(from_database(row.value, row.type), expected[row.index])
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            n_values = 11
+            initial_list = tuple(("list_1", 1.1 * i) for i in range(1, n_values + 1))
+            count = self._assert_success(import_parameter_value_lists(db_map, initial_list))
+            self.assertEqual(count, n_values + 1)
+            count = self._assert_success(import_parameter_value_lists(db_map, (("list_1", 23.0),)))
+            self.assertEqual(count, 1)
+            db_map.commit_session("test")
+            value_lists = db_map.query(db_map.parameter_value_list_sq).all()
+            self.assertEqual(len(value_lists), 1)
+            self.assertEqual(value_lists[0].name, "list_1")
+            list_values = db_map.query(db_map.list_value_sq).all()
+            self.assertEqual(len(list_values), n_values + 1)
+            expected = {i: 1.1 * (i + 1) for i in range(n_values)}
+            expected[len(expected)] = 23.0
+            for row in list_values:
+                self.assertEqual(from_database(row.value, row.type), expected[row.index])
 
 
-class TestImportAlternative(unittest.TestCase):
+class TestImportAlternative(ImportsTestCase):
     def test_single_alternative(self):
-        db_map = create_db_map()
-        count, errors = import_alternatives(db_map, ["alternative"])
-        self.assertEqual(count, 1)
-        self.assertFalse(errors)
-        db_map.commit_session("test")
-        alternatives = [a.name for a in db_map.query(db_map.alternative_sq)]
-        self.assertEqual(len(alternatives), 2)
-        self.assertIn("Base", alternatives)
-        self.assertIn("alternative", alternatives)
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            count = self._assert_success(import_alternatives(db_map, ["alternative"]))
+            self.assertEqual(count, 1)
+            db_map.commit_session("test")
+            alternatives = [a.name for a in db_map.query(db_map.alternative_sq)]
+            self.assertEqual(len(alternatives), 2)
+            self.assertIn("Base", alternatives)
+            self.assertIn("alternative", alternatives)
 
     def test_alternative_description(self):
-        db_map = create_db_map()
-        count, errors = import_alternatives(db_map, [["alternative", "description"]])
-        self.assertEqual(count, 1)
-        self.assertFalse(errors)
-        db_map.commit_session("test")
-        alternatives = {a.name: a.description for a in db_map.query(db_map.alternative_sq)}
-        expected = {"Base": "Base alternative", "alternative": "description"}
-        self.assertEqual(alternatives, expected)
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            count = self._assert_success(import_alternatives(db_map, [["alternative", "description"]]))
+            self.assertEqual(count, 1)
+            db_map.commit_session("test")
+            alternatives = {a.name: a.description for a in db_map.query(db_map.alternative_sq)}
+            expected = {"Base": "Base alternative", "alternative": "description"}
+            self.assertEqual(alternatives, expected)
 
     def test_update_alternative_description(self):
-        db_map = create_db_map()
-        count, errors = import_alternatives(db_map, [["Base", "new description"]])
-        self.assertEqual(count, 1)
-        self.assertFalse(errors)
-        db_map.commit_session("test")
-        alternatives = {a.name: a.description for a in db_map.query(db_map.alternative_sq)}
-        expected = {"Base": "new description"}
-        self.assertEqual(alternatives, expected)
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            count = self._assert_success(import_alternatives(db_map, [["Base", "new description"]]))
+            self.assertEqual(count, 1)
+            db_map.commit_session("test")
+            alternatives = {a.name: a.description for a in db_map.query(db_map.alternative_sq)}
+            expected = {"Base": "new description"}
+            self.assertEqual(alternatives, expected)
 
 
-class TestImportScenario(unittest.TestCase):
+class TestImportScenario(ImportsTestCase):
     def test_single_scenario(self):
-        db_map = create_db_map()
-        count, errors = import_scenarios(db_map, ["scenario"])
-        self.assertEqual(count, 1)
-        self.assertFalse(errors)
-        db_map.commit_session("test")
-        scenarios = {s.name: s.description for s in db_map.query(db_map.scenario_sq)}
-        self.assertEqual(scenarios, {"scenario": None})
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            count = self._assert_success(import_scenarios(db_map, ["scenario"]))
+            self.assertEqual(count, 1)
+            db_map.commit_session("test")
+            scenarios = {s.name: s.description for s in db_map.query(db_map.scenario_sq)}
+            self.assertEqual(scenarios, {"scenario": None})
 
     def test_import_single_scenario_as_tuple(self):
         with DatabaseMapping("sqlite://", create=True) as db_map:
-            count, errors = import_scenarios(db_map, [("scenario",)])
-            self.assertEqual(errors, [])
+            count = self._assert_success(import_scenarios(db_map, [("scenario",)]))
             self.assertEqual(count, 1)
             db_map.commit_session("test")
             scenarios = {s.name: s.description for s in db_map.query(db_map.scenario_sq)}
             self.assertEqual(scenarios, {"scenario": None})
 
     def test_scenario_with_description(self):
-        db_map = create_db_map()
-        count, errors = import_scenarios(db_map, [["scenario", False, "description"]])
-        self.assertEqual(count, 1)
-        self.assertFalse(errors)
-        db_map.commit_session("test")
-        scenarios = {s.name: s.description for s in db_map.query(db_map.scenario_sq)}
-        self.assertEqual(scenarios, {"scenario": "description"})
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            count = self._assert_success(import_scenarios(db_map, [["scenario", False, "description"]]))
+            self.assertEqual(count, 1)
+            db_map.commit_session("test")
+            scenarios = {s.name: s.description for s in db_map.query(db_map.scenario_sq)}
+            self.assertEqual(scenarios, {"scenario": "description"})
 
     def test_update_scenario_description(self):
-        db_map = create_db_map()
-        import_scenarios(db_map, [["scenario", False, "initial description"]])
-        count, errors = import_scenarios(db_map, [["scenario", False, "new description"]])
-        self.assertEqual(count, 1)
-        self.assertFalse(errors)
-        db_map.commit_session("test")
-        scenarios = {s.name: s.description for s in db_map.query(db_map.scenario_sq)}
-        self.assertEqual(scenarios, {"scenario": "new description"})
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(import_scenarios(db_map, [["scenario", False, "initial description"]]))
+            count = self._assert_success(import_scenarios(db_map, [["scenario", False, "new description"]]))
+            self.assertEqual(count, 1)
+            db_map.commit_session("test")
+            scenarios = {s.name: s.description for s in db_map.query(db_map.scenario_sq)}
+            self.assertEqual(scenarios, {"scenario": "new description"})
         db_map.close()
 
 
-class TestImportScenarioAlternative(unittest.TestCase):
-    def setUp(self):
-        self._db_map = create_db_map()
-
-    def tearDown(self):
-        self._db_map.close()
-
+class TestImportScenarioAlternative(ImportsTestCase):
     def test_single_scenario_alternative_import(self):
-        import_data(self._db_map, scenarios=["scenario"], alternatives=["alternative"])
-        count, errors = import_scenario_alternatives(self._db_map, [["scenario", "alternative"]])
-        self.assertFalse(errors)
-        self.assertEqual(count, 1)
-        scenario_alternatives = self.scenario_alternatives()
-        self.assertEqual(scenario_alternatives, {"scenario": {"alternative": 1}})
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(import_data(db_map, scenarios=["scenario"], alternatives=["alternative"]))
+            count = self._assert_success(import_scenario_alternatives(db_map, [["scenario", "alternative"]]))
+            self.assertEqual(count, 1)
+            scenario_alternatives = self.scenario_alternatives(db_map)
+            self.assertEqual(scenario_alternatives, {"scenario": {"alternative": 1}})
 
     def test_scenario_alternative_import_multiple_without_before_alternatives(self):
-        import_data(self._db_map, scenarios=["scenario"], alternatives=["alternative1", "alternative2"])
-        count, errors = import_scenario_alternatives(
-            self._db_map, [["scenario", "alternative1"], ["scenario", "alternative2"]]
-        )
-        self.assertFalse(errors)
-        self.assertEqual(count, 2)
-        scenario_alternatives = self.scenario_alternatives()
-        self.assertEqual(scenario_alternatives, {"scenario": {"alternative1": 1, "alternative2": 2}})
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(import_data(db_map, scenarios=["scenario"], alternatives=["alternative1", "alternative2"]))
+            count = self._assert_success(import_scenario_alternatives(
+                db_map, [["scenario", "alternative1"], ["scenario", "alternative2"]]
+            ))
+            self.assertEqual(count, 2)
+            scenario_alternatives = self.scenario_alternatives(db_map)
+            self.assertEqual(scenario_alternatives, {"scenario": {"alternative1": 1, "alternative2": 2}})
 
     def test_scenario_alternative_import_multiple_with_before_alternatives(self):
-        import_data(self._db_map, scenarios=["scenario"], alternatives=["alternative1", "alternative2", "alternative3"])
-        count, errors = import_scenario_alternatives(
-            self._db_map,
-            [["scenario", "alternative1"], ["scenario", "alternative3"], ["scenario", "alternative2", "alternative3"]],
-        )
-        self.assertFalse(errors)
-        self.assertEqual(count, 3)
-        scenario_alternatives = self.scenario_alternatives()
-        self.assertEqual(scenario_alternatives, {"scenario": {"alternative1": 1, "alternative2": 2, "alternative3": 3}})
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(import_data(db_map, scenarios=["scenario"], alternatives=["alternative1", "alternative2", "alternative3"]))
+            count = self._assert_success(import_scenario_alternatives(
+                db_map,
+                [["scenario", "alternative1"], ["scenario", "alternative3"], ["scenario", "alternative2", "alternative3"]],
+            ))
+            self.assertEqual(count, 3)
+            scenario_alternatives = self.scenario_alternatives(db_map)
+            self.assertEqual(scenario_alternatives, {"scenario": {"alternative1": 1, "alternative2": 2, "alternative3": 3}})
 
     def test_fails_with_nonexistent_before_alternative(self):
-        import_data(self._db_map, scenarios=["scenario"], alternatives=["alternative"])
-        count, errors = import_scenario_alternatives(
-            self._db_map, [["scenario", "alternative", "nonexistent_alternative"]]
-        )
-        self.assertEqual(
-            errors,
-            [
-                "can't insert alternative 'alternative' before 'nonexistent_alternative' "
-                "because the latter is not in scenario 'scenario'"
-            ],
-        )
-        self.assertEqual(count, 0)
-        scenario_alternatives = self.scenario_alternatives()
-        self.assertEqual(scenario_alternatives, {})
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(import_data(db_map, scenarios=["scenario"], alternatives=["alternative"]))
+            count, errors = import_scenario_alternatives(
+                db_map, [["scenario", "alternative", "nonexistent_alternative"]]
+            )
+            self.assertEqual(
+                errors,
+                [
+                    "can't insert alternative 'alternative' before 'nonexistent_alternative' "
+                    "because the latter is not in scenario 'scenario'"
+                ],
+            )
+            self.assertEqual(count, 0)
+            scenario_alternatives = self.scenario_alternatives(db_map)
+            self.assertEqual(scenario_alternatives, {})
 
     def test_importing_existing_scenario_alternative_does_not_alter_scenario_alternatives(self):
-        import_data(self._db_map, scenarios=["scenario"], alternatives=["alternative1", "alternative2"])
-        count, errors = import_scenario_alternatives(
-            self._db_map,
-            [["scenario", "alternative2", "alternative1"], ["scenario", "alternative1"]],
-        )
-        self.assertFalse(errors)
-        self.assertEqual(count, 2)
-        scenario_alternatives = self.scenario_alternatives()
-        self.assertEqual(scenario_alternatives, {"scenario": {"alternative1": 2, "alternative2": 1}})
-        count, errors = import_scenario_alternatives(
-            self._db_map,
-            [["scenario", "alternative1"]],
-        )
-        self.assertFalse(errors)
-        self.assertEqual(count, 0)
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(import_data(db_map, scenarios=["scenario"], alternatives=["alternative1", "alternative2"]))
+            count = self._assert_success(import_scenario_alternatives(
+                db_map,
+                [["scenario", "alternative2", "alternative1"], ["scenario", "alternative1"]],
+            ))
+            self.assertEqual(count, 2)
+            scenario_alternatives = self.scenario_alternatives(db_map)
+            self.assertEqual(scenario_alternatives, {"scenario": {"alternative1": 2, "alternative2": 1}})
+            count = self._assert_success(import_scenario_alternatives(
+                db_map,
+                [["scenario", "alternative1"]],
+            ))
+            self.assertEqual(count, 0)
 
     def test_import_scenario_alternatives_in_arbitrary_order(self):
-        count, errors = import_scenarios(self._db_map, [("A (1)", False, "")])
-        self.assertEqual(errors, [])
-        self.assertEqual(count, 1)
-        count, errors = import_alternatives(
-            self._db_map, [("Base", "Base alternative"), ("b", ""), ("c", ""), ("d", "")]
-        )
-        self.assertEqual(errors, [])
-        self.assertEqual(count, 3)
-        count, errors = import_scenario_alternatives(
-            self._db_map, [("A (1)", "c", "d"), ("A (1)", "d", None), ("A (1)", "Base", "b"), ("A (1)", "b", "c")]
-        )
-        self.assertEqual(errors, [])
-        self.assertEqual(count, 4)
-        scenario_alternatives = self.scenario_alternatives()
-        self.assertEqual(scenario_alternatives, {"A (1)": {"Base": 1, "b": 2, "c": 3, "d": 4}})
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            count = self._assert_success(import_scenarios(db_map, [("A (1)", False, "")]))
+            self.assertEqual(count, 1)
+            count = self._assert_success(import_alternatives(
+                db_map, [("Base", "Base alternative"), ("b", ""), ("c", ""), ("d", "")]
+            ))
+            self.assertEqual(count, 3)
+            count = self._assert_success(import_scenario_alternatives(
+                db_map, [("A (1)", "c", "d"), ("A (1)", "d", None), ("A (1)", "Base", "b"), ("A (1)", "b", "c")]
+            ))
+            self.assertEqual(count, 4)
+            scenario_alternatives = self.scenario_alternatives(db_map)
+            self.assertEqual(scenario_alternatives, {"A (1)": {"Base": 1, "b": 2, "c": 3, "d": 4}})
 
     def test_insert_scenario_alternative_in_the_middle_of_other_alternatives(self):
-        import_data(self._db_map, scenarios=["scenario"], alternatives=["alternative1", "alternative2", "alternative3"])
-        count, errors = import_scenario_alternatives(
-            self._db_map,
-            [["scenario", "alternative2", "alternative1"], ["scenario", "alternative1"]],
-        )
-        self.assertFalse(errors)
-        self.assertEqual(count, 2)
-        scenario_alternatives = self.scenario_alternatives()
-        self.assertEqual(scenario_alternatives, {"scenario": {"alternative1": 2, "alternative2": 1}})
-        count, errors = import_scenario_alternatives(self._db_map, [["scenario", "alternative3", "alternative1"]])
-        self.assertFalse(errors)
-        self.assertEqual(count, 2)
-        scenario_alternatives = self.scenario_alternatives()
-        self.assertEqual(scenario_alternatives, {"scenario": {"alternative1": 3, "alternative2": 1, "alternative3": 2}})
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(import_data(db_map, scenarios=["scenario"], alternatives=["alternative1", "alternative2", "alternative3"]))
+            count = self._assert_success(import_scenario_alternatives(
+                db_map,
+                [["scenario", "alternative2", "alternative1"], ["scenario", "alternative1"]],
+            ))
+            self.assertEqual(count, 2)
+            scenario_alternatives = self.scenario_alternatives(db_map)
+            self.assertEqual(scenario_alternatives, {"scenario": {"alternative1": 2, "alternative2": 1}})
+            count = self._assert_success(import_scenario_alternatives(db_map, [["scenario", "alternative3", "alternative1"]]))
+            self.assertEqual(count, 2)
+            scenario_alternatives = self.scenario_alternatives(db_map)
+            self.assertEqual(scenario_alternatives, {"scenario": {"alternative1": 3, "alternative2": 1, "alternative3": 2}})
 
     def test_import_inconsistent_scenario_alternatives(self):
-        import_data(self._db_map, scenarios=["scenario"], alternatives=["alternative1", "alternative2", "alternative3"])
-        count, errors = import_scenario_alternatives(
-            self._db_map,
-            [["scenario", "alternative3", "alternative1"], ["scenario", "alternative1"]],
-        )
-        self.assertFalse(errors)
-        self.assertEqual(count, 2)
-        scenario_alternatives = self.scenario_alternatives()
-        self.assertEqual(scenario_alternatives, {"scenario": {"alternative1": 2, "alternative3": 1}})
-        count, errors = import_scenario_alternatives(
-            self._db_map,
-            [
-                ["scenario", "alternative3", "alternative2"],
-                ["scenario", "alternative2", "alternative1"],
-                ["scenario", "alternative1"],
-            ],
-        )
-        self.assertFalse(errors)
-        self.assertEqual(count, 2)
-        scenario_alternatives = self.scenario_alternatives()
-        self.assertEqual(scenario_alternatives, {"scenario": {"alternative1": 3, "alternative2": 2, "alternative3": 1}})
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(import_data(db_map, scenarios=["scenario"], alternatives=["alternative1", "alternative2", "alternative3"]))
+            count = self._assert_success(import_scenario_alternatives(
+                db_map,
+                [["scenario", "alternative3", "alternative1"], ["scenario", "alternative1"]],
+            ))
+            self.assertEqual(count, 2)
+            scenario_alternatives = self.scenario_alternatives(db_map)
+            self.assertEqual(scenario_alternatives, {"scenario": {"alternative1": 2, "alternative3": 1}})
+            count = self._assert_success(import_scenario_alternatives(
+                db_map,
+                [
+                    ["scenario", "alternative3", "alternative2"],
+                    ["scenario", "alternative2", "alternative1"],
+                    ["scenario", "alternative1"],
+                ],
+            ))
+            self.assertEqual(count, 2)
+            scenario_alternatives = self.scenario_alternatives(db_map)
+            self.assertEqual(scenario_alternatives, {"scenario": {"alternative1": 3, "alternative2": 2, "alternative3": 1}})
 
-    def scenario_alternatives(self):
-        self._db_map.commit_session("test")
+    @staticmethod
+    def scenario_alternatives(db_map):
+        db_map.commit_session("test")
         scenario_alternative_qry = (
-            self._db_map.query(
-                self._db_map.scenario_sq.c.name.label("scenario_name"),
-                self._db_map.alternative_sq.c.name.label("alternative_name"),
-                self._db_map.scenario_alternative_sq.c.rank,
+            db_map.query(
+                db_map.scenario_sq.c.name.label("scenario_name"),
+                db_map.alternative_sq.c.name.label("alternative_name"),
+                db_map.scenario_alternative_sq.c.rank,
             )
-            .filter(self._db_map.scenario_alternative_sq.c.scenario_id == self._db_map.scenario_sq.c.id)
-            .filter(self._db_map.scenario_alternative_sq.c.alternative_id == self._db_map.alternative_sq.c.id)
+            .filter(db_map.scenario_alternative_sq.c.scenario_id == db_map.scenario_sq.c.id)
+            .filter(db_map.scenario_alternative_sq.c.alternative_id == db_map.alternative_sq.c.id)
         )
         scenario_alternatives = {}
         for scenario_alternative in scenario_alternative_qry:
@@ -1441,221 +1317,204 @@ class TestImportScenarioAlternative(unittest.TestCase):
         return scenario_alternatives
 
 
-class TestImportMetadata(unittest.TestCase):
+class TestImportMetadata(ImportsTestCase):
     def test_import_metadata(self):
-        db_map = create_db_map()
-        count, errors = import_metadata(db_map, ['{"name": "John", "age": 17}', '{"name": "Charly", "age": 90}'])
-        self.assertEqual(count, 4)
-        self.assertFalse(errors)
-        db_map.commit_session("test")
-        metadata = [(x.name, x.value) for x in db_map.query(db_map.metadata_sq)]
-        self.assertEqual(len(metadata), 4)
-        self.assertIn(("name", "John"), metadata)
-        self.assertIn(("name", "Charly"), metadata)
-        self.assertIn(("age", "17"), metadata)
-        self.assertIn(("age", "90"), metadata)
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            count = self._assert_success(import_metadata(db_map, ['{"name": "John", "age": 17}', '{"name": "Charly", "age": 90}']))
+            self.assertEqual(count, 4)
+            db_map.commit_session("test")
+            metadata = [(x.name, x.value) for x in db_map.query(db_map.metadata_sq)]
+            self.assertEqual(len(metadata), 4)
+            self.assertIn(("name", "John"), metadata)
+            self.assertIn(("name", "Charly"), metadata)
+            self.assertIn(("age", "17"), metadata)
+            self.assertIn(("age", "90"), metadata)
 
     def test_import_metadata_with_duplicate_entry(self):
-        db_map = create_db_map()
-        count, errors = import_metadata(db_map, ['{"name": "John", "age": 17}', '{"name": "Charly", "age": 17}'])
-        self.assertEqual(count, 3)
-        self.assertFalse(errors)
-        db_map.commit_session("test")
-        metadata = [(x.name, x.value) for x in db_map.query(db_map.metadata_sq)]
-        self.assertEqual(len(metadata), 3)
-        self.assertIn(("name", "John"), metadata)
-        self.assertIn(("name", "Charly"), metadata)
-        self.assertIn(("age", "17"), metadata)
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            count = self._assert_success(import_metadata(db_map, ['{"name": "John", "age": 17}', '{"name": "Charly", "age": 17}']))
+            self.assertEqual(count, 3)
+            db_map.commit_session("test")
+            metadata = [(x.name, x.value) for x in db_map.query(db_map.metadata_sq)]
+            self.assertEqual(len(metadata), 3)
+            self.assertIn(("name", "John"), metadata)
+            self.assertIn(("name", "Charly"), metadata)
+            self.assertIn(("age", "17"), metadata)
 
     def test_import_metadata_with_nested_dict(self):
-        db_map = create_db_map()
-        count, errors = import_metadata(db_map, ['{"name": "John", "info": {"age": 17, "city": "LA"}}'])
-        db_map.commit_session("test")
-        metadata = [(x.name, x.value) for x in db_map.query(db_map.metadata_sq)]
-        self.assertEqual(count, 2)
-        self.assertFalse(errors)
-        self.assertEqual(len(metadata), 2)
-        self.assertIn(("name", "John"), metadata)
-        self.assertIn(("info", "{'age': 17, 'city': 'LA'}"), metadata)
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            count = self._assert_success(import_metadata(db_map, ['{"name": "John", "info": {"age": 17, "city": "LA"}}']))
+            db_map.commit_session("test")
+            metadata = [(x.name, x.value) for x in db_map.query(db_map.metadata_sq)]
+            self.assertEqual(count, 2)
+            self.assertEqual(len(metadata), 2)
+            self.assertIn(("name", "John"), metadata)
+            self.assertIn(("info", "{'age': 17, 'city': 'LA'}"), metadata)
 
     def test_import_metadata_with_nested_list(self):
-        db_map = create_db_map()
-        count, errors = import_metadata(db_map, ['{"contributors": [{"name": "John"}, {"name": "Charly"}]}'])
-        db_map.commit_session("test")
-        metadata = [(x.name, x.value) for x in db_map.query(db_map.metadata_sq)]
-        self.assertEqual(count, 2)
-        self.assertFalse(errors)
-        self.assertEqual(len(metadata), 2)
-        self.assertIn(("contributors", "{'name': 'John'}"), metadata)
-        self.assertIn(("contributors", "{'name': 'Charly'}"), metadata)
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            count = self._assert_success(import_metadata(db_map, ['{"contributors": [{"name": "John"}, {"name": "Charly"}]}']))
+            db_map.commit_session("test")
+            metadata = [(x.name, x.value) for x in db_map.query(db_map.metadata_sq)]
+            self.assertEqual(count, 2)
+            self.assertEqual(len(metadata), 2)
+            self.assertIn(("contributors", "{'name': 'John'}"), metadata)
+            self.assertIn(("contributors", "{'name': 'Charly'}"), metadata)
 
     def test_import_unformatted_metadata(self):
-        db_map = create_db_map()
-        count, errors = import_metadata(db_map, ["not a JSON object"])
-        db_map.commit_session("test")
-        metadata = [(x.name, x.value) for x in db_map.query(db_map.metadata_sq)]
-        self.assertEqual(count, 1)
-        self.assertFalse(errors)
-        self.assertEqual(len(metadata), 1)
-        self.assertIn(("unnamed", "not a JSON object"), metadata)
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            count = self._assert_success(import_metadata(db_map, ["not a JSON object"]))
+            db_map.commit_session("test")
+            metadata = [(x.name, x.value) for x in db_map.query(db_map.metadata_sq)]
+            self.assertEqual(count, 1)
+            self.assertEqual(len(metadata), 1)
+            self.assertIn(("unnamed", "not a JSON object"), metadata)
 
 
-class TestImportEntityMetadata(unittest.TestCase):
-    @staticmethod
-    def populate(db_map):
-        import_object_classes(db_map, ["object_class1", "object_class2"])
-        import_relationship_classes(db_map, [("rel_cls1", ("object_class1", "object_class2"))])
-        import_objects(db_map, [("object_class1", "object1"), ("object_class2", "object2")])
-        import_relationships(db_map, [("rel_cls1", ("object1", "object2"))])
-        import_object_parameters(db_map, [("object_class1", "param1")])
-        import_relationship_parameters(db_map, [("rel_cls1", "param2")])
-        import_object_parameter_values(db_map, [("object_class1", "object1", "param1", "value1")])
-        import_relationship_parameter_values(db_map, [("rel_cls1", ("object1", "object2"), "param2", "value2")])
-        import_metadata(db_map, ['{"co-author": "John", "age": 17}', '{"co-author": "Charly", "age": 90}'])
+class TestImportEntityMetadata(ImportsTestCase):
+    def populate(self, db_map):
+        self._assert_success(import_object_classes(db_map, ["object_class1", "object_class2"]))
+        self._assert_success(import_relationship_classes(db_map, [("rel_cls1", ("object_class1", "object_class2"))]))
+        self._assert_success(import_objects(db_map, [("object_class1", "object1"), ("object_class2", "object2")]))
+        self._assert_success(import_relationships(db_map, [("rel_cls1", ("object1", "object2"))]))
+        self._assert_success(import_object_parameters(db_map, [("object_class1", "param1")]))
+        self._assert_success(import_relationship_parameters(db_map, [("rel_cls1", "param2")]))
+        self._assert_success(import_object_parameter_values(db_map, [("object_class1", "object1", "param1", "value1")]))
+        self._assert_success(import_relationship_parameter_values(db_map, [("rel_cls1", ("object1", "object2"), "param2", "value2")]))
+        self._assert_success(import_metadata(db_map, ['{"co-author": "John", "age": 17}', '{"co-author": "Charly", "age": 90}']))
 
     def test_import_object_metadata(self):
-        db_map = create_db_map()
-        self.populate(db_map)
-        count, errors = import_object_metadata(
-            db_map,
-            [
-                ("object_class1", "object1", '{"co-author": "John", "age": 90}'),
-                ("object_class1", "object1", '{"co-author": "Charly", "age": 17}'),
-            ],
-        )
-        self.assertEqual(count, 4)
-        self.assertFalse(errors)
-        db_map.commit_session("test")
-        metadata = [
-            (x.entity_name, x.metadata_name, x.metadata_value) for x in db_map.query(db_map.ext_entity_metadata_sq)
-        ]
-        self.assertEqual(len(metadata), 4)
-        self.assertIn(("object1", "co-author", "John"), metadata)
-        self.assertIn(("object1", "age", "90"), metadata)
-        self.assertIn(("object1", "co-author", "Charly"), metadata)
-        self.assertIn(("object1", "age", "17"), metadata)
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self.populate(db_map)
+            count = self._assert_success(import_object_metadata(
+                db_map,
+                [
+                    ("object_class1", "object1", '{"co-author": "John", "age": 90}'),
+                    ("object_class1", "object1", '{"co-author": "Charly", "age": 17}'),
+                ],
+            ))
+            self.assertEqual(count, 4)
+            db_map.commit_session("test")
+            metadata = [
+                (x.entity_name, x.metadata_name, x.metadata_value) for x in db_map.query(db_map.ext_entity_metadata_sq)
+            ]
+            self.assertEqual(len(metadata), 4)
+            self.assertIn(("object1", "co-author", "John"), metadata)
+            self.assertIn(("object1", "age", "90"), metadata)
+            self.assertIn(("object1", "co-author", "Charly"), metadata)
+            self.assertIn(("object1", "age", "17"), metadata)
 
     def test_import_relationship_metadata(self):
-        db_map = create_db_map()
-        self.populate(db_map)
-        count, errors = import_relationship_metadata(
-            db_map,
-            [
-                ("rel_cls1", ("object1", "object2"), '{"co-author": "John", "age": 90}'),
-                ("rel_cls1", ("object1", "object2"), '{"co-author": "Charly", "age": 17}'),
-            ],
-        )
-        self.assertEqual(count, 4)
-        self.assertFalse(errors)
-        db_map.commit_session("test")
-        metadata = [(x.metadata_name, x.metadata_value) for x in db_map.query(db_map.ext_entity_metadata_sq)]
-        self.assertEqual(len(metadata), 4)
-        self.assertIn(("co-author", "John"), metadata)
-        self.assertIn(("age", "90"), metadata)
-        self.assertIn(("co-author", "Charly"), metadata)
-        self.assertIn(("age", "17"), metadata)
-        db_map.close()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self.populate(db_map)
+            count = self._assert_success(import_relationship_metadata(
+                db_map,
+                [
+                    ("rel_cls1", ("object1", "object2"), '{"co-author": "John", "age": 90}'),
+                    ("rel_cls1", ("object1", "object2"), '{"co-author": "Charly", "age": 17}'),
+                ],
+            ))
+            self.assertEqual(count, 4)
+            db_map.commit_session("test")
+            metadata = [(x.metadata_name, x.metadata_value) for x in db_map.query(db_map.ext_entity_metadata_sq)]
+            self.assertEqual(len(metadata), 4)
+            self.assertIn(("co-author", "John"), metadata)
+            self.assertIn(("age", "90"), metadata)
+            self.assertIn(("co-author", "Charly"), metadata)
+            self.assertIn(("age", "17"), metadata)
 
 
-class TestImportParameterValueMetadata(unittest.TestCase):
-    def setUp(self):
-        self._db_map = create_db_map()
-        import_metadata(self._db_map, ['{"co-author": "John", "age": 17}'])
-
-    def tearDown(self):
-        self._db_map.close()
+class TestImportParameterValueMetadata(ImportsTestCase):
+    def _import_metadata(self, db_map):
+        self._assert_success(import_metadata(db_map, ['{"co-author": "John", "age": 17}']))
 
     def test_import_object_parameter_value_metadata(self):
-        import_object_classes(self._db_map, ["object_class"])
-        import_object_parameters(self._db_map, [("object_class", "param")])
-        import_objects(self._db_map, [("object_class", "object")])
-        import_object_parameter_values(self._db_map, [("object_class", "object", "param", "value")])
-        count, errors = import_object_parameter_value_metadata(
-            self._db_map, [("object_class", "object", "param", '{"co-author": "John", "age": 17}')]
-        )
-        self.assertEqual(errors, [])
-        self.assertEqual(count, 2)
-        self._db_map.commit_session("test")
-        metadata = self._db_map.query(self._db_map.ext_parameter_value_metadata_sq).all()
-        self.assertEqual(len(metadata), 2)
-        self.assertEqual(
-            dict(metadata[0]),
-            {
-                "alternative_name": "Base",
-                "entity_name": "object",
-                "id": 1,
-                "metadata_id": 1,
-                "metadata_name": "co-author",
-                "metadata_value": "John",
-                "parameter_name": "param",
-                "parameter_value_id": 1,
-                "commit_id": 2,
-            },
-        )
-        self.assertEqual(
-            dict(metadata[1]),
-            {
-                "alternative_name": "Base",
-                "entity_name": "object",
-                "id": 2,
-                "metadata_id": 2,
-                "metadata_name": "age",
-                "metadata_value": "17",
-                "parameter_name": "param",
-                "parameter_value_id": 1,
-                "commit_id": 2,
-            },
-        )
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._import_metadata(db_map)
+            self._assert_success(import_object_classes(db_map, ["object_class"]))
+            self._assert_success(import_object_parameters(db_map, [("object_class", "param")]))
+            self._assert_success(import_objects(db_map, [("object_class", "object")]))
+            self._assert_success(import_object_parameter_values(db_map, [("object_class", "object", "param", "value")]))
+            count = self._assert_success(import_object_parameter_value_metadata(
+                db_map, [("object_class", "object", "param", '{"co-author": "John", "age": 17}')]
+            ))
+            self.assertEqual(count, 2)
+            db_map.commit_session("test")
+            metadata = db_map.query(db_map.ext_parameter_value_metadata_sq).all()
+            self.assertEqual(len(metadata), 2)
+            self.assertEqual(
+                dict(metadata[0]),
+                {
+                    "alternative_name": "Base",
+                    "entity_name": "object",
+                    "id": 1,
+                    "metadata_id": 1,
+                    "metadata_name": "co-author",
+                    "metadata_value": "John",
+                    "parameter_name": "param",
+                    "parameter_value_id": 1,
+                    "commit_id": 2,
+                },
+            )
+            self.assertEqual(
+                dict(metadata[1]),
+                {
+                    "alternative_name": "Base",
+                    "entity_name": "object",
+                    "id": 2,
+                    "metadata_id": 2,
+                    "metadata_name": "age",
+                    "metadata_value": "17",
+                    "parameter_name": "param",
+                    "parameter_value_id": 1,
+                    "commit_id": 2,
+                },
+            )
 
     def test_import_relationship_parameter_value_metadata(self):
-        import_object_classes(self._db_map, ["object_class"])
-        import_objects(self._db_map, [("object_class", "object")])
-        import_relationship_classes(self._db_map, (("relationship_class", ("object_class",)),))
-        import_relationships(self._db_map, (("relationship_class", ("object",)),))
-        import_relationship_parameters(self._db_map, (("relationship_class", "param"),))
-        import_relationship_parameter_values(self._db_map, (("relationship_class", ("object",), "param", "value"),))
-        count, errors = import_relationship_parameter_value_metadata(
-            self._db_map, (("relationship_class", ("object",), "param", '{"co-author": "John", "age": 17}'),)
-        )
-        self.assertEqual(errors, [])
-        self.assertEqual(count, 2)
-        self._db_map.commit_session("test")
-        metadata = self._db_map.query(self._db_map.ext_parameter_value_metadata_sq).all()
-        self.assertEqual(len(metadata), 2)
-        self.assertEqual(
-            dict(metadata[0]),
-            {
-                "alternative_name": "Base",
-                "entity_name": "object__",
-                "id": 1,
-                "metadata_id": 1,
-                "metadata_name": "co-author",
-                "metadata_value": "John",
-                "parameter_name": "param",
-                "parameter_value_id": 1,
-                "commit_id": 2,
-            },
-        )
-        self.assertEqual(
-            dict(metadata[1]),
-            {
-                "alternative_name": "Base",
-                "entity_name": "object__",
-                "id": 2,
-                "metadata_id": 2,
-                "metadata_name": "age",
-                "metadata_value": "17",
-                "parameter_name": "param",
-                "parameter_value_id": 1,
-                "commit_id": 2,
-            },
-        )
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._import_metadata(db_map)
+            self._assert_success(import_object_classes(db_map, ["object_class"]))
+            self._assert_success(import_objects(db_map, [("object_class", "object")]))
+            self._assert_success(import_relationship_classes(db_map, (("relationship_class", ("object_class",)),)))
+            self._assert_success(import_relationships(db_map, (("relationship_class", ("object",)),)))
+            self._assert_success(import_relationship_parameters(db_map, (("relationship_class", "param"),)))
+            self._assert_success(import_relationship_parameter_values(db_map, (("relationship_class", ("object",), "param", "value"),)))
+            count = self._assert_success(import_relationship_parameter_value_metadata(
+                db_map, (("relationship_class", ("object",), "param", '{"co-author": "John", "age": 17}'),)
+            ))
+            self.assertEqual(count, 2)
+            db_map.commit_session("test")
+            metadata = db_map.query(db_map.ext_parameter_value_metadata_sq).all()
+            self.assertEqual(len(metadata), 2)
+            self.assertEqual(
+                dict(metadata[0]),
+                {
+                    "alternative_name": "Base",
+                    "entity_name": "object__",
+                    "id": 1,
+                    "metadata_id": 1,
+                    "metadata_name": "co-author",
+                    "metadata_value": "John",
+                    "parameter_name": "param",
+                    "parameter_value_id": 1,
+                    "commit_id": 2,
+                },
+            )
+            self.assertEqual(
+                dict(metadata[1]),
+                {
+                    "alternative_name": "Base",
+                    "entity_name": "object__",
+                    "id": 2,
+                    "metadata_id": 2,
+                    "metadata_name": "age",
+                    "metadata_value": "17",
+                    "parameter_name": "param",
+                    "parameter_value_id": 1,
+                    "commit_id": 2,
+                },
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_parameter_value.py
+++ b/tests/test_parameter_value.py
@@ -36,9 +36,11 @@ from spinedb_api.parameter_value import (
     convert_map_to_table,
     deep_copy_value,
     duration_to_relativedelta,
+    fancy_type_to_type_and_rank,
     from_database,
     relativedelta_to_duration,
     to_database,
+    type_and_rank_to_fancy_type,
 )
 
 
@@ -1094,6 +1096,32 @@ class TestParameterValue(unittest.TestCase):
         self.assertEqual(x, copy_of_x)
         self.assertIsNot(x, copy_of_x)
         self.assertIsNot(x.get_value("T1"), copy_of_x.get_value("T1"))
+
+
+class TestTypeAndRankToFancyType(unittest.TestCase):
+    def test_function_works(self):
+        self.assertEqual(type_and_rank_to_fancy_type("float", 0), "float")
+        self.assertEqual(type_and_rank_to_fancy_type("str", 0), "str")
+        self.assertEqual(type_and_rank_to_fancy_type("bool", 0), "bool")
+        self.assertEqual(type_and_rank_to_fancy_type("date_time", 0), "date_time")
+        self.assertEqual(type_and_rank_to_fancy_type("duration", 0), "duration")
+        self.assertEqual(type_and_rank_to_fancy_type("array", 1), "array")
+        self.assertEqual(type_and_rank_to_fancy_type("time_pattern", 1), "time_pattern")
+        self.assertEqual(type_and_rank_to_fancy_type("time_series", 1), "time_series")
+        self.assertEqual(type_and_rank_to_fancy_type("map", 23), "23d_map")
+
+
+class TestFancyTypeToTypeAndRank(unittest.TestCase):
+    def test_function_works(self):
+        self.assertEqual(fancy_type_to_type_and_rank("float"), ("float", 0))
+        self.assertEqual(fancy_type_to_type_and_rank("str"), ("str", 0))
+        self.assertEqual(fancy_type_to_type_and_rank("bool"), ("bool", 0))
+        self.assertEqual(fancy_type_to_type_and_rank("date_time"), ("date_time", 0))
+        self.assertEqual(fancy_type_to_type_and_rank("duration"), ("duration", 0))
+        self.assertEqual(fancy_type_to_type_and_rank("array"), ("array", 1))
+        self.assertEqual(fancy_type_to_type_and_rank("time_pattern"), ("time_pattern", 1))
+        self.assertEqual(fancy_type_to_type_and_rank("time_series"), ("time_series", 1))
+        self.assertEqual(fancy_type_to_type_and_rank("23d_map"), ("map", 23))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds parameter_type table to the database and a corresponding migration script. The table defines valid parameter types for parameter definitions. If a definition has no entries in the table, all types are considered valid. There is a new mapped item, `ParameterTypeItem` that mirrors the rows of parameter_type, but the information can be accessed more conveniently via the new `parameter_type_list` field of `ParameterDefinitionItem`.

Currently, we do not enforce valid types anywhere. There is some support for checking the value and default value types geared towards use in Toolbox but it is left to clients to ensure their types are valid.

Re spine-tools/Spine-Toolbox#2791

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
