### PR TITLE
Fix pivoted import mappings using column headers

### DIFF
--- a/spinedb_api/mapping.py
+++ b/spinedb_api/mapping.py
@@ -165,8 +165,8 @@ class Mapping:
         Returns:
             bool: True if mapping is effectively the last child, False otherwise
         """
-        return self._child is None or any(
-            child.position in (Position.hidden, Position.table_name) for child in self._child.flatten()
+        return self._child is None or all(
+            child.position in (Position.hidden, Position.table_name) for child in self._child.flatten()[:-1]
         )
 
     def is_pivoted(self):

--- a/tests/import_mapping/test_import_mapping.py
+++ b/tests/import_mapping/test_import_mapping.py
@@ -32,6 +32,7 @@ from spinedb_api.import_mapping.import_mapping import (
     ParameterValueTypeMapping,
     check_validity,
     default_import_mapping,
+    from_dict,
 )
 from spinedb_api.import_mapping.import_mapping_compat import (
     import_mapping_from_dict,
@@ -197,6 +198,21 @@ class TestPolishImportMapping(unittest.TestCase):
         mapping.polish(table_name, header, mapping_name)
         self.assertEqual(mapping.position, Position.mapping_name)
         self.assertEqual(mapping.value, "some_mapping_name")
+
+    def test_polishing_pivoted_mapping_for_preview_with_column_headers_doesnt_break_it(self):
+        mapping_dicts = [
+            {"map_type": "EntityClass", "position": "table_name"},
+            {"map_type": "Dimension", "position": "header", "value": 0},
+            {"map_type": "Entity", "position": "hidden"},
+            {"map_type": "Element", "position": 0},
+            {"map_type": "Alternative", "position": "hidden", "value": "Base"},
+            {"map_type": "ParameterDefinition", "position": "header"},
+            {"map_type": "ParameterValue", "position": "hidden"},
+        ]
+        root_mapping = from_dict(mapping_dicts)
+        self.assertEqual(root_mapping.child.value, 0)
+        root_mapping.polish("table name", ["entity class", "1st parameter"], "Test mapping", for_preview=True)
+        self.assertEqual(root_mapping.child.value, 0)
 
 
 class TestImportMappingIO(unittest.TestCase):


### PR DESCRIPTION
In certain scenarios mapping's value would be accidentally set to None which would change the meaning of mapping's position from "column header" to "headers".

No associated issue.

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
