### PR TITLE
Fix issues with items that have been committed, then removed and replaced by new items

### DIFF
--- a/spinedb_api/db_mapping.py
+++ b/spinedb_api/db_mapping.py
@@ -278,14 +278,22 @@ class DatabaseMapping(DatabaseMappingQueryMixin, DatabaseMappingCommitMixin, Dat
                     f"one. This database cannot be reverted back to an older version."
                     f"<ul>"
                     f"  <li>If you have installed through pip, and there is "
-                    f"<a href=""https://github.com/spine-tools/Spine-Toolbox#upgrade-when-using-pipx"">no newer "
+                    f"<a href="
+                    "https://github.com/spine-tools/Spine-Toolbox#upgrade-when-using-pipx"
+                    ">no newer "
                     f"Toolbox version available</a>, you need to "
-                    f"<a href=""https://github.com/spine-tools/Spine-Toolbox#installation-from-sources-using-git"">"
+                    f"<a href="
+                    "https://github.com/spine-tools/Spine-Toolbox#installation-from-sources-using-git"
+                    ">"
                     f"install using git</a> or wait for the next release (could be a month).</li>"
                     f"  <li>If you have grabbed a Toolbox zip-file, then you need to try to "
-                    f"<a href=""https://github.com/spine-tools/Spine-Toolbox#installation-with-python-and-pipx"">"
+                    f"<a href="
+                    "https://github.com/spine-tools/Spine-Toolbox#installation-with-python-and-pipx"
+                    ">"
                     f"install using pip</a> or, to be safe, "
-                    f"<a href=""https://github.com/spine-tools/Spine-Toolbox#installation-from-sources-using-git"">"
+                    f"<a href="
+                    "https://github.com/spine-tools/Spine-Toolbox#installation-from-sources-using-git"
+                    ">"
                     f"install from sources using git</a> to get the latest Spine Toolbox."
                 )
                 option_to_kwargs = {}
@@ -552,7 +560,7 @@ class DatabaseMapping(DatabaseMappingQueryMixin, DatabaseMappingCommitMixin, Dat
                 self._mapped_tables[table].purged for table in existing_item.ref_types() if table in self._mapped_tables
             )
         ):
-            checked_item.status = Status.to_update
+            checked_item.replaced_item_waiting_for_removal = existing_item
         return checked_item.public_item, error
 
     def add_items(self, item_type, *items, check=True, strict=False):
