### PR TITLE
Fix adding parameter definitions by entity class id

### DIFF
--- a/spinedb_api/mapped_items.py
+++ b/spinedb_api/mapped_items.py
@@ -637,20 +637,22 @@ class ParameterDefinitionItem(ParameterItemBase):
     def _sorted_parameter_types(self):
         self._db_map.do_fetch_all("parameter_type")
         if "id" in self:
+            id_ = dict.__getitem__(self, "id")
             return sorted(
                 (
                     x
                     for x in self._db_map.mapped_table("parameter_type").valid_values()
-                    if x["parameter_definition_id"] == dict.__getitem__(self, "id")
+                    if x["parameter_definition_id"] == id_
                 ),
                 key=lambda i: (i["type"], i["rank"]),
             )
+        name = dict.__getitem__(self, "name")
+        class_name = self["entity_class_name"]
         return sorted(
             (
                 x
                 for x in self._db_map.mapped_table("parameter_type").valid_values()
-                if x["parameter_definition_name"] == dict.__getitem__(self, "name")
-                and x["entity_class_name"] == dict.__getitem__(self, "entity_class_name")
+                if x["parameter_definition_name"] == name and x["entity_class_name"] == class_name
             ),
             key=lambda i: (i["type"], i["rank"]),
         )

--- a/tests/test_DatabaseMapping.py
+++ b/tests/test_DatabaseMapping.py
@@ -1929,6 +1929,12 @@ class TestDatabaseMapping(AssertSuccessTestCase):
                 entity_alternatives = db_map.get_entity_alternative_items()
                 self.assertEqual(len(entity_alternatives), 0)
 
+    def test_add_parameter_definition_by_entity_class_id(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            object_class = self._assert_success(db_map.add_entity_class_item(name="Object"))
+            x = self._assert_success(db_map.add_parameter_definition_item(name="x", entity_class_id=object_class["id"]))
+            self.assertEqual(x["entity_class_name"], "Object")
+
 
 class TestDatabaseMappingLegacy(unittest.TestCase):
     """'Backward compatibility' tests, i.e. pre-entity tests converted to work with the entity structure."""


### PR DESCRIPTION
This PR fixes a PR that would occur when parameter definitions were added using entity class id instead of name.

Fixes irena-flextool/flextool#228

## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black & isort
- [ ] Unit tests pass
