### PR TITLE
Raise NothingToCommit when there is nothing to commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- ``commit_session()`` now raises ``NothingToCommit`` when there is nothing to commit.
+  Previously, it would raise ``SpineDBAPIException``.
+
 ### Deprecated
 
 ### Removed

--- a/spinedb_api/db_mapping.py
+++ b/spinedb_api/db_mapping.py
@@ -37,7 +37,7 @@ from .compatibility import compatibility_transformations
 from .db_mapping_base import DatabaseMappingBase, Status
 from .db_mapping_commit_mixin import DatabaseMappingCommitMixin
 from .db_mapping_query_mixin import DatabaseMappingQueryMixin
-from .exception import SpineDBAPIError, SpineDBVersionError, SpineIntegrityError
+from .exception import NothingToCommit, SpineDBAPIError, SpineDBVersionError, SpineIntegrityError
 from .filters.tools import apply_filter_stack, load_filters, pop_filter_configs
 from .helpers import (
     Asterisk,
@@ -848,7 +848,7 @@ class DatabaseMapping(DatabaseMappingQueryMixin, DatabaseMappingCommitMixin, Dat
             dirty_items = self._dirty_items()
             if not dirty_items:
                 connection.execute(commit.delete().where(commit.c.id == commit_id))
-                raise SpineDBAPIError("Nothing to commit.")
+                raise NothingToCommit()
             for tablename, (to_add, to_update, to_remove) in dirty_items:
                 for item in to_add + to_update + to_remove:
                     item.commit(commit_id)

--- a/spinedb_api/exception.py
+++ b/spinedb_api/exception.py
@@ -80,3 +80,10 @@ class InvalidMappingComponent(InvalidMapping):
 
 class ConnectorError(SpineDBAPIError):
     """Failure in import/export connector."""
+
+
+class NothingToCommit(SpineDBAPIError):
+    """A notification that the session contains no changes."""
+
+    def __init__(self):
+        super().__init__("Nothing to commit.")

--- a/tests/test_DatabaseMapping.py
+++ b/tests/test_DatabaseMapping.py
@@ -30,6 +30,7 @@ from spinedb_api import (
     to_database,
 )
 from spinedb_api.db_mapping_base import PublicItem, Status
+from spinedb_api.exception import NothingToCommit
 from spinedb_api.filters.scenario_filter import scenario_filter_config
 from spinedb_api.helpers import Asterisk, DisplayStatus, name_from_elements
 from spinedb_api.parameter_value import Duration, type_for_scalar
@@ -4231,7 +4232,7 @@ class TestDatabaseMappingCommitMixin(unittest.TestCase):
         self.assertRaisesRegex(SpineDBAPIError, "Commit message cannot be empty.", self._db_map.commit_session, "")
 
     def test_commit_session_raise_when_nothing_to_commit(self):
-        self.assertRaisesRegex(SpineDBAPIError, "Nothing to commit.", self._db_map.commit_session, "No changes.")
+        self.assertRaisesRegex(NothingToCommit, "Nothing to commit.", self._db_map.commit_session, "No changes.")
 
     def test_rollback_addition(self):
         import_functions.import_object_classes(self._db_map, ("my_class",))


### PR DESCRIPTION
It is now possible to ignore the specific condition of nothing-to-commit:

```python
with suppress(NothingToCommit):
    db_map.commit_session("May or may contain changes.")
```

No associated issue.

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [ ] Unit tests pass
