### PR TITLE
Fix Traceback when fetching data from scenario filtered database

### DIFF
--- a/spinedb_api/db_mapping_query_mixin.py
+++ b/spinedb_api/db_mapping_query_mixin.py
@@ -435,7 +435,7 @@ class DatabaseMappingQueryMixin:
             :class:`~sqlalchemy.sql.expression.Alias`
         """
         if self._entity_alternative_sq is None:
-            self._entity_alternative_sq = self._subquery("entity_alternative")
+            self._entity_alternative_sq = self._make_entity_alternative_sq()
         return self._entity_alternative_sq
 
     @property
@@ -1285,6 +1285,15 @@ class DatabaseMappingQueryMixin:
         """
         return self._subquery("entity_element")
 
+    def _make_entity_alternative_sq(self):
+        """
+        Creates a subquery for entity-alternatives.
+
+        Returns:
+            Alias: an entity_alternative subquery
+        """
+        return self._subquery("entity_alternative")
+
     def _make_parameter_definition_sq(self):
         """
         Creates a subquery for parameter definitions.
@@ -1407,6 +1416,17 @@ class DatabaseMappingQueryMixin:
         """
         self._make_entity_element_sq = MethodType(method, self)
         self._clear_subqueries("entity_element")
+
+    def override_eneity_alternative_sq_maker(self, method):
+        """
+        Overrides the function that creates the ``entity_alternative_sq`` property.
+
+        Args:
+            method (Callable): a function that accepts a :class:`DatabaseMapping` as its argument and
+                returns entity alternative subquery as an :class:`Alias` object
+        """
+        self._make_entity_alternative_sq = MethodType(method, self)
+        self._clear_subqueries("entity_alternative")
 
     def override_parameter_definition_sq_maker(self, method):
         """

--- a/tests/filters/test_scenario_filter.py
+++ b/tests/filters/test_scenario_filter.py
@@ -13,27 +13,12 @@
 from pathlib import Path
 from tempfile import TemporaryDirectory
 import unittest
-from sqlalchemy.engine.url import URL
 from spinedb_api import (
     DatabaseMapping,
     SpineDBAPIError,
     apply_filter_stack,
     apply_scenario_filter_to_subqueries,
-    create_new_spine_database,
-    import_alternatives,
-    import_entities,
-    import_entity_alternatives,
-    import_entity_classes,
-    import_object_classes,
-    import_object_parameter_values,
-    import_object_parameters,
-    import_objects,
-    import_relationship_classes,
-    import_relationship_parameter_values,
-    import_relationship_parameters,
-    import_relationships,
-    import_scenario_alternatives,
-    import_scenarios,
+    to_database,
 )
 from spinedb_api.filters.scenario_filter import (
     scenario_filter_config,
@@ -42,6 +27,7 @@ from spinedb_api.filters.scenario_filter import (
     scenario_filter_shorthand_to_config,
     scenario_name_from_dict,
 )
+from tests.mock_helpers import AssertSuccessTestCase
 
 
 class TestScenarioFilterInMemory(unittest.TestCase):
@@ -119,409 +105,706 @@ class TestScenarioFilterInMemory(unittest.TestCase):
             self.assertEqual(len(entities), 0)
 
 
-class TestScenarioFilter(unittest.TestCase):
-    _db_url = None
-    _temp_dir = None
+class DataBuilderTestCase(AssertSuccessTestCase):
+    def _build_data_with_single_scenario(self, db_map, commit=True):
+        self._assert_success(db_map.add_alternative_item(name="alternative"))
+        self._assert_success(db_map.add_entity_class_item(name="object_class"))
+        self._assert_success(db_map.add_entity_item(entity_class_name="object_class", name="object"))
+        self._assert_success(db_map.add_parameter_definition_item(entity_class_name="object_class", name="parameter"))
+        value, value_type = to_database(-1.0)
+        self._assert_success(
+            db_map.add_parameter_value_item(
+                entity_class_name="object_class",
+                entity_byname=("object",),
+                parameter_definition_name="parameter",
+                value=value,
+                type=value_type,
+                alternative_name="Base",
+            )
+        )
+        value, value_type = to_database(23.0)
+        self._assert_success(
+            db_map.add_parameter_value_item(
+                entity_class_name="object_class",
+                entity_byname=("object",),
+                parameter_definition_name="parameter",
+                value=value,
+                type=value_type,
+                alternative_name="alternative",
+            )
+        )
+        self._assert_success(db_map.add_scenario_item(name="scenario"))
+        self._assert_success(
+            db_map.add_scenario_alternative_item(scenario_name="scenario", alternative_name="alternative", rank=1)
+        )
+        for entity_class in db_map.get_entity_class_items():
+            entity_class.update(active_by_default=True)
+        if commit:
+            db_map.commit_session("Add test data.")
 
-    @classmethod
-    def setUpClass(cls):
-        cls._temp_dir = TemporaryDirectory()
-        cls._db_url = URL("sqlite", database=Path(cls._temp_dir.name, "test_scenario_filter_mapping.sqlite").as_posix())
 
-    def setUp(self):
-        create_new_spine_database(self._db_url)
-        self._out_db_map = DatabaseMapping(self._db_url)
-        self._db_map = DatabaseMapping(self._db_url)
-
-    def tearDown(self):
-        self._out_db_map.close()
-        self._db_map.close()
-
-    def _build_data_with_single_scenario(self):
-        import_alternatives(self._out_db_map, ["alternative"])
-        import_object_classes(self._out_db_map, ["object_class"])
-        import_objects(self._out_db_map, [("object_class", "object")])
-        import_object_parameters(self._out_db_map, [("object_class", "parameter")])
-        import_object_parameter_values(self._out_db_map, [("object_class", "object", "parameter", -1.0)])
-        import_object_parameter_values(self._out_db_map, [("object_class", "object", "parameter", 23.0, "alternative")])
-        import_scenarios(self._out_db_map, [("scenario", True)])
-        import_scenario_alternatives(self._out_db_map, [("scenario", "alternative")])
+class TestScenarioFilter(DataBuilderTestCase):
 
     def test_scenario_filter(self):
-        _build_data_with_single_scenario(self._out_db_map)
-        apply_scenario_filter_to_subqueries(self._db_map, "scenario")
-        parameters = self._db_map.query(self._db_map.parameter_value_sq).all()
-        self.assertEqual(len(parameters), 1)
-        self.assertEqual(parameters[0].value, b"23.0")
-        alternatives = [dict(a) for a in self._db_map.query(self._db_map.alternative_sq)]
-        self.assertEqual(alternatives, [{"name": "alternative", "description": None, "id": 2, "commit_id": 2}])
-        scenarios = [dict(s) for s in self._db_map.query(self._db_map.wide_scenario_sq).all()]
-        self.assertEqual(
-            scenarios,
-            [
-                {
-                    "name": "scenario",
-                    "description": None,
-                    "active": True,
-                    "alternative_name_list": "alternative",
-                    "alternative_id_list": "2",
-                    "id": 1,
-                    "commit_id": 2,
-                }
-            ],
-        )
+        with TemporaryDirectory() as temp_dir:
+            url = "sqlite:///" + str(Path(temp_dir, "db.sqlite"))
+            with DatabaseMapping(url, create=True) as db_map:
+                self._build_data_with_single_scenario(db_map)
+            with DatabaseMapping(url, create=True):
+                apply_scenario_filter_to_subqueries(db_map, "scenario")
+                parameters = db_map.query(db_map.parameter_value_sq).all()
+                self.assertEqual(len(parameters), 1)
+                self.assertEqual(parameters[0].value, b"23.0")
+                alternatives = [dict(a) for a in db_map.query(db_map.alternative_sq)]
+                self.assertEqual(alternatives, [{"name": "alternative", "description": None, "id": 2, "commit_id": 2}])
+                scenarios = [dict(s) for s in db_map.query(db_map.wide_scenario_sq).all()]
+                self.assertEqual(
+                    scenarios,
+                    [
+                        {
+                            "name": "scenario",
+                            "description": None,
+                            "active": False,
+                            "alternative_name_list": "alternative",
+                            "alternative_id_list": "2",
+                            "id": 1,
+                            "commit_id": 2,
+                        }
+                    ],
+                )
 
     def test_scenario_filter_uncommitted_data(self):
-        _build_data_with_single_scenario(self._out_db_map, commit=False)
-        with self.assertRaises(SpineDBAPIError):
-            apply_scenario_filter_to_subqueries(self._out_db_map, "scenario")
-        parameters = self._out_db_map.query(self._out_db_map.parameter_value_sq).all()
-        self.assertEqual(len(parameters), 0)
-        alternatives = [dict(a) for a in self._out_db_map.query(self._out_db_map.alternative_sq)]
-        self.assertEqual(alternatives, [{"name": "Base", "description": "Base alternative", "id": 1, "commit_id": 1}])
-        scenarios = self._out_db_map.query(self._out_db_map.wide_scenario_sq).all()
-        self.assertEqual(len(scenarios), 0)
-        self._out_db_map.rollback_session()
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._build_data_with_single_scenario(db_map, commit=False)
+            with self.assertRaises(SpineDBAPIError):
+                apply_scenario_filter_to_subqueries(db_map, "scenario")
+            parameters = db_map.query(db_map.parameter_value_sq).all()
+            self.assertEqual(len(parameters), 0)
+            alternatives = [dict(a) for a in db_map.query(db_map.alternative_sq)]
+            self.assertEqual(
+                alternatives, [{"name": "Base", "description": "Base alternative", "id": 1, "commit_id": 1}]
+            )
+            scenarios = db_map.query(db_map.wide_scenario_sq).all()
+            self.assertEqual(len(scenarios), 0)
+            db_map.rollback_session()
 
     def test_scenario_filter_works_for_entity_sq(self):
-        import_alternatives(self._out_db_map, ["alternative1", "alternative2"])
-        import_entity_classes(
-            self._out_db_map, [("class1", ()), ("class2", ()), ("class1__class2", ("class1", "class2"))]
-        )
-        import_entities(
-            self._out_db_map,
-            [
-                ("class1", "obj1"),
-                ("class2", "obj2"),
-                ("class2", "obj22"),
-                ("class1__class2", ("obj1", "obj2")),
-                ("class1__class2", ("obj1", "obj22")),
-            ],
-        )
-        import_entity_alternatives(
-            self._out_db_map,
-            [
-                ("class2", "obj2", "alternative1", True),
-                ("class2", "obj2", "alternative2", False),
-                ("class2", "obj22", "alternative1", False),
-                ("class2", "obj22", "alternative2", True),
-            ],
-        )
-        import_scenarios(self._out_db_map, [("scenario1", True)])
-        import_scenario_alternatives(
-            self._out_db_map, [("scenario1", "alternative2"), ("scenario1", "alternative1", "alternative2")]
-        )
-        for entity_class in self._out_db_map.get_entity_class_items():
-            entity_class.update(active_by_default=True)
-        self._out_db_map.commit_session("Add test data")
-        entities = self._db_map.query(self._db_map.entity_sq).all()
-        self.assertEqual(len(entities), 5)
-        apply_scenario_filter_to_subqueries(self._db_map, "scenario1")
-        # After this, obj2 should be excluded because it is inactive in the highest-ranked alternative2
-        # The multidimensional entity 'class1__class2, (obj1, obj2)' should also be excluded because involves obj2
-        entities = self._db_map.query(self._db_map.wide_entity_sq).all()
-        self.assertEqual(len(entities), 3)
-        entity_names = {
-            name
-            for x in entities
-            for name in (x["element_name_list"].split(",") if x["element_name_list"] else (x["name"],))
-        }
-        self.assertFalse("obj2" in entity_names)
+        with TemporaryDirectory() as temp_dir:
+            url = "sqlite:///" + str(Path(temp_dir, "db.sqlite"))
+            with DatabaseMapping(url, create=True) as db_map:
+                self._assert_success(db_map.add_alternative_item(name="alternative1"))
+                self._assert_success(db_map.add_alternative_item(name="alternative2"))
+                self._assert_success(db_map.add_entity_class_item(name="class1"))
+                self._assert_success(db_map.add_entity_class_item(name="class2"))
+                self._assert_success(
+                    db_map.add_entity_class_item(name="class1__class2", dimension_name_list=["class1", "class2"])
+                )
+                self._assert_success(db_map.add_entity_item(name="obj1", entity_class_name="class1"))
+                self._assert_success(db_map.add_entity_item(name="obj2", entity_class_name="class2"))
+                self._assert_success(db_map.add_entity_item(name="obj22", entity_class_name="class2"))
+                self._assert_success(
+                    db_map.add_entity_item(element_name_list=["obj1", "obj2"], entity_class_name="class1__class2")
+                )
+                self._assert_success(
+                    db_map.add_entity_item(element_name_list=["obj1", "obj22"], entity_class_name="class1__class2")
+                )
+                self._assert_success(
+                    db_map.add_entity_alternative_item(
+                        entity_class_name="class2",
+                        entity_byname=("obj2",),
+                        alternative_name="alternative1",
+                        active=True,
+                    )
+                )
+                self._assert_success(
+                    db_map.add_entity_alternative_item(
+                        entity_class_name="class2",
+                        entity_byname=("obj2",),
+                        alternative_name="alternative2",
+                        active=False,
+                    )
+                )
+                self._assert_success(
+                    db_map.add_entity_alternative_item(
+                        entity_class_name="class2",
+                        entity_byname=("obj22",),
+                        alternative_name="alternative1",
+                        active=False,
+                    )
+                )
+                self._assert_success(
+                    db_map.add_entity_alternative_item(
+                        entity_class_name="class2",
+                        entity_byname=("obj22",),
+                        alternative_name="alternative2",
+                        active=True,
+                    )
+                )
+                self._assert_success(db_map.add_scenario_item(name="scenario1"))
+                self._assert_success(
+                    db_map.add_scenario_alternative_item(
+                        scenario_name="scenario1", alternative_name="alternative1", rank=1
+                    )
+                )
+                self._assert_success(
+                    db_map.add_scenario_alternative_item(
+                        scenario_name="scenario1", alternative_name="alternative2", rank=2
+                    )
+                )
+                for entity_class in db_map.get_entity_class_items():
+                    entity_class.update(active_by_default=True)
+                db_map.commit_session("Add test data")
+            with DatabaseMapping(url) as db_map:
+                entities = db_map.query(db_map.entity_sq).all()
+                self.assertEqual(len(entities), 5)
+                apply_scenario_filter_to_subqueries(db_map, "scenario1")
+                # After this, obj2 should be excluded because it is inactive in the highest-ranked alternative2
+                # The multidimensional entity 'class1__class2, (obj1, obj2)' should also be excluded because involves obj2
+                entities = db_map.query(db_map.wide_entity_sq).all()
+                self.assertEqual(len(entities), 3)
+                entity_names = {
+                    name
+                    for x in entities
+                    for name in (x["element_name_list"].split(",") if x["element_name_list"] else (x["name"],))
+                }
+                self.assertFalse("obj2" in entity_names)
 
     def test_scenario_filter_works_for_object_parameter_value_sq(self):
-        _build_data_with_single_scenario(self._out_db_map)
-        apply_scenario_filter_to_subqueries(self._db_map, "scenario")
-        parameters = self._db_map.query(self._db_map.object_parameter_value_sq).all()
-        self.assertEqual(len(parameters), 1)
-        self.assertEqual(parameters[0].value, b"23.0")
-        alternatives = [dict(a) for a in self._db_map.query(self._db_map.alternative_sq)]
-        self.assertEqual(alternatives, [{"name": "alternative", "description": None, "id": 2, "commit_id": 2}])
-        scenarios = [dict(s) for s in self._db_map.query(self._db_map.wide_scenario_sq).all()]
-        self.assertEqual(
-            scenarios,
-            [
-                {
-                    "name": "scenario",
-                    "description": None,
-                    "active": True,
-                    "alternative_name_list": "alternative",
-                    "alternative_id_list": "2",
-                    "id": 1,
-                    "commit_id": 2,
-                }
-            ],
-        )
+        with TemporaryDirectory() as temp_dir:
+            url = "sqlite:///" + str(Path(temp_dir, "db.sqlite"))
+            with DatabaseMapping(url, create=True) as db_map:
+                self._build_data_with_single_scenario(db_map)
+            with DatabaseMapping(url) as db_map:
+                apply_scenario_filter_to_subqueries(db_map, "scenario")
+                parameters = db_map.query(db_map.object_parameter_value_sq).all()
+                self.assertEqual(len(parameters), 1)
+                self.assertEqual(parameters[0].value, b"23.0")
+                alternatives = [dict(a) for a in db_map.query(db_map.alternative_sq)]
+                self.assertEqual(alternatives, [{"name": "alternative", "description": None, "id": 2, "commit_id": 2}])
+                scenarios = [dict(s) for s in db_map.query(db_map.wide_scenario_sq).all()]
+                self.assertEqual(
+                    scenarios,
+                    [
+                        {
+                            "name": "scenario",
+                            "description": None,
+                            "active": False,
+                            "alternative_name_list": "alternative",
+                            "alternative_id_list": "2",
+                            "id": 1,
+                            "commit_id": 2,
+                        }
+                    ],
+                )
 
     def test_scenario_filter_works_for_relationship_parameter_value_sq(self):
-        _build_data_with_single_scenario(self._out_db_map, commit=False)
-        import_relationship_classes(self._out_db_map, [("relationship_class", ["object_class"])])
-        import_relationship_parameters(self._out_db_map, [("relationship_class", "relationship_parameter")])
-        import_relationships(self._out_db_map, [("relationship_class", ["object"])])
-        import_relationship_parameter_values(
-            self._out_db_map, [("relationship_class", ["object"], "relationship_parameter", -1)]
-        )
-        import_relationship_parameter_values(
-            self._out_db_map, [("relationship_class", ["object"], "relationship_parameter", 23.0, "alternative")]
-        )
-        self._out_db_map.commit_session("Add test data")
-        apply_scenario_filter_to_subqueries(self._db_map, "scenario")
-        parameters = self._db_map.query(self._db_map.relationship_parameter_value_sq).all()
-        self.assertEqual(len(parameters), 1)
-        self.assertEqual(parameters[0].value, b"23.0")
-        alternatives = [dict(a) for a in self._db_map.query(self._db_map.alternative_sq)]
-        self.assertEqual(alternatives, [{"name": "alternative", "description": None, "id": 2, "commit_id": 2}])
-        scenarios = [dict(s) for s in self._db_map.query(self._db_map.wide_scenario_sq).all()]
-        self.assertEqual(
-            scenarios,
-            [
-                {
-                    "name": "scenario",
-                    "description": None,
-                    "active": True,
-                    "alternative_name_list": "alternative",
-                    "alternative_id_list": "2",
-                    "id": 1,
-                    "commit_id": 2,
-                }
-            ],
-        )
+        with TemporaryDirectory() as temp_dir:
+            url = "sqlite:///" + str(Path(temp_dir, "db.sqlite"))
+            with DatabaseMapping(url, create=True) as db_map:
+                self._build_data_with_single_scenario(db_map, commit=False)
+                self._assert_success(
+                    db_map.add_entity_class_item(name="relationship_class", dimension_name_list=["object_class"])
+                )
+                self._assert_success(
+                    db_map.add_parameter_definition_item(
+                        entity_class_name="relationship_class", name="relationship_parameter"
+                    )
+                )
+                self._assert_success(
+                    db_map.add_entity_item(entity_class_name="relationship_class", element_name_list=["object"])
+                )
+                value, value_type = to_database(-1.0)
+                self._assert_success(
+                    db_map.add_parameter_value_item(
+                        entity_class_name="relationship_class",
+                        entity_byname=("object",),
+                        parameter_definition_name="relationship_parameter",
+                        value=value,
+                        type=value_type,
+                        alternative_name="Base",
+                    )
+                )
+                value, value_type = to_database(23.0)
+                self._assert_success(
+                    db_map.add_parameter_value_item(
+                        entity_class_name="relationship_class",
+                        entity_byname=("object",),
+                        parameter_definition_name="relationship_parameter",
+                        value=value,
+                        type=value_type,
+                        alternative_name="alternative",
+                    )
+                )
+                db_map.commit_session("Add test data")
+            with DatabaseMapping(url) as db_map:
+                apply_scenario_filter_to_subqueries(db_map, "scenario")
+                parameters = db_map.query(db_map.relationship_parameter_value_sq).all()
+                self.assertEqual(len(parameters), 1)
+                self.assertEqual((parameters[0].value, parameters[0].type), to_database(23.0))
+                alternatives = [dict(a) for a in db_map.query(db_map.alternative_sq)]
+                self.assertEqual(alternatives, [{"name": "alternative", "description": None, "id": 2, "commit_id": 2}])
+                scenarios = [dict(s) for s in db_map.query(db_map.wide_scenario_sq).all()]
+                self.assertEqual(
+                    scenarios,
+                    [
+                        {
+                            "name": "scenario",
+                            "description": None,
+                            "active": False,
+                            "alternative_name_list": "alternative",
+                            "alternative_id_list": "2",
+                            "id": 1,
+                            "commit_id": 2,
+                        }
+                    ],
+                )
 
     def test_scenario_filter_selects_highest_ranked_alternative(self):
-        import_alternatives(self._out_db_map, ["alternative3"])
-        import_alternatives(self._out_db_map, ["alternative1"])
-        import_alternatives(self._out_db_map, ["alternative2"])
-        import_object_classes(self._out_db_map, ["object_class"])
-        import_objects(self._out_db_map, [("object_class", "object")])
-        import_object_parameters(self._out_db_map, [("object_class", "parameter")])
-        import_object_parameter_values(self._out_db_map, [("object_class", "object", "parameter", -1.0)])
-        import_object_parameter_values(
-            self._out_db_map, [("object_class", "object", "parameter", 10.0, "alternative1")]
-        )
-        import_object_parameter_values(
-            self._out_db_map, [("object_class", "object", "parameter", 2000.0, "alternative2")]
-        )
-        import_object_parameter_values(
-            self._out_db_map, [("object_class", "object", "parameter", 300.0, "alternative3")]
-        )
-        import_scenarios(self._out_db_map, [("scenario", True)])
-        import_scenario_alternatives(
-            self._out_db_map,
-            [
-                ("scenario", "alternative2"),
-                ("scenario", "alternative3", "alternative2"),
-                ("scenario", "alternative1", "alternative3"),
-            ],
-        )
-        self._out_db_map.commit_session("Add test data")
-        apply_scenario_filter_to_subqueries(self._db_map, "scenario")
-        parameters = self._db_map.query(self._db_map.parameter_value_sq).all()
-        self.assertEqual(len(parameters), 1)
-        self.assertEqual(parameters[0].value, b"2000.0")
-        alternatives = [dict(a) for a in self._db_map.query(self._db_map.alternative_sq)]
-        self.assertEqual(
-            alternatives,
-            [
-                {"name": "alternative3", "description": None, "id": 2, "commit_id": 2},
-                {"name": "alternative1", "description": None, "id": 3, "commit_id": 2},
-                {"name": "alternative2", "description": None, "id": 4, "commit_id": 2},
-            ],
-        )
-        scenarios = [dict(s) for s in self._db_map.query(self._db_map.wide_scenario_sq).all()]
-        self.assertEqual(
-            scenarios,
-            [
-                {
-                    "name": "scenario",
-                    "description": None,
-                    "active": True,
-                    "alternative_name_list": "alternative1,alternative3,alternative2",
-                    "alternative_id_list": "3,2,4",
-                    "id": 1,
-                    "commit_id": 2,
-                }
-            ],
-        )
+        with TemporaryDirectory() as temp_dir:
+            url = "sqlite:///" + str(Path(temp_dir, "db.sqlite"))
+            with DatabaseMapping(url, create=True) as db_map:
+                self._assert_success(db_map.add_alternative_item(name="alternative3"))
+                self._assert_success(db_map.add_alternative_item(name="alternative1"))
+                self._assert_success(db_map.add_alternative_item(name="alternative2"))
+                self._assert_success(db_map.add_entity_class_item(name="object_class"))
+                self._assert_success(db_map.add_entity_item(entity_class_name="object_class", name="object"))
+                self._assert_success(
+                    db_map.add_parameter_definition_item(entity_class_name="object_class", name="parameter")
+                )
+                value, value_type = to_database(-1.0)
+                self._assert_success(
+                    db_map.add_parameter_value_item(
+                        entity_class_name="object_class",
+                        entity_byname=("object",),
+                        parameter_definition_name="parameter",
+                        value=value,
+                        type=value_type,
+                        alternative_name="Base",
+                    )
+                )
+                value, value_type = to_database(10.0)
+                self._assert_success(
+                    db_map.add_parameter_value_item(
+                        entity_class_name="object_class",
+                        entity_byname=("object",),
+                        parameter_definition_name="parameter",
+                        value=value,
+                        type=value_type,
+                        alternative_name="alternative1",
+                    )
+                )
+                value, value_type = to_database(2000.0)
+                self._assert_success(
+                    db_map.add_parameter_value_item(
+                        entity_class_name="object_class",
+                        entity_byname=("object",),
+                        parameter_definition_name="parameter",
+                        value=value,
+                        type=value_type,
+                        alternative_name="alternative2",
+                    )
+                )
+                value, value_type = to_database(300.0)
+                self._assert_success(
+                    db_map.add_parameter_value_item(
+                        entity_class_name="object_class",
+                        entity_byname=("object",),
+                        parameter_definition_name="parameter",
+                        value=value,
+                        type=value_type,
+                        alternative_name="alternative3",
+                    )
+                )
+                self._assert_success(db_map.add_scenario_item(name="scenario"))
+                self._assert_success(
+                    db_map.add_scenario_alternative_item(
+                        scenario_name="scenario", alternative_name="alternative2", rank=3
+                    )
+                )
+                self._assert_success(
+                    db_map.add_scenario_alternative_item(
+                        scenario_name="scenario", alternative_name="alternative3", rank=2
+                    )
+                )
+                self._assert_success(
+                    db_map.add_scenario_alternative_item(
+                        scenario_name="scenario", alternative_name="alternative1", rank=1
+                    )
+                )
+                db_map.commit_session("Add test data")
+            with DatabaseMapping(url, create=True) as db_map:
+                apply_scenario_filter_to_subqueries(db_map, "scenario")
+                parameters = db_map.query(db_map.parameter_value_sq).all()
+                self.assertEqual(len(parameters), 1)
+                self.assertEqual((parameters[0].value, parameters[0].type), to_database(2000.0))
+                alternatives = [dict(a) for a in db_map.query(db_map.alternative_sq)]
+                self.assertEqual(
+                    alternatives,
+                    [
+                        {"name": "alternative3", "description": None, "id": 2, "commit_id": 2},
+                        {"name": "alternative1", "description": None, "id": 3, "commit_id": 2},
+                        {"name": "alternative2", "description": None, "id": 4, "commit_id": 2},
+                    ],
+                )
+                scenarios = [dict(s) for s in db_map.query(db_map.wide_scenario_sq).all()]
+                self.assertEqual(
+                    scenarios,
+                    [
+                        {
+                            "name": "scenario",
+                            "description": None,
+                            "active": False,
+                            "alternative_name_list": "alternative1,alternative3,alternative2",
+                            "alternative_id_list": "3,2,4",
+                            "id": 1,
+                            "commit_id": 2,
+                        }
+                    ],
+                )
 
     def test_scenario_filter_selects_highest_ranked_alternative_of_active_scenario(self):
-        import_alternatives(
-            self._out_db_map, ["alternative3", "alternative1", "alternative2", "non_active_alternative"]
-        )
-        import_object_classes(self._out_db_map, ["object_class"])
-        import_objects(self._out_db_map, [("object_class", "object")])
-        import_object_parameters(self._out_db_map, [("object_class", "parameter")])
-        import_object_parameter_values(
-            self._out_db_map,
-            [
-                ("object_class", "object", "parameter", -1.0),
-                ("object_class", "object", "parameter", 10.0, "alternative1"),
-                ("object_class", "object", "parameter", 2000.0, "alternative2"),
-                ("object_class", "object", "parameter", 300.0, "alternative3"),
-            ],
-        )
-        import_scenarios(self._out_db_map, [("scenario", True), "non_active_scenario"])
-        import_scenario_alternatives(
-            self._out_db_map,
-            [
-                ("scenario", "alternative2"),
-                ("scenario", "alternative3", "alternative2"),
-                ("scenario", "alternative1", "alternative3"),
-            ],
-        )
-        import_scenario_alternatives(
-            self._out_db_map,
-            [
-                ("non_active_scenario", "non_active_alternative"),
-                ("scenario", "alternative2", "non_active_alternative"),
-                ("scenario", "alternative3", "alternative2"),
-                ("scenario", "alternative1", "alternative3"),
-            ],
-        )
-        self._out_db_map.commit_session("Add test data")
-        apply_scenario_filter_to_subqueries(self._db_map, "scenario")
-        parameters = self._db_map.query(self._db_map.parameter_value_sq).all()
-        self.assertEqual(len(parameters), 1)
-        self.assertEqual(parameters[0].value, b"2000.0")
-        alternatives = [dict(a) for a in self._db_map.query(self._db_map.alternative_sq)]
-        self.assertEqual(
-            alternatives,
-            [
-                {"name": "alternative3", "description": None, "id": 2, "commit_id": 2},
-                {"name": "alternative1", "description": None, "id": 3, "commit_id": 2},
-                {"name": "alternative2", "description": None, "id": 4, "commit_id": 2},
-            ],
-        )
-        scenarios = [dict(s) for s in self._db_map.query(self._db_map.wide_scenario_sq).all()]
-        self.assertEqual(
-            scenarios,
-            [
-                {
-                    "name": "scenario",
-                    "description": None,
-                    "active": True,
-                    "alternative_name_list": "alternative1,alternative3,alternative2",
-                    "alternative_id_list": "3,2,4",
-                    "id": 1,
-                    "commit_id": 2,
-                }
-            ],
-        )
+        with TemporaryDirectory() as temp_dir:
+            url = "sqlite:///" + str(Path(temp_dir, "db.sqlite"))
+            with DatabaseMapping(url, create=True) as db_map:
+                self._assert_success(db_map.add_alternative_item(name="alternative3"))
+                self._assert_success(db_map.add_alternative_item(name="alternative1"))
+                self._assert_success(db_map.add_alternative_item(name="alternative2"))
+                self._assert_success(db_map.add_alternative_item(name="non_active_alternative"))
+                self._assert_success(db_map.add_entity_class_item(name="object_class"))
+                self._assert_success(db_map.add_entity_item(entity_class_name="object_class", name="object"))
+                self._assert_success(
+                    db_map.add_parameter_definition_item(entity_class_name="object_class", name="parameter")
+                )
+                value, value_type = to_database(-1.0)
+                self._assert_success(
+                    db_map.add_parameter_value_item(
+                        entity_class_name="object_class",
+                        entity_byname=("object",),
+                        parameter_definition_name="parameter",
+                        value=value,
+                        type=value_type,
+                        alternative_name="Base",
+                    )
+                )
+                value, value_type = to_database(10.0)
+                self._assert_success(
+                    db_map.add_parameter_value_item(
+                        entity_class_name="object_class",
+                        entity_byname=("object",),
+                        parameter_definition_name="parameter",
+                        value=value,
+                        type=value_type,
+                        alternative_name="alternative1",
+                    )
+                )
+                value, value_type = to_database(2000.0)
+                self._assert_success(
+                    db_map.add_parameter_value_item(
+                        entity_class_name="object_class",
+                        entity_byname=("object",),
+                        parameter_definition_name="parameter",
+                        value=value,
+                        type=value_type,
+                        alternative_name="alternative2",
+                    )
+                )
+                value, value_type = to_database(300.0)
+                self._assert_success(
+                    db_map.add_parameter_value_item(
+                        entity_class_name="object_class",
+                        entity_byname=("object",),
+                        parameter_definition_name="parameter",
+                        value=value,
+                        type=value_type,
+                        alternative_name="alternative3",
+                    )
+                )
+                self._assert_success(db_map.add_scenario_item(name="scenario"))
+                self._assert_success(db_map.add_scenario_item(name="non_active_scenario"))
+                self._assert_success(
+                    db_map.add_scenario_alternative_item(
+                        scenario_name="scenario", alternative_name="alternative1", rank=1
+                    )
+                )
+                self._assert_success(
+                    db_map.add_scenario_alternative_item(
+                        scenario_name="scenario", alternative_name="alternative3", rank=2
+                    )
+                )
+                self._assert_success(
+                    db_map.add_scenario_alternative_item(
+                        scenario_name="scenario", alternative_name="alternative2", rank=3
+                    )
+                )
+                self._assert_success(
+                    db_map.add_scenario_alternative_item(
+                        scenario_name="non_active_scenario", alternative_name="alternative1", rank=1
+                    )
+                )
+                self._assert_success(
+                    db_map.add_scenario_alternative_item(
+                        scenario_name="non_active_scenario", alternative_name="alternative3", rank=2
+                    )
+                )
+                self._assert_success(
+                    db_map.add_scenario_alternative_item(
+                        scenario_name="non_active_scenario", alternative_name="alternative2", rank=3
+                    )
+                )
+                self._assert_success(
+                    db_map.add_scenario_alternative_item(
+                        scenario_name="non_active_scenario", alternative_name="non_active_alternative", rank=4
+                    )
+                )
+                db_map.commit_session("Add test data")
+            with DatabaseMapping(url, create=True) as db_map:
+                apply_scenario_filter_to_subqueries(db_map, "scenario")
+                parameters = db_map.query(db_map.parameter_value_sq).all()
+                self.assertEqual(len(parameters), 1)
+                self.assertEqual((parameters[0].value, parameters[0].type), to_database(2000.0))
+                alternatives = [dict(a) for a in db_map.query(db_map.alternative_sq)]
+                self.assertEqual(
+                    alternatives,
+                    [
+                        {"name": "alternative3", "description": None, "id": 2, "commit_id": 2},
+                        {"name": "alternative1", "description": None, "id": 3, "commit_id": 2},
+                        {"name": "alternative2", "description": None, "id": 4, "commit_id": 2},
+                    ],
+                )
+                scenarios = [dict(s) for s in db_map.query(db_map.wide_scenario_sq).all()]
+                self.assertEqual(
+                    scenarios,
+                    [
+                        {
+                            "name": "scenario",
+                            "description": None,
+                            "active": False,
+                            "alternative_name_list": "alternative1,alternative3,alternative2",
+                            "alternative_id_list": "3,2,4",
+                            "id": 1,
+                            "commit_id": 2,
+                        }
+                    ],
+                )
 
     def test_scenario_filter_for_multiple_objects_and_parameters(self):
-        import_alternatives(self._out_db_map, ["alternative"])
-        import_object_classes(self._out_db_map, ["object_class"])
-        import_objects(self._out_db_map, [("object_class", "object1")])
-        import_objects(self._out_db_map, [("object_class", "object2")])
-        import_object_parameters(self._out_db_map, [("object_class", "parameter1")])
-        import_object_parameters(self._out_db_map, [("object_class", "parameter2")])
-        import_object_parameter_values(self._out_db_map, [("object_class", "object1", "parameter1", -1.0)])
-        import_object_parameter_values(
-            self._out_db_map, [("object_class", "object1", "parameter1", 10.0, "alternative")]
-        )
-        import_object_parameter_values(self._out_db_map, [("object_class", "object1", "parameter2", -1.0)])
-        import_object_parameter_values(
-            self._out_db_map, [("object_class", "object1", "parameter2", 11.0, "alternative")]
-        )
-        import_object_parameter_values(self._out_db_map, [("object_class", "object2", "parameter1", -2.0)])
-        import_object_parameter_values(
-            self._out_db_map, [("object_class", "object2", "parameter1", 20.0, "alternative")]
-        )
-        import_object_parameter_values(self._out_db_map, [("object_class", "object2", "parameter2", -2.0)])
-        import_object_parameter_values(
-            self._out_db_map, [("object_class", "object2", "parameter2", 22.0, "alternative")]
-        )
-        import_scenarios(self._out_db_map, [("scenario", True)])
-        import_scenario_alternatives(self._out_db_map, [("scenario", "alternative")])
-        for item in self._out_db_map.get_entity_class_items():
-            item.update(active_by_default=True)
-        self._out_db_map.commit_session("Add test data")
-        apply_scenario_filter_to_subqueries(self._db_map, "scenario")
-        parameters = self._db_map.query(self._db_map.parameter_value_sq).all()
-        self.assertEqual(len(parameters), 4)
-        object_names = {o.id: o.name for o in self._db_map.query(self._db_map.object_sq).all()}
-        alternative_names = {a.id: a.name for a in self._db_map.query(self._db_map.alternative_sq).all()}
-        parameter_names = {d.id: d.name for d in self._db_map.query(self._db_map.parameter_definition_sq).all()}
-        datamined_values = {}
-        for parameter in parameters:
-            self.assertEqual(alternative_names[parameter.alternative_id], "alternative")
-            parameter_values = datamined_values.setdefault(object_names[parameter.entity_id], {})
-            parameter_values[parameter_names[parameter.parameter_definition_id]] = parameter.value
-        self.assertEqual(
-            datamined_values,
-            {
-                "object1": {"parameter1": b"10.0", "parameter2": b"11.0"},
-                "object2": {"parameter1": b"20.0", "parameter2": b"22.0"},
-            },
-        )
-        alternatives = [dict(a) for a in self._db_map.query(self._db_map.alternative_sq)]
-        self.assertEqual(alternatives, [{"name": "alternative", "description": None, "id": 2, "commit_id": 2}])
-        scenarios = [dict(s) for s in self._db_map.query(self._db_map.wide_scenario_sq).all()]
-        self.assertEqual(
-            scenarios,
-            [
-                {
-                    "name": "scenario",
-                    "description": None,
-                    "active": True,
-                    "alternative_name_list": "alternative",
-                    "alternative_id_list": "2",
-                    "id": 1,
-                    "commit_id": 2,
-                }
-            ],
-        )
+        with TemporaryDirectory() as temp_dir:
+            url = "sqlite:///" + str(Path(temp_dir, "db.sqlite"))
+            with DatabaseMapping(url, create=True) as db_map:
+                self._assert_success(db_map.add_alternative_item(name="alternative"))
+                self._assert_success(db_map.add_entity_class_item(name="object_class"))
+                self._assert_success(db_map.add_entity_item(entity_class_name="object_class", name="object1"))
+                self._assert_success(db_map.add_entity_item(entity_class_name="object_class", name="object2"))
+                self._assert_success(
+                    db_map.add_parameter_definition_item(entity_class_name="object_class", name="parameter1")
+                )
+                self._assert_success(
+                    db_map.add_parameter_definition_item(entity_class_name="object_class", name="parameter2")
+                )
+                value, value_type = to_database(-1.0)
+                self._assert_success(
+                    db_map.add_parameter_value_item(
+                        entity_class_name="object_class",
+                        entity_byname=("object1",),
+                        parameter_definition_name="parameter1",
+                        value=value,
+                        type=value_type,
+                        alternative_name="Base",
+                    )
+                )
+                value, value_type = to_database(10.0)
+                self._assert_success(
+                    db_map.add_parameter_value_item(
+                        entity_class_name="object_class",
+                        entity_byname=("object1",),
+                        parameter_definition_name="parameter1",
+                        value=value,
+                        type=value_type,
+                        alternative_name="alternative",
+                    )
+                )
+                value, value_type = to_database(-1.0)
+                self._assert_success(
+                    db_map.add_parameter_value_item(
+                        entity_class_name="object_class",
+                        entity_byname=("object1",),
+                        parameter_definition_name="parameter2",
+                        value=value,
+                        type=value_type,
+                        alternative_name="Base",
+                    )
+                )
+                value, value_type = to_database(11.0)
+                self._assert_success(
+                    db_map.add_parameter_value_item(
+                        entity_class_name="object_class",
+                        entity_byname=("object1",),
+                        parameter_definition_name="parameter2",
+                        value=value,
+                        type=value_type,
+                        alternative_name="alternative",
+                    )
+                )
+                value, value_type = to_database(-2.0)
+                self._assert_success(
+                    db_map.add_parameter_value_item(
+                        entity_class_name="object_class",
+                        entity_byname=("object2",),
+                        parameter_definition_name="parameter1",
+                        value=value,
+                        type=value_type,
+                        alternative_name="Base",
+                    )
+                )
+                value, value_type = to_database(20.0)
+                self._assert_success(
+                    db_map.add_parameter_value_item(
+                        entity_class_name="object_class",
+                        entity_byname=("object2",),
+                        parameter_definition_name="parameter1",
+                        value=value,
+                        type=value_type,
+                        alternative_name="alternative",
+                    )
+                )
+                value, value_type = to_database(-2.0)
+                self._assert_success(
+                    db_map.add_parameter_value_item(
+                        entity_class_name="object_class",
+                        entity_byname=("object2",),
+                        parameter_definition_name="parameter2",
+                        value=value,
+                        type=value_type,
+                        alternative_name="Base",
+                    )
+                )
+                value, value_type = to_database(22.0)
+                self._assert_success(
+                    db_map.add_parameter_value_item(
+                        entity_class_name="object_class",
+                        entity_byname=("object2",),
+                        parameter_definition_name="parameter2",
+                        value=value,
+                        type=value_type,
+                        alternative_name="alternative",
+                    )
+                )
+                self._assert_success(db_map.add_scenario_item(name="scenario"))
+                self._assert_success(
+                    db_map.add_scenario_alternative_item(
+                        scenario_name="scenario", alternative_name="alternative", rank=1
+                    )
+                )
+                for item in db_map.get_entity_class_items():
+                    item.update(active_by_default=True)
+                db_map.commit_session("Add test data")
+            with DatabaseMapping(url, create=True) as db_map:
+                apply_scenario_filter_to_subqueries(db_map, "scenario")
+                parameters = db_map.query(db_map.parameter_value_sq).all()
+                self.assertEqual(len(parameters), 4)
+                object_names = {o.id: o.name for o in db_map.query(db_map.object_sq).all()}
+                alternative_names = {a.id: a.name for a in db_map.query(db_map.alternative_sq).all()}
+                parameter_names = {d.id: d.name for d in db_map.query(db_map.parameter_definition_sq).all()}
+                datamined_values = {}
+                for parameter in parameters:
+                    self.assertEqual(alternative_names[parameter.alternative_id], "alternative")
+                    parameter_values = datamined_values.setdefault(object_names[parameter.entity_id], {})
+                    parameter_values[parameter_names[parameter.parameter_definition_id]] = parameter.value
+                self.assertEqual(
+                    datamined_values,
+                    {
+                        "object1": {"parameter1": b"10.0", "parameter2": b"11.0"},
+                        "object2": {"parameter1": b"20.0", "parameter2": b"22.0"},
+                    },
+                )
+                alternatives = [dict(a) for a in db_map.query(db_map.alternative_sq)]
+                self.assertEqual(alternatives, [{"name": "alternative", "description": None, "id": 2, "commit_id": 2}])
+                scenarios = [dict(s) for s in db_map.query(db_map.wide_scenario_sq).all()]
+                self.assertEqual(
+                    scenarios,
+                    [
+                        {
+                            "name": "scenario",
+                            "description": None,
+                            "active": False,
+                            "alternative_name_list": "alternative",
+                            "alternative_id_list": "2",
+                            "id": 1,
+                            "commit_id": 2,
+                        }
+                    ],
+                )
 
     def test_filters_scenarios_and_alternatives(self):
-        import_scenarios(self._out_db_map, ("scenario1", "scenario2"))
-        import_alternatives(self._out_db_map, ("alternative1", "alternative2", "alternative3"))
-        import_scenario_alternatives(
-            self._out_db_map,
-            (
-                ("scenario1", "alternative2"),
-                ("scenario1", "alternative1", "alternative2"),
-                ("scenario2", "alternative3"),
-                ("scenario2", "alternative2", "alternative3"),
-            ),
-        )
-        self._out_db_map.commit_session("Add test data.")
-        apply_scenario_filter_to_subqueries(self._db_map, "scenario2")
-        alternatives = [dict(a) for a in self._db_map.query(self._db_map.alternative_sq)]
-        self.assertEqual(
-            alternatives,
-            [
-                {"name": "alternative2", "description": None, "id": 3, "commit_id": 2},
-                {"name": "alternative3", "description": None, "id": 4, "commit_id": 2},
-            ],
-        )
-        scenarios = [dict(s) for s in self._db_map.query(self._db_map.wide_scenario_sq).all()]
-        self.assertEqual(
-            scenarios,
-            [
-                {
-                    "name": "scenario2",
-                    "description": None,
-                    "active": False,
-                    "alternative_name_list": "alternative2,alternative3",
-                    "alternative_id_list": "3,4",
-                    "id": 2,
-                    "commit_id": 2,
-                }
-            ],
-        )
+        with TemporaryDirectory() as temp_dir:
+            url = "sqlite:///" + str(Path(temp_dir, "db.sqlite"))
+            with DatabaseMapping(url, create=True) as db_map:
+                self._assert_success(db_map.add_scenario_item(name="scenario1"))
+                self._assert_success(db_map.add_scenario_item(name="scenario2"))
+                self._assert_success(db_map.add_alternative_item(name="alternative1"))
+                self._assert_success(db_map.add_alternative_item(name="alternative2"))
+                self._assert_success(db_map.add_alternative_item(name="alternative3"))
+                self._assert_success(
+                    db_map.add_scenario_alternative_item(
+                        scenario_name="scenario1", alternative_name="alternative1", rank=1
+                    )
+                )
+                self._assert_success(
+                    db_map.add_scenario_alternative_item(
+                        scenario_name="scenario1", alternative_name="alternative2", rank=2
+                    )
+                )
+                self._assert_success(
+                    db_map.add_scenario_alternative_item(
+                        scenario_name="scenario2", alternative_name="alternative2", rank=1
+                    )
+                )
+                self._assert_success(
+                    db_map.add_scenario_alternative_item(
+                        scenario_name="scenario2", alternative_name="alternative3", rank=2
+                    )
+                )
+                db_map.commit_session("Add test data.")
+            with DatabaseMapping(url, create=True) as db_map:
+                apply_scenario_filter_to_subqueries(db_map, "scenario2")
+                alternatives = [dict(a) for a in db_map.query(db_map.alternative_sq)]
+                self.assertEqual(
+                    alternatives,
+                    [
+                        {"name": "alternative2", "description": None, "id": 3, "commit_id": 2},
+                        {"name": "alternative3", "description": None, "id": 4, "commit_id": 2},
+                    ],
+                )
+                scenarios = [dict(s) for s in db_map.query(db_map.wide_scenario_sq).all()]
+                self.assertEqual(
+                    scenarios,
+                    [
+                        {
+                            "name": "scenario2",
+                            "description": None,
+                            "active": False,
+                            "alternative_name_list": "alternative2,alternative3",
+                            "alternative_id_list": "3,4",
+                            "id": 2,
+                            "commit_id": 2,
+                        }
+                    ],
+                )
 
 
-class TestScenarioFilterUtils(unittest.TestCase):
+class TestScenarioFilterUtils(DataBuilderTestCase):
     def test_scenario_filter_config(self):
         config = scenario_filter_config("scenario name")
         self.assertEqual(config, {"type": "scenario_filter", "scenario": "scenario name"})
 
     def test_scenario_filter_from_dict(self):
-        db_map = DatabaseMapping("sqlite://", create=True)
-        _build_data_with_single_scenario(db_map)
-        config = scenario_filter_config("scenario")
-        scenario_filter_from_dict(db_map, config)
-        parameters = db_map.query(db_map.parameter_value_sq).all()
-        self.assertEqual(len(parameters), 1)
-        self.assertEqual(parameters[0].value, b"23.0")
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._build_data_with_single_scenario(db_map)
+            config = scenario_filter_config("scenario")
+            scenario_filter_from_dict(db_map, config)
+            parameters = db_map.query(db_map.parameter_value_sq).all()
+            self.assertEqual(len(parameters), 1)
+            self.assertEqual((parameters[0].value, parameters[0].type), to_database(23.0))
 
     def test_scenario_name_from_dict(self):
         config = scenario_filter_config("scenario name")
@@ -535,21 +818,6 @@ class TestScenarioFilterUtils(unittest.TestCase):
     def test_scenario_filter_shorthand_to_config(self):
         config = scenario_filter_shorthand_to_config("scenario:scenario name")
         self.assertEqual(config, {"type": "scenario_filter", "scenario": "scenario name"})
-
-
-def _build_data_with_single_scenario(db_map, commit=True):
-    import_alternatives(db_map, ["alternative"])
-    import_object_classes(db_map, ["object_class"])
-    import_objects(db_map, [("object_class", "object")])
-    import_object_parameters(db_map, [("object_class", "parameter")])
-    import_object_parameter_values(db_map, [("object_class", "object", "parameter", -1.0)])
-    import_object_parameter_values(db_map, [("object_class", "object", "parameter", 23.0, "alternative")])
-    import_scenarios(db_map, [("scenario", True)])
-    import_scenario_alternatives(db_map, [("scenario", "alternative")])
-    for entity_class in db_map.get_entity_class_items():
-        entity_class.update(active_by_default=True)
-    if commit:
-        db_map.commit_session("Add test data.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Scenario filter was letting parameter value and entity alternative records slip through where the records were referring to entities that were dropped by the filter. This often caused a Traceback when fetching because e.g. some entity alternative items could try to make references to non-existing entity ids.

Now, scenario filter produces entity alternative and parameter value subqueries that properly filter records that would otherwise contain ids of inactive entities.

Fixes spine-tools/Spine-Toolbox#2942

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
