### PR TITLE
Fix adding parameter definition when db has parameter types

### DIFF
--- a/spinedb_api/mapped_items.py
+++ b/spinedb_api/mapped_items.py
@@ -626,11 +626,21 @@ class ParameterDefinitionItem(ParameterItemBase):
 
     def _sorted_parameter_types(self):
         self._db_map.do_fetch_all("parameter_type")
+        if "id" in self:
+            return sorted(
+                (
+                    x
+                    for x in self._db_map.mapped_table("parameter_type").valid_values()
+                    if x["parameter_definition_id"] == dict.__getitem__(self, "id")
+                ),
+                key=lambda i: (i["type"], i["rank"]),
+            )
         return sorted(
             (
                 x
                 for x in self._db_map.mapped_table("parameter_type").valid_values()
-                if x["parameter_definition_id"] == self["id"]
+                if x["parameter_definition_name"] == dict.__getitem__(self, "name")
+                and x["entity_class_name"] == dict.__getitem__(self, "entity_class_name")
             ),
             key=lambda i: (i["type"], i["rank"]),
         )

--- a/tests/test_DatabaseMapping.py
+++ b/tests/test_DatabaseMapping.py
@@ -1858,6 +1858,20 @@ class TestDatabaseMapping(AssertSuccessTestCase):
                 gadgets = db_map.get_items("entity", entity_class_name="Gadget")
                 self.assertEqual(len(gadgets), 1)
 
+    def test_add_parameter_definition_to_database_with_parameter_types_does_not_raise_key_error(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(db_map.add_entity_class_item(name="Key"))
+            repeat_rate = self._assert_success(
+                db_map.add_parameter_definition_item(
+                    name="repeat rate", entity_class_name="Key", parameter_type_list=("float",)
+                )
+            )
+            self.assertEqual(repeat_rate["parameter_type_list"], ("float",))
+            is_useful = self._assert_success(
+                db_map.add_parameter_definition_item(name="is useful", entity_class_name="Key")
+            )
+            self.assertNotEqual(is_useful, {})
+
 
 class TestDatabaseMappingLegacy(unittest.TestCase):
     """'Backward compatibility' tests, i.e. pre-entity tests converted to work with the entity structure."""


### PR DESCRIPTION
This PR fixes a Traceback when adding parameter definitions to database that has parameter types.

Fixes spine-tools/Spine-Toolbox#2932

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [ ] Unit tests pass
