### PR TITLE
Require psycopg2-binary instead of the compiled psycopg2 module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ classifiers = [
     "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
     "Operating System :: OS Independent",
 ]
-requires-python = ">=3.8.1"
+requires-python = ">=3.8.1, <3.13"
 dependencies = [
     # v1.4 does not pass tests
     "SQLAlchemy >=1.3, <1.4",
@@ -25,7 +25,7 @@ dependencies = [
     "ijson >=3.1.4",
     "chardet >=4.0.0",
     "PyMySQL >=1.0.2",
-    "psycopg2",
+    "psycopg2-binary",
 ]
 
 [project.urls]


### PR DESCRIPTION
Re spine-tools/Spine-Toolbox#2986

## Checklist before merging
- [ ] Unit tests pass
