### PR TITLE
Fix importing pivoted data with read_start_row

### DIFF
--- a/spinedb_api/export_mapping/export_mapping.py
+++ b/spinedb_api/export_mapping/export_mapping.py
@@ -1309,12 +1309,25 @@ class ScenarioAlternativeMapping(ExportMapping):
     MAP_TYPE = "ScenarioAlternative"
 
     def add_query_columns(self, db_map, query):
+        if self._child is None:
+            return query.add_columns(
+                db_map.ext_scenario_sq.c.alternative_id,
+                db_map.ext_scenario_sq.c.alternative_name,
+                db_map.ext_scenario_sq.c.rank,
+            )
+        # Legacy: expecting child to be ScenarioBeforeAlternativeMapping
         return query.add_columns(
             db_map.ext_linked_scenario_alternative_sq.c.alternative_id,
             db_map.ext_linked_scenario_alternative_sq.c.alternative_name,
         )
 
     def filter_query(self, db_map, query):
+        if self._child is None:
+            return query.outerjoin(
+                db_map.ext_scenario_sq,
+                db_map.ext_scenario_sq.c.id == db_map.scenario_sq.c.id,
+            ).order_by(db_map.ext_scenario_sq.c.name, db_map.ext_scenario_sq.c.rank)
+        # Legacy: expecting child to be ScenarioBeforeAlternativeMapping
         return query.outerjoin(
             db_map.ext_linked_scenario_alternative_sq,
             db_map.ext_linked_scenario_alternative_sq.c.scenario_id == db_map.scenario_sq.c.id,

--- a/spinedb_api/export_mapping/generator.py
+++ b/spinedb_api/export_mapping/generator.py
@@ -9,10 +9,7 @@
 # Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
-"""
-Contains generator functions that convert a Spine database into rows of tabular data.
-
-"""
+""" Contains generator functions that convert a Spine database into rows of tabular data. """
 from copy import deepcopy
 from ..mapping import Position
 from .export_mapping import pair_header_buddies

--- a/spinedb_api/export_mapping/settings.py
+++ b/spinedb_api/export_mapping/settings.py
@@ -333,24 +333,19 @@ def scenario_export(
     return scenario_mapping
 
 
-def scenario_alternative_export(
-    scenario_position=Position.hidden, alternative_position=Position.hidden, before_alternative_position=Position.hidden
-):
+def scenario_alternative_export(scenario_position=Position.hidden, alternative_position=Position.hidden):
     """
     Sets up export mappings for exporting scenario alternatives.
 
     Args:
         scenario_position (int or Position): position of scenarios
         alternative_position (int or Position): position of alternatives
-        before_alternative_position (int or Position): position of 'before' alternatives
-            (for each row, the 'alternative' goes *before* the 'before alternative' in the scenario rank)
 
     Returns:
         Mapping: root mapping
     """
     scenario_mapping = ScenarioMapping(scenario_position)
-    alternative_mapping = scenario_mapping.child = ScenarioAlternativeMapping(alternative_position)
-    alternative_mapping.child = ScenarioBeforeAlternativeMapping(before_alternative_position)
+    scenario_mapping.child = ScenarioAlternativeMapping(alternative_position)
     return scenario_mapping
 
 

--- a/spinedb_api/import_mapping/import_mapping.py
+++ b/spinedb_api/import_mapping/import_mapping.py
@@ -974,8 +974,7 @@ def _default_scenario_alternative_mapping():
         ScenarioAlternativeMapping: root mapping
     """
     root_mapping = ScenarioMapping(Position.hidden)
-    scen_alt_mapping = root_mapping.child = ScenarioAlternativeMapping(Position.hidden)
-    scen_alt_mapping.child = ScenarioBeforeAlternativeMapping(Position.hidden)
+    root_mapping.child = ScenarioAlternativeMapping(Position.hidden)
     return root_mapping
 
 

--- a/tests/import_mapping/test_generator.py
+++ b/tests/import_mapping/test_generator.py
@@ -955,6 +955,28 @@ class TestGetMappedData(unittest.TestCase):
             },
         )
 
+    def test_skip_first_row_when_importing_pivoted_data(self):
+        data_source = iter(
+            [
+                [None, "alternative1", "alternative2", "alternative3"],
+                ["Scenario1", "Base", "fixed_prices", None],
+            ]
+        )
+        mappings = [
+            [
+                {"map_type": "Scenario", "position": 0, "read_start_row": 1},
+                {"map_type": "ScenarioAlternative", "position": -1},
+            ]
+        ]
+        convert_function_specs = {0: "string", 1: "string", 2: "string", 3: "string"}
+        convert_functions = {column: value_to_convert_spec(spec) for column, spec in convert_function_specs.items()}
+        mapped_data, errors = get_mapped_data(data_source, mappings, column_convert_fns=convert_functions)
+        self.assertEqual(errors, [])
+        self.assertEqual(
+            mapped_data,
+            {"scenario_alternatives": [["Scenario1", "Base"], ["Scenario1", "fixed_prices"]]},
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR fixes a special case where only the last component of import mappings is set to pivoted and read_start_row > 0.

Fixes spine-tools/Spine-Toolbox#2962

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
