### PR TITLE
Improve fetch bookkeeping

### DIFF
--- a/spinedb_api/db_mapping.py
+++ b/spinedb_api/db_mapping.py
@@ -788,9 +788,10 @@ class DatabaseMapping(DatabaseMappingQueryMixin, DatabaseMappingCommitMixin, Dat
             *item_types: One or more of <spine_item_types>. If none given, then the entire DB is fetched.
         """
         item_types = set(self.item_types()) if not item_types else set(item_types) & set(self.item_types())
+        commit_count = self._query_commit_count()
         for item_type in item_types:
             item_type = self.real_item_type(item_type)
-            self.do_fetch_more(item_type)
+            self.do_fetch_all(item_type, commit_count)
 
     def query(self, *args, **kwargs):
         """Returns a :class:`~spinedb_api.query.Query` object to execute against the mapped DB.


### PR DESCRIPTION
`fetch_all()` was calling `do_fetch_more()` directly, but it makes more sense to call `do_fetch_all()` instead to keep record of what has been fetched.

No associated issue

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [ ] Unit tests pass