@@ -731,7 +739,7 @@ class DatabaseMapping(DatabaseMappingQueryMixin, DatabaseMappingCommitMixin, Dat
         item_type = self.real_item_type(item_type)
         mapped_table = self.mapped_table(item_type)
         restored_item = mapped_table.restore_item(id_)
-        return (restored_item.public_item, "") if restored_item else (None, "failed to restore item")
+        return (restored_item.public_item, None) if restored_item else (None, "failed to restore item")
 
     def restore_items(self, item_type, *ids):
         """Restores many previously removed items into the in-memory mapping.

--- a/spinedb_api/db_mapping_base.py
+++ b/spinedb_api/db_mapping_base.py
@@ -144,7 +144,7 @@ class DatabaseMappingBase:
 
     def make_item(self, item_type, **item):
         factory = self.item_factory(item_type)
-        return factory(self, item_type, **item)
+        return factory(self, **item)
 
     def dirty_ids(self, item_type):
         return {
@@ -367,7 +367,8 @@ class _MappedTable(dict):
         self._item_type = item_type
         self._ids_by_unique_key_value = {}
         self._temp_id_lookup = {}
-        self.wildcard_item = MappedItemBase(self._db_map, self._item_type, id=Asterisk)
+        self.wildcard_item = MappedItemBase(self._db_map, id=Asterisk)
+        self.wildcard_item.item_type = self._item_type
 
     @property
     def purged(self):
@@ -679,6 +680,7 @@ class _MappedTable(dict):
 class MappedItemBase(dict):
     """A dictionary that represents a db item."""
 
+    item_type = "not implemented"
     fields = {}
     """A dictionary mapping fields to a another dict mapping "type" to a Python type,
     "value" to a description of the value for the key, and "optional" to a bool."""
@@ -714,14 +716,14 @@ class MappedItemBase(dict):
     """A set with fields that should be ignored in validations."""
     is_protected = False
 
-    def __init__(self, db_map, item_type, **kwargs):
+    def __init__(self, db_map, **kwargs):
         """
         Args:
             db_map (DatabaseMappingBase): the DB where this item belongs.
+            **kwargs: parameter passed to dict constructor
         """
         super().__init__(**kwargs)
         self._db_map = db_map
-        self._item_type = item_type
         self._referrers = {}
         self._weak_referrers = {}
         self.restore_callbacks = set()
@@ -798,15 +800,6 @@ class MappedItemBase(dict):
         return self._removed
 
     @property
-    def item_type(self):
-        """Returns this item's type
-
-        Returns:
-            str
-        """
-        return self._item_type
-
-    @property
     def key(self):
         """Returns a tuple (item_type, id) for convenience, or None if this item doesn't yet have an id.
 
@@ -816,7 +809,7 @@ class MappedItemBase(dict):
         id_ = dict.get(self, "id")
         if not isinstance(id_, TempId):
             return None
-        return (self._item_type, id_)
+        return (self.item_type, id_)
 
     @property
     def has_valid_id(self):
@@ -890,7 +883,7 @@ class MappedItemBase(dict):
             MappedItemBase
         """
         if self.status == Status.to_update:
-            db_item = self._db_map.make_item(self._item_type, **self.backup)
+            db_item = self._db_map.make_item(self.item_type, **self.backup)
             db_item.polish()
             return db_item
         return self
@@ -1181,14 +1174,14 @@ class MappedItemBase(dict):
 
     def cascade_add_unique(self):
         """Adds item and all its referrers unique keys and ids in cascade."""
-        mapped_table = self._db_map.mapped_table(self._item_type)
+        mapped_table = self._db_map.mapped_table(self.item_type)
         mapped_table.add_unique(self)
         for referrer in self._referrers.values():
             referrer.cascade_add_unique()
 
     def cascade_remove_unique(self):
         """Removes item and all its referrers unique keys and ids in cascade."""
-        mapped_table = self._db_map.mapped_table(self._item_type)
+        mapped_table = self._db_map.mapped_table(self.item_type)
         mapped_table.remove_unique(self)
         for referrer in self._referrers.values():
             referrer.cascade_remove_unique()
@@ -1210,7 +1203,7 @@ class MappedItemBase(dict):
 
     def __repr__(self):
         """Overridden to return a more verbose representation."""
-        return f"{self._item_type}{self._extended()}"
+        return f"{self.item_type}{self._extended()}"
 
     def __getattr__(self, name):
         """Overridden to return the dictionary key named after the attribute, or None if it doesn't exist."""

--- a/spinedb_api/mapped_items.py
+++ b/spinedb_api/mapped_items.py
@@ -9,6 +9,7 @@
 # Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
+import inspect
 from operator import itemgetter
 import re
 from .db_mapping_base import MappedItemBase
@@ -27,27 +28,7 @@ from .parameter_value import (
 
 
 def item_factory(item_type):
-    return {
-        "commit": CommitItem,
-        "entity_class": EntityClassItem,
-        "superclass_subclass": SuperclassSubclassItem,
-        "entity": EntityItem,
-        "entity_alternative": EntityAlternativeItem,
-        "entity_group": EntityGroupItem,
-        "display_mode": DisplayModeItem,
-        "entity_class_display_mode": EntityClassDisplayModeItem,
-        "parameter_definition": ParameterDefinitionItem,
-        "parameter_type": ParameterTypeItem,
-        "parameter_value": ParameterValueItem,
-        "parameter_value_list": ParameterValueListItem,
-        "list_value": ListValueItem,
-        "alternative": AlternativeItem,
-        "scenario": ScenarioItem,
-        "scenario_alternative": ScenarioAlternativeItem,
-        "metadata": MetadataItem,
-        "entity_metadata": EntityMetadataItem,
-        "parameter_value_metadata": ParameterValueMetadataItem,
-    }.get(item_type, MappedItemBase)
+    return ITEM_CLASS_BY_TYPE.get(item_type, MappedItemBase)
 
 
 _ENTITY_BYNAME_VALUE = (
@@ -57,6 +38,7 @@ _ENTITY_BYNAME_VALUE = (
 
 
 class CommitItem(MappedItemBase):
+    item_type = "commit"
     fields = {
         "comment": {"type": str, "value": "A comment describing the commit."},
         "date": {"type": str, "value": "Date and time of the commit in ISO 8601 format."},
@@ -71,6 +53,7 @@ class CommitItem(MappedItemBase):
 
 
 class EntityClassItem(MappedItemBase):
+    item_type = "entity_class"
     fields = {
         "name": {"type": str, "value": "The class name."},
         "dimension_name_list": {
@@ -138,6 +121,7 @@ class EntityClassItem(MappedItemBase):
 
 
 class EntityItem(MappedItemBase):
+    item_type = "entity"
     fields = {
         "entity_class_name": {"type": str, "value": "The entity class name."},
         "name": {"type": str, "value": "The entity name."},
@@ -282,6 +266,7 @@ class EntityItem(MappedItemBase):
 
 
 class EntityGroupItem(MappedItemBase):
+    item_type = "entity_group"
     fields = {
         "entity_class_name": {"type": str, "value": "The entity class name."},
         "group_name": {"type": str, "value": "The group entity name."},
@@ -327,6 +312,7 @@ class EntityGroupItem(MappedItemBase):
 
 
 class EntityAlternativeItem(MappedItemBase):
+    item_type = "entity_alternative"
     fields = {
         "entity_class_name": {"type": str, "value": "The entity class name."},
         "entity_byname": {
@@ -374,6 +360,7 @@ class EntityAlternativeItem(MappedItemBase):
 
 
 class DisplayModeItem(MappedItemBase):
+    item_type = "display_mode"
     fields = {
         "name": {"type": str, "value": "The display mode name."},
         "description": {"type": str, "value": "The display mode description.", "optional": True},
@@ -384,6 +371,7 @@ class DisplayModeItem(MappedItemBase):
 
 
 class EntityClassDisplayModeItem(MappedItemBase):
+    item_type = "entity_class_display_mode"
     fields = {
         "entity_class_name": {"type": str, "value": "The entity class name."},
         "display_mode_name": {"type": int, "value": "The display mode name."},
@@ -565,6 +553,7 @@ class ParameterItemBase(ParsedValueBase):
 
 
 class ParameterDefinitionItem(ParameterItemBase):
+    item_type = "parameter_definition"
     fields = {
         "entity_class_name": {"type": str, "value": "The entity class name."},
         "name": {"type": str, "value": "The parameter name."},
@@ -598,8 +587,8 @@ class ParameterDefinitionItem(ParameterItemBase):
         "parameter_value_list_id": (("parameter_value_list_name",), "id"),
     }
 
-    def __init__(self, db_map, item_type, **kwargs):
-        super().__init__(db_map, item_type, **kwargs)
+    def __init__(self, db_map, **kwargs):
+        super().__init__(db_map, **kwargs)
         self._init_type_list = kwargs.get("parameter_type_list")
 
     @property
@@ -752,6 +741,7 @@ class ParameterDefinitionItem(ParameterItemBase):
 
 
 class ParameterTypeItem(MappedItemBase):
+    item_type = "parameter_type"
     fields = {
         "entity_class_name": {"type": str, "value": "The entity class name."},
         "parameter_definition_name": {"type": str, "value": "The parameter name."},
@@ -804,6 +794,7 @@ class ParameterTypeItem(MappedItemBase):
 
 
 class ParameterValueItem(ParameterItemBase):
+    item_type = "parameter_value"
     fields = {
         "entity_class_name": {"type": str, "value": "The entity class name."},
         "parameter_definition_name": {"type": str, "value": "The parameter name."},
@@ -881,12 +872,14 @@ class ParameterValueItem(ParameterItemBase):
 
 
 class ParameterValueListItem(MappedItemBase):
+    item_type = "parameter_value_list"
     fields = {"name": {"type": str, "value": "The parameter value list name."}}
     unique_keys = (("name",),)
     required_key_combinations = (("name",),)
 
 
 class ListValueItem(ParsedValueBase):
+    item_type = "list_value"
     fields = {
         "parameter_value_list_name": {"type": str, "value": "The parameter value list name."},
         "value": {"type": bytes, "value": "The value."},
@@ -926,6 +919,7 @@ class ListValueItem(ParsedValueBase):
 
 
 class AlternativeItem(MappedItemBase):
+    item_type = "alternative"
     fields = {
         "name": {"type": str, "value": "The alternative name."},
         "description": {"type": str, "value": "The alternative description.", "optional": True},
@@ -936,6 +930,7 @@ class AlternativeItem(MappedItemBase):
 
 
 class ScenarioItem(MappedItemBase):
+    item_type = "scenario"
     fields = {
         "name": {"type": str, "value": "The scenario name."},
         "description": {"type": str, "value": "The scenario description.", "optional": True},
@@ -964,6 +959,7 @@ class ScenarioItem(MappedItemBase):
 
 
 class ScenarioAlternativeItem(MappedItemBase):
+    item_type = "scenario_alternative"
     fields = {
         "scenario_name": {"type": str, "value": "The scenario name."},
         "alternative_name": {"type": str, "value": "The alternative name."},
@@ -993,6 +989,7 @@ class ScenarioAlternativeItem(MappedItemBase):
 
 
 class MetadataItem(MappedItemBase):
+    item_type = "metadata"
     fields = {
         "name": {"type": str, "value": "The metadata entry name."},
         "value": {"type": str, "value": "The metadata entry value."},
@@ -1002,6 +999,7 @@ class MetadataItem(MappedItemBase):
 
 
 class EntityMetadataItem(MappedItemBase):
+    item_type = "entity_metadata"
     fields = {
         "entity_class_name": {"type": str, "value": "The entity class name."},
         "entity_byname": {"type": tuple, "value": _ENTITY_BYNAME_VALUE},
@@ -1039,6 +1037,7 @@ class EntityMetadataItem(MappedItemBase):
 
 
 class ParameterValueMetadataItem(MappedItemBase):
+    item_type = "parameter_value_metadata"
     fields = {
         "entity_class_name": {"type": str, "value": "The entity class name."},
         "parameter_definition_name": {"type": str, "value": "The parameter name."},
@@ -1094,6 +1093,7 @@ class ParameterValueMetadataItem(MappedItemBase):
 
 
 class SuperclassSubclassItem(MappedItemBase):
+    item_type = "superclass_subclass"
     fields = {
         "superclass_name": {"type": str, "value": "The superclass name."},
         "subclass_name": {"type": str, "value": "The subclass name."},
@@ -1124,3 +1124,9 @@ class SuperclassSubclassItem(MappedItemBase):
 
     def commit(self, _commit_id):
         super().commit(None)
+
+
+ITEM_CLASSES = tuple(
+    x for x in tuple(locals().values()) if inspect.isclass(x) and issubclass(x, MappedItemBase) and x != MappedItemBase
+)
+ITEM_CLASS_BY_TYPE = {klass.item_type: klass for klass in ITEM_CLASSES}

--- a/spinedb_api/mapped_items.py
+++ b/spinedb_api/mapped_items.py
@@ -760,7 +760,7 @@ class ParameterTypeItem(MappedItemBase):
     }
     unique_keys = (("entity_class_name", "parameter_definition_name", "type", "rank"),)
     required_key_combinations = (
-        ("entity_class_name", "entity_class_id"),
+        ("entity_class_name", "entity_class_id", "parameter_definition_id"),
         ("parameter_definition_name", "parameter_definition_id"),
         ("type",),
         ("rank",),

--- a/tests/test_DatabaseMapping.py
+++ b/tests/test_DatabaseMapping.py
@@ -1182,13 +1182,19 @@ class TestDatabaseMapping(AssertSuccessTestCase):
                 db_map.fetch_more("parameter_value_list")
                 value_list = db_map.get_parameter_value_list_item(name="yes_no")
                 value_list.remove()
-                self._assert_success(db_map.add_parameter_value_list_item(name="yes_no"))
+                new_value_list = self._assert_success(db_map.add_parameter_value_list_item(name="yes_no"))
                 self._assert_success(
                     db_map.add_list_value_item(
                         parameter_value_list_name="yes_no", index=0, value=value, type=value_type
                     )
                 )
                 db_map.commit_session("Readd value list.")
+                self.assertIsNone(new_value_list.mapped_item.replaced_item_waiting_for_removal)
+                list_values = db_map.get_list_value_items()
+                self.assertEqual(len(list_values), 1)
+                self.assertEqual(list_values[0]["parameter_value_list_name"], "yes_no")
+                self.assertEqual(from_database(list_values[0]["value"], list_values[0]["type"]), "yes")
+                self.assertIsNone(list_values[0].mapped_item.replaced_item_waiting_for_removal)
 
     def test_add_referrer_called_only_once_for_fetched_items(self):
         with TemporaryDirectory() as temp_dir:
@@ -1766,6 +1772,76 @@ class TestDatabaseMapping(AssertSuccessTestCase):
             with DatabaseMapping(url) as db_map:
                 list_value_rows = db_map.query(db_map.list_value_sq).all()
                 self.assertEqual(len(list_value_rows), 0)
+
+    def test_scenario_alternative_ids_dont_get_messed_up(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(db_map.add_scenario_item(name="Keys"))
+            self._assert_success(db_map.add_alternative_item(name="ctrl"))
+            self._assert_success(db_map.add_alternative_item(name="alt"))
+            original_base = self._assert_success(
+                db_map.add_scenario_alternative_item(scenario_name="Keys", alternative_name="Base", rank=1)
+            )
+            original_ctrl = self._assert_success(
+                db_map.add_scenario_alternative_item(scenario_name="Keys", alternative_name="ctrl", rank=2)
+            )
+            original_alt = self._assert_success(
+                db_map.add_scenario_alternative_item(scenario_name="Keys", alternative_name="alt", rank=3)
+            )
+            db_map.commit_session("Add scenario")
+            self._assert_success(original_base.remove())
+            self._assert_success(original_ctrl.remove())
+            self._assert_success(original_alt.remove())
+            shuffled_alt = self._assert_success(
+                db_map.add_scenario_alternative_item(scenario_name="Keys", alternative_name="alt", rank=1)
+            )
+            self._assert_success(shuffled_alt.remove())
+            db_map.commit_session("Shuffled scenario alternatives")
+            scenario_alternatives = db_map.get_scenario_alternative_items()
+            self.assertEqual(len(scenario_alternatives), 0)
+
+    def test_swapping_scenario_alternatives_then_deleting_highest_rank_doesnt_violate_unique_constraints(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(db_map.add_scenario_item(name="Keys"))
+            self._assert_success(db_map.add_alternative_item(name="alt"))
+            self._assert_success(db_map.add_alternative_item(name="ctrl"))
+            original_alt = self._assert_success(
+                db_map.add_scenario_alternative_item(scenario_name="Keys", alternative_name="alt", rank=1)
+            )
+            original_ctrl = self._assert_success(
+                db_map.add_scenario_alternative_item(scenario_name="Keys", alternative_name="ctrl", rank=2)
+            )
+            db_map.commit_session("Add scenario")
+            self._assert_success(original_alt.remove())
+            self._assert_success(original_ctrl.remove())
+            self._assert_success(
+                db_map.add_scenario_alternative_item(scenario_name="Keys", alternative_name="ctrl", rank=1)
+            )
+            shuffled_alt = self._assert_success(
+                db_map.add_scenario_alternative_item(scenario_name="Keys", alternative_name="alt", rank=2)
+            )
+            self._assert_success(shuffled_alt.remove())
+            db_map.commit_session("Shuffled scenario alternatives")
+            scenario_alternatives = db_map.get_scenario_alternative_items()
+            self.assertEqual(len(scenario_alternatives), 1)
+
+    def test_restore_item_whose_db_id_has_been_invalidated_by_id(self):
+        with TemporaryDirectory() as temp_dir:
+            url = "sqlite:///" + os.path.join(temp_dir, "db.sqlite")
+            with DatabaseMapping(url, create=True) as db_map:
+                self._assert_success(db_map.add_alternative_item(name="alt"))
+                db_map.commit_session("Add alternative")
+            with DatabaseMapping(url) as db_map:
+                alternative_in_db = db_map.get_alternative_item(name="alt")
+                self.assertNotEqual(alternative_in_db, {})
+                alternative_in_db.remove()
+                replacement_alternative = self._assert_success(db_map.add_alternative_item(name="alt"))
+                db_map.commit_session("Replace alternative")
+                self._assert_success(replacement_alternative.remove())
+                self._assert_success(alternative_in_db.restore())
+                db_map.commit_session("No net changes")
+            with DatabaseMapping(url) as db_map:
+                restored_alternative = db_map.get_alternative_item(name="alt")
+                self.assertEqual(restored_alternative["name"], "alt")
 
 
 class TestDatabaseMappingLegacy(unittest.TestCase):
@@ -4282,7 +4358,7 @@ class TestDatabaseMappingConcurrent(AssertSuccessTestCase):
                 db_map.commit_session("Add initial data.")
                 items = db_map.fetch_more("entity")
                 self.assertEqual(len(items), 1)
-                db_map.remove_item("entity", original_id)
+                self._assert_success(db_map.remove_item("entity", original_id))
                 db_map.commit_session("Removed entity.")
                 self.assertEqual(len(db_map.get_entity_items()), 0)
                 with DatabaseMapping(url) as shadow_db_map:
@@ -4296,8 +4372,7 @@ class TestDatabaseMappingConcurrent(AssertSuccessTestCase):
                 self.assertEqual(items[0]["name"], "other_entity")
                 all_items = db_map.get_entity_items()
                 self.assertEqual(len(all_items), 1)
-                restored_item, error = db_map.restore_item("entity", original_id)
-                self.assertEqual(error, "")
+                restored_item = self._assert_success(db_map.restore_item("entity", original_id))
                 self.assertEqual(restored_item["name"], "my_entity")
                 all_items = db_map.get_entity_items()
                 self.assertEqual(len(all_items), 2)

--- a/tests/test_db_mapping_base.py
+++ b/tests/test_db_mapping_base.py
@@ -66,18 +66,18 @@ class TestMappedTable(unittest.TestCase):
 class TestMappedItemBase(unittest.TestCase):
     def test_id_is_valid_initially(self):
         db_map = TestDBMapping()
-        item = MappedItemBase(db_map, "cutlery")
+        item = MappedItemBase(db_map)
         self.assertTrue(item.has_valid_id)
 
     def test_id_can_be_invalidated(self):
         db_map = TestDBMapping()
-        item = MappedItemBase(db_map, "cutlery")
+        item = MappedItemBase(db_map)
         item.invalidate_id()
         self.assertFalse(item.has_valid_id)
 
     def test_setting_new_id_validates_it(self):
         db_map = TestDBMapping()
-        item = MappedItemBase(db_map, "cutlery")
+        item = MappedItemBase(db_map)
         item.invalidate_id()
         self.assertFalse(item.has_valid_id)
         item["id"] = 23


### PR DESCRIPTION
Consider a scenario where we fetch an item from the database, then remove the item. Since the item has been removed, it is possible to add a new item with the same unique key. Previously, the new item would "steal" the removed item's "identity" by settings its status to `to_update` and the removed item was deleted from the mapped table. However, since the new item did not yet have a database id, removing it caused a Traceback in `commit_session()`.

Stealing the removed item's id and giving it to the new item would not work because we must be able to delete the removed item's referrers in cascade: just adding a new imposer item with the same unique keys does not save the referrers.

This PR solves the issue by replacing the "identity steal" by a mechanism that stores the removed item for later removal on commit. This allows proper cascade delete of the removed item and its referrers.

No associated issue

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
