### PR TITLE
Use reusable Toolbox test actions from Toolbox repo

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -57,88 +57,22 @@ jobs:
       uses: codecov/codecov-action@v4
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-  toolbox-unit-tests:
-    name: Spine Toolbox unit tests
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: true
-      matrix:
-        python-version: [3.8]
-        os: [ubuntu-22.04]
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        repository: spine-tools/Spine-Toolbox
-        fetch-depth: 0
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-        cache: pip
-        cache-dependency-path: |
-          pyproject.toml
-          requirements.txt
-          dev-requirements.txt
-    - name: Install additional packages for Linux
-      if: runner.os == 'Linux'
-      run: |
-        sudo apt-get update -y
-        sudo apt-get install -y libegl1
-    - name: Install dependencies
-      env:
-        PYTHONUTF8: 1
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install -r requirements.txt
-        python -m pip install -r dev-requirements.txt
-        python -m pip install git+${{ github.server_url }}/${{ github.repository }}.git@${{ github.ref_name }}
-    - name: List packages
-      run:
-        python -m pip list
-    - name: Run tests
-      run: |
-        if [ "$RUNNER_OS" != "Windows" ]; then
-          export QT_QPA_PLATFORM=offscreen
-        fi
-        python -m unittest discover --verbose
-      shell: bash
-  toolbox-execution-tests:
-    name: Spine Toolbox execution tests
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: [3.8]
-        os: [ubuntu-22.04]
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        repository: spine-tools/Spine-Toolbox
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-        cache: pip
-        cache-dependency-path: |
-          pyproject.toml
-          requirements.txt
-          dev-requirements.txt
-    - name: Install additional packages for Linux
-      if: runner.os == 'Linux'
-      run: |
-        sudo apt-get update -y
-        sudo apt-get install -y libegl1
-    - name: Install dependencies
-      env:
-        PYTHONUTF8: 1
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install -r requirements.txt
-        python -m pip install -r dev-requirements.txt
-        python -m pip install git+${{ github.server_url }}/${{ github.repository }}.git@${{ github.ref_name }}
-    - name: List packages
-      run:
-        python -m pip list
-    - name: Run tests
-      run:
-        python -m unittest discover --pattern execution_test.py --verbose
+  call-toolbox-unit-tests:
+    name: Toolbox unit tests
+    uses: spine-tools/Spine-Toolbox/.github/workflows/unit_tests.yml
+    with:
+      host-os: ubuntu-22.04
+      python-version: 3.9
+      repository: spine-tools/Spine-Toolbox
+      coverage: false
+      post-installation-command: python -m pip install git+${{ github.server_url }}/${{ github.repository }}.git@${{ github.ref_name }}
+    secrets: inherit
+  call-toolbox-execution-tests:
+    name: Toolbox execution tests
+    uses: spine-tools/Spine-Toolbox/.github/workflows/execution_tests.yml
+    with:
+      host-os: ubuntu-22.04
+      python-version: 3.9
+      repository: spine-tools/Spine-Toolbox
+      post-installation-command: python -m pip install git+${{ github.server_url }}/${{ github.repository }}.git@${{ github.ref_name }}
+    secrets: inherit


### PR DESCRIPTION
Instead of duplicating the code for Toolbox test actions in this repository, we can now call the reusable test actions from Toolbox repository.

No associated issue

## Checklist before merging
- [ ] Unit tests pass
