### PR TITLE
Fix scenario filter when active_by_default is false

### DIFF
--- a/spinedb_api/filters/scenario_filter.py
+++ b/spinedb_api/filters/scenario_filter.py
@@ -382,7 +382,10 @@ def _make_scenario_filtered_parameter_value_sq(db_map, state):
         .filter(ext_parameter_value_sq.c.entity_id == ext_entity_sq.c.id)
         .filter(
             ext_entity_sq.c.desc_rank_row_number == 1,
-            or_(ext_entity_sq.c.active == True, ext_entity_sq.c.active == None),
+            or_(
+                ext_entity_sq.c.active == True,
+                and_(ext_entity_sq.c.active == None, ext_entity_sq.c.active_by_default == True),
+            ),
         )
         .subquery()
     )


### PR DESCRIPTION
This PR fixes parameter values leaking through scenario filter when the corresponding entities had `active_by_default` set to false but no entity alternative defined.

No associated issue.

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
