### PR TITLE
Implement entity alternatives for alternative filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Alternative filter now filters entities, metadata, alternatives and scenarios.
+
 ### Deprecated
 
 ### Removed
@@ -45,8 +47,8 @@ Spine-Database-API now requires Python 3.9 or later, up to 3.12.
 
 ### Changed
 
-- ``GdxWriter`` now uses ``gamsapi`` module instead of ``gdxcc``.
-  A relatively recent version of GAMS may be needed to use the facility.
+- ``spine_io`` now uses ``gamsapi`` module instead of ``gdxcc``.
+  GAMS version 42 or later is required for ``.gdx`` import/export functionality.
 
 ## [0.31.4]
 

--- a/spinedb_api/db_mapping_query_mixin.py
+++ b/spinedb_api/db_mapping_query_mixin.py
@@ -1417,7 +1417,7 @@ class DatabaseMappingQueryMixin:
         self._make_entity_element_sq = MethodType(method, self)
         self._clear_subqueries("entity_element")
 
-    def override_eneity_alternative_sq_maker(self, method):
+    def override_entity_alternative_sq_maker(self, method):
         """
         Overrides the function that creates the ``entity_alternative_sq`` property.
 

--- a/spinedb_api/filters/execution_filter.py
+++ b/spinedb_api/filters/execution_filter.py
@@ -9,11 +9,7 @@
 # Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
-
-"""
-Provides functions to apply filtering based on scenarios to parameter value subqueries.
-
-"""
+""" Provides functions to apply filtering based on scenarios to parameter value subqueries. """
 
 from functools import partial
 import json

--- a/spinedb_api/filters/scenario_filter.py
+++ b/spinedb_api/filters/scenario_filter.py
@@ -33,7 +33,7 @@ def apply_scenario_filter_to_subqueries(db_map, scenario):
     make_entity_sq = partial(_make_scenario_filtered_entity_sq, state=state)
     db_map.override_entity_sq_maker(make_entity_sq)
     make_entity_alternative_sq = partial(_make_scenario_filtered_entity_alternative_sq, state=state)
-    db_map.override_eneity_alternative_sq_maker(make_entity_alternative_sq)
+    db_map.override_entity_alternative_sq_maker(make_entity_alternative_sq)
     make_parameter_value_sq = partial(_make_scenario_filtered_parameter_value_sq, state=state)
     db_map.override_parameter_value_sq_maker(make_parameter_value_sq)
     make_alternative_sq = partial(_make_scenario_filtered_alternative_sq, state=state)
@@ -323,7 +323,7 @@ def _make_scenario_filtered_entity_sq(db_map, state):
 
 def _make_scenario_filtered_entity_alternative_sq(db_map, state):
     """
-    Returns a scenario filtering subquery similar to :func:`DatabaseMapping.entity_alternative_sq`.
+    Returns an entity alternative filtering subquery similar to :func:`DatabaseMapping.entity_alternative_sq`.
 
     This function can be used as replacement for entity_alternative subquery maker in :class:`DatabaseMapping`.
 

--- a/spinedb_api/filters/tools.py
+++ b/spinedb_api/filters/tools.py
@@ -9,7 +9,6 @@
 # Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
-
 """ Tools and utilities to work with filters, manipulators and database URLs. """
 from itertools import dropwhile, takewhile
 from json import dump, load

--- a/spinedb_api/filters/value_transformer.py
+++ b/spinedb_api/filters/value_transformer.py
@@ -9,11 +9,7 @@
 # Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
-
-"""
-Provides a database query manipulator that applies mathematical transformations to parameter values.
-
-"""
+""" Provides a database query manipulator that applies mathematical transformations to parameter values. """
 from functools import partial
 from numbers import Number
 from sqlalchemy import Integer, LargeBinary, String, case, literal

--- a/spinedb_api/spine_io/importers/gdx_connector.py
+++ b/spinedb_api/spine_io/importers/gdx_connector.py
@@ -10,10 +10,7 @@
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
 
-"""
-Contains GDXConnector class and a help function.
-
-"""
+""" Contains GDXConnector class and a help function. """
 
 from gdx2py import GAMSParameter, GAMSScalar, GAMSSet, GdxFile
 from spinedb_api import SpineDBAPIError

--- a/tests/filters/test_alternative_filter.py
+++ b/tests/filters/test_alternative_filter.py
@@ -9,11 +9,7 @@
 # Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
-
-"""
-Unit tests for ``alternative_filter`` module.
-
-"""
+""" Unit tests for ``alternative_filter`` module. """
 from pathlib import Path
 from tempfile import TemporaryDirectory
 import unittest
@@ -22,13 +18,9 @@ from spinedb_api import (
     DatabaseMapping,
     SpineDBAPIError,
     apply_alternative_filter_to_parameter_value_sq,
-    create_new_spine_database,
     from_database,
     import_alternatives,
-    import_object_classes,
-    import_object_parameter_values,
-    import_object_parameters,
-    import_objects,
+    to_database,
 )
 from spinedb_api.filters.alternative_filter import (
     alternative_filter_config,
@@ -37,114 +29,341 @@ from spinedb_api.filters.alternative_filter import (
     alternative_filter_shorthand_to_config,
     alternative_names_from_dict,
 )
+from spinedb_api.import_functions import (
+    import_entities,
+    import_entity_classes,
+    import_parameter_definitions,
+    import_parameter_values,
+)
+from tests.mock_helpers import AssertSuccessTestCase
 
 
-class TestAlternativeFilter(unittest.TestCase):
-    _db_url = None
-    _temp_dir = None
-
-    @classmethod
-    def setUpClass(cls):
-        cls._temp_dir = TemporaryDirectory()
-        cls._db_url = URL("sqlite", database=Path(cls._temp_dir.name, "test_scenario_filter_mapping.sqlite").as_posix())
-
-    def setUp(self):
-        create_new_spine_database(self._db_url)
-        self._out_db_map = DatabaseMapping(self._db_url)
-        self._db_map = DatabaseMapping(self._db_url)
-
-    def tearDown(self):
-        self._out_db_map.close()
-        self._db_map.close()
-
+class TestAlternativeFilter(AssertSuccessTestCase):
     def test_alternative_filter_without_scenarios_or_alternatives(self):
-        self._build_data_without_alternatives()
-        self._out_db_map.commit_session("Add test data")
-        apply_alternative_filter_to_parameter_value_sq(self._db_map, [])
-        parameters = self._db_map.query(self._db_map.parameter_value_sq).all()
-        self.assertEqual(parameters, [])
+        with TemporaryDirectory() as temp_dir:
+            url = URL("sqlite", database=Path(temp_dir, "test_scenario_filter_mapping.sqlite").as_posix())
+            with DatabaseMapping(url, create=True) as db_map:
+                self._build_data_without_alternatives(db_map)
+            with DatabaseMapping(url) as db_map:
+                apply_alternative_filter_to_parameter_value_sq(db_map, [])
+                parameters = db_map.query(db_map.parameter_value_sq).all()
+                self.assertEqual(parameters, [])
 
     def test_alternative_filter_without_scenarios_or_alternatives_uncommitted_data(self):
-        self._build_data_without_alternatives()
-        apply_alternative_filter_to_parameter_value_sq(self._out_db_map, alternatives=[])
-        parameters = self._out_db_map.query(self._out_db_map.parameter_value_sq).all()
-        self.assertEqual(parameters, [])
-        self._out_db_map.rollback_session()
+        with TemporaryDirectory() as temp_dir:
+            url = URL("sqlite", database=Path(temp_dir, "test_scenario_filter_mapping.sqlite").as_posix())
+            with DatabaseMapping(url, create=True) as db_map:
+                self._build_data_without_alternatives(db_map, commit=False)
+                apply_alternative_filter_to_parameter_value_sq(db_map, alternatives=[])
+                parameters = db_map.query(db_map.parameter_value_sq).all()
+                self.assertEqual(parameters, [])
+                db_map.rollback_session()
 
     def test_alternative_filter(self):
-        self._build_data_with_single_alternative()
-        self._out_db_map.commit_session("Add test data")
-        apply_alternative_filter_to_parameter_value_sq(self._db_map, ["alternative"])
-        parameters = self._db_map.query(self._db_map.parameter_value_sq).all()
-        self.assertEqual(len(parameters), 1)
-        self.assertEqual(parameters[0].value, b"23.0")
+        with TemporaryDirectory() as temp_dir:
+            url = URL("sqlite", database=Path(temp_dir, "test_scenario_filter_mapping.sqlite").as_posix())
+            with DatabaseMapping(url, create=True) as db_map:
+                self._build_data_with_single_alternative(db_map)
+            with DatabaseMapping(url) as db_map:
+                apply_alternative_filter_to_parameter_value_sq(db_map, ["alternative"])
+                parameters = db_map.query(db_map.parameter_value_sq).all()
+                self.assertEqual(len(parameters), 1)
+                self.assertEqual(parameters[0].value, to_database(-23.0)[0])
 
     def test_alternative_filter_uncommitted_data(self):
-        self._build_data_with_single_alternative()
-        with self.assertRaises(SpineDBAPIError):
-            apply_alternative_filter_to_parameter_value_sq(self._out_db_map, ["alternative"])
-        parameters = self._out_db_map.query(self._out_db_map.parameter_value_sq).all()
-        self.assertEqual(len(parameters), 0)
-        self._out_db_map.rollback_session()
+        with TemporaryDirectory() as temp_dir:
+            url = URL("sqlite", database=Path(temp_dir, "test_scenario_filter_mapping.sqlite").as_posix())
+            with DatabaseMapping(url, create=True) as db_map:
+                self._build_data_with_single_alternative(db_map, commit=False)
+                with self.assertRaises(SpineDBAPIError):
+                    apply_alternative_filter_to_parameter_value_sq(db_map, ["alternative"])
+                parameters = db_map.query(db_map.parameter_value_sq).all()
+                self.assertEqual(len(parameters), 0)
+                db_map.rollback_session()
 
     def test_alternative_filter_from_dict(self):
-        self._build_data_with_single_alternative()
-        self._out_db_map.commit_session("Add test data")
-        config = alternative_filter_config(["alternative"])
-        alternative_filter_from_dict(self._db_map, config)
-        parameters = self._db_map.query(self._db_map.parameter_value_sq).all()
-        self.assertEqual(len(parameters), 1)
-        self.assertEqual(parameters[0].value, b"23.0")
-
-    def _build_data_without_alternatives(self):
-        import_object_classes(self._out_db_map, ["object_class"])
-        import_objects(self._out_db_map, [("object_class", "object")])
-        import_object_parameters(self._out_db_map, [("object_class", "parameter")])
-        import_object_parameter_values(self._out_db_map, [("object_class", "object", "parameter", 23.0)])
-
-    def _build_data_with_single_alternative(self):
-        import_alternatives(self._out_db_map, ["alternative"])
-        import_object_classes(self._out_db_map, ["object_class"])
-        import_objects(self._out_db_map, [("object_class", "object")])
-        import_object_parameters(self._out_db_map, [("object_class", "parameter")])
-        import_object_parameter_values(self._out_db_map, [("object_class", "object", "parameter", -1.0)])
-        import_object_parameter_values(self._out_db_map, [("object_class", "object", "parameter", 23.0, "alternative")])
-
-
-class TestAlternativeFilterWithMemoryDatabase(unittest.TestCase):
-    def setUp(self):
-        self._db_map = DatabaseMapping("sqlite://", create=True)
-        import_object_classes(self._db_map, ["object_class"])
-        import_objects(self._db_map, [("object_class", "object")])
-        import_object_parameters(self._db_map, [("object_class", "parameter")])
-        import_object_parameter_values(self._db_map, [("object_class", "object", "parameter", -1.0)])
-        self._db_map.commit_session("Add initial data.")
-
-    def tearDown(self):
-        self._db_map.close()
+        with TemporaryDirectory() as temp_dir:
+            url = URL("sqlite", database=Path(temp_dir, "test_scenario_filter_mapping.sqlite").as_posix())
+            with DatabaseMapping(url, create=True) as db_map:
+                self._build_data_with_single_alternative(db_map)
+            with DatabaseMapping(url) as db_map:
+                config = alternative_filter_config(["alternative"])
+                alternative_filter_from_dict(db_map, config)
+                parameters = db_map.query(db_map.parameter_value_sq).all()
+                self.assertEqual(len(parameters), 1)
+                self.assertEqual(parameters[0].value, to_database(-23.0)[0])
 
     def test_alternative_names_with_colons(self):
-        self._add_value_in_alternative(23.0, "new@2023-23-23T11:12:13")
-        config = alternative_filter_config(["new@2023-23-23T11:12:13"])
-        alternative_filter_from_dict(self._db_map, config)
-        parameters = self._db_map.query(self._db_map.parameter_value_sq).all()
-        self.assertEqual(len(parameters), 1)
-        self.assertEqual(parameters[0].value, b"23.0")
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._build_data_with_single_alternative(db_map)
+            self._add_value_in_alternative(db_map, 23.0, "new@2023-23-23T11:12:13")
+            config = alternative_filter_config(["new@2023-23-23T11:12:13"])
+            alternative_filter_from_dict(db_map, config)
+            parameters = db_map.query(db_map.parameter_value_sq).all()
+            self.assertEqual(len(parameters), 1)
+            self.assertEqual(parameters[0].value, to_database(23.0)[0])
 
     def test_multiple_alternatives(self):
-        self._add_value_in_alternative(23.0, "new@2023-23-23T11:12:13")
-        self._add_value_in_alternative(101.1, "new@2005-05-05T22:23:24")
-        config = alternative_filter_config(["new@2005-05-05T22:23:24", "new@2023-23-23T11:12:13"])
-        alternative_filter_from_dict(self._db_map, config)
-        parameters = self._db_map.query(self._db_map.parameter_value_sq).all()
-        self.assertEqual(len(parameters), 2)
-        values = {from_database(p.value, p.type) for p in parameters}
-        self.assertEqual(values, {23.0, 101.1})
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._build_data_with_single_alternative(db_map)
+            self._add_value_in_alternative(db_map, 23.0, "new@2023-23-23T11:12:13")
+            self._add_value_in_alternative(db_map, 101.1, "new@2005-05-05T22:23:24")
+            config = alternative_filter_config(["new@2005-05-05T22:23:24", "new@2023-23-23T11:12:13"])
+            alternative_filter_from_dict(db_map, config)
+            parameters = db_map.query(db_map.parameter_value_sq).all()
+            self.assertEqual(len(parameters), 2)
+            values = {from_database(p.value, p.type) for p in parameters}
+            self.assertEqual(values, {23.0, 101.1})
 
-    def _add_value_in_alternative(self, value, alternative):
-        import_alternatives(self._db_map, [alternative])
-        import_object_parameter_values(self._db_map, [("object_class", "object", "parameter", value, alternative)])
-        self._db_map.commit_session(f"Add value in {alternative}")
+    def test_filters_alternatives(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(db_map.add_alternative_item(name="visible"))
+            db_map.commit_session("Add alternative")
+            config = alternative_filter_config(["visible"])
+            alternative_filter_from_dict(db_map, config)
+            alternatives = db_map.query(db_map.alternative_sq).all()
+            self.assertEqual(len(alternatives), 1)
+            self.assertEqual(alternatives[0]["name"], "visible")
+
+    def test_filters_scenarios(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(db_map.add_alternative_item(name="visible"))
+            self._assert_success(db_map.add_scenario_item(name="Empty"))
+            self._assert_success(db_map.add_scenario_item(name="Base and visible"))
+            self._assert_success(
+                db_map.add_scenario_alternative_item(scenario_name="Base and visible", alternative_name="Base", rank=1)
+            )
+            self._assert_success(
+                db_map.add_scenario_alternative_item(
+                    scenario_name="Base and visible", alternative_name="visible", rank=2
+                )
+            )
+            self._assert_success(db_map.add_scenario_item(name="Base only"))
+            self._assert_success(
+                db_map.add_scenario_alternative_item(scenario_name="Base only", alternative_name="Base", rank=1)
+            )
+            self._assert_success(db_map.add_scenario_item(name="Visible only"))
+            self._assert_success(
+                db_map.add_scenario_alternative_item(scenario_name="Visible only", alternative_name="visible", rank=1)
+            )
+            db_map.commit_session("Add scenarios")
+            config = alternative_filter_config(["visible"])
+            alternative_filter_from_dict(db_map, config)
+            scenarios = db_map.query(db_map.scenario_sq).all()
+            self.assertEqual(len(scenarios), 2)
+            self.assertCountEqual([s["name"] for s in scenarios], ["Empty", "Visible only"])
+
+    def test_filters_scenario_alternatives(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(db_map.add_alternative_item(name="visible"))
+            self._assert_success(db_map.add_scenario_item(name="Base and visible"))
+            self._assert_success(
+                db_map.add_scenario_alternative_item(scenario_name="Base and visible", alternative_name="Base", rank=1)
+            )
+            self._assert_success(
+                db_map.add_scenario_alternative_item(
+                    scenario_name="Base and visible", alternative_name="visible", rank=2
+                )
+            )
+            db_map.commit_session("Add scenario with two alternatives")
+            config = alternative_filter_config(["visible"])
+            alternative_filter_from_dict(db_map, config)
+            scenario_alternatives = db_map.query(db_map.scenario_alternative_sq).all()
+            self.assertEqual(len(scenario_alternatives), 0)
+
+    def test_filters_entities_in_class_thats_active_by_default(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(db_map.add_entity_class_item(name="ActiveByDefault", active_by_default=True))
+            self._assert_success(db_map.add_entity_item(name="visible_by_default", entity_class_name="ActiveByDefault"))
+            self._assert_success(db_map.add_entity_item(name="visible", entity_class_name="ActiveByDefault"))
+            self._assert_success(
+                db_map.add_entity_alternative_item(
+                    entity_class_name="ActiveByDefault",
+                    entity_byname=("visible",),
+                    alternative_name="Base",
+                    active=True,
+                )
+            )
+            self._assert_success(db_map.add_entity_item(name="invisible", entity_class_name="ActiveByDefault"))
+            self._assert_success(
+                db_map.add_entity_alternative_item(
+                    entity_class_name="ActiveByDefault",
+                    entity_byname=("invisible",),
+                    alternative_name="Base",
+                    active=False,
+                )
+            )
+            db_map.commit_session("Add entities.")
+            config = alternative_filter_config(["Base"])
+            alternative_filter_from_dict(db_map, config)
+            entities = db_map.query(db_map.entity_sq).all()
+            self.assertEqual(len(entities), 2)
+            self.assertCountEqual([e["name"] for e in entities], ["visible", "visible_by_default"])
+
+    def test_filters_entities_in_class_that_isnt_active_by_default(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(db_map.add_entity_class_item(name="InactiveByDefault", active_by_default=False))
+            self._assert_success(
+                db_map.add_entity_item(name="invisible_by_default", entity_class_name="InactiveByDefault")
+            )
+            self._assert_success(db_map.add_entity_item(name="visible", entity_class_name="InactiveByDefault"))
+            self._assert_success(
+                db_map.add_entity_alternative_item(
+                    entity_class_name="InactiveByDefault",
+                    entity_byname=("visible",),
+                    alternative_name="Base",
+                    active=True,
+                )
+            )
+            self._assert_success(db_map.add_entity_item(name="invisible", entity_class_name="InactiveByDefault"))
+            self._assert_success(
+                db_map.add_entity_alternative_item(
+                    entity_class_name="InactiveByDefault",
+                    entity_byname=("invisible",),
+                    alternative_name="Base",
+                    active=False,
+                )
+            )
+            db_map.commit_session("Add entities.")
+            config = alternative_filter_config(["Base"])
+            alternative_filter_from_dict(db_map, config)
+            entities = db_map.query(db_map.entity_sq).all()
+            self.assertEqual(len(entities), 1)
+            self.assertCountEqual([e["name"] for e in entities], ["visible"])
+
+    def test_filters_multidimensional_entities_that_have_inactive_elements(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(db_map.add_entity_class_item(name="Object"))
+            self._assert_success(db_map.add_entity_item(name="invisible", entity_class_name="Object"))
+            self._assert_success(
+                db_map.add_entity_alternative_item(
+                    entity_class_name="Object", entity_byname=("invisible",), alternative_name="Base", active=False
+                )
+            )
+            self._assert_success(db_map.add_entity_item(name="visible", entity_class_name="Object"))
+            self._assert_success(
+                db_map.add_entity_alternative_item(
+                    entity_class_name="Object", entity_byname=("visible",), alternative_name="Base", active=True
+                )
+            )
+            self._assert_success(db_map.add_entity_class_item(name="Relationship", dimension_name_list=["Object"]))
+            self._assert_success(db_map.add_entity_item(entity_byname=("invisible",), entity_class_name="Relationship"))
+            self._assert_success(db_map.add_entity_item(entity_byname=("visible",), entity_class_name="Relationship"))
+            db_map.commit_session("Add entities.")
+            config = alternative_filter_config(["Base"])
+            alternative_filter_from_dict(db_map, config)
+            entities = db_map.query(db_map.entity_sq).all()
+            self.assertEqual(len(entities), 2)
+            self.assertCountEqual([e["name"] for e in entities], ["visible", "visible__"])
+
+    def test_filters_parameters_values_of_inactive_entities(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(db_map.add_entity_class_item(name="Object"))
+            self._assert_success(db_map.add_entity_item(name="invisible", entity_class_name="Object"))
+            self._assert_success(
+                db_map.add_entity_alternative_item(
+                    entity_class_name="Object", entity_byname=("invisible",), alternative_name="Base", active=False
+                )
+            )
+            self._assert_success(db_map.add_entity_item(name="visible", entity_class_name="Object"))
+            self._assert_success(
+                db_map.add_entity_alternative_item(
+                    entity_class_name="Object", entity_byname=("visible",), alternative_name="Base", active=True
+                )
+            )
+            self._assert_success(db_map.add_parameter_definition_item(name="y", entity_class_name="Object"))
+            value, value_type = to_database(-2.3)
+            self._assert_success(
+                db_map.add_parameter_value_item(
+                    entity_class_name="Object",
+                    entity_byname=("invisible",),
+                    parameter_definition_name="y",
+                    alternative_name="Base",
+                    value=value,
+                    type=value_type,
+                )
+            )
+            value, value_type = to_database(2.3)
+            self._assert_success(
+                db_map.add_parameter_value_item(
+                    entity_class_name="Object",
+                    entity_byname=("visible",),
+                    parameter_definition_name="y",
+                    alternative_name="Base",
+                    value=value,
+                    type=value_type,
+                )
+            )
+            db_map.commit_session("Add values.")
+            config = alternative_filter_config(["Base"])
+            alternative_filter_from_dict(db_map, config)
+            values = db_map.query(db_map.parameter_value_sq).all()
+            self.assertEqual(len(values), 1)
+            self.assertEqual(from_database(values[0]["value"], values[0]["type"]), 2.3)
+
+    def test_filters_parameters_values_by_active_by_default(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(db_map.add_entity_class_item(name="ActiveByDefault", active_by_default=True))
+            self._assert_success(db_map.add_parameter_definition_item(name="x", entity_class_name="ActiveByDefault"))
+            self._assert_success(db_map.add_entity_item(name="visible", entity_class_name="ActiveByDefault"))
+            value, value_type = to_database(-2.3)
+            self._assert_success(
+                db_map.add_parameter_value_item(
+                    entity_class_name="ActiveByDefault",
+                    entity_byname=("visible",),
+                    parameter_definition_name="x",
+                    alternative_name="Base",
+                    value=value,
+                    type=value_type,
+                )
+            )
+            self._assert_success(db_map.add_entity_class_item(name="InactiveByDefault", active_by_default=False))
+            self._assert_success(db_map.add_parameter_definition_item(name="y", entity_class_name="InactiveByDefault"))
+            self._assert_success(db_map.add_entity_item(name="invisible", entity_class_name="InactiveByDefault"))
+            value, value_type = to_database(2.3)
+            self._assert_success(
+                db_map.add_parameter_value_item(
+                    entity_class_name="InactiveByDefault",
+                    entity_byname=("invisible",),
+                    parameter_definition_name="y",
+                    alternative_name="Base",
+                    value=value,
+                    type=value_type,
+                )
+            )
+            db_map.commit_session("Add values.")
+            config = alternative_filter_config(["Base"])
+            alternative_filter_from_dict(db_map, config)
+            values = db_map.query(db_map.parameter_value_sq).all()
+            self.assertEqual(len(values), 1)
+            self.assertEqual(from_database(values[0]["value"], values[0]["type"]), -2.3)
+
+    def _build_data_without_alternatives(self, db_map, commit=True):
+        self._assert_imports(import_entity_classes(db_map, ["object_class"]))
+        self._assert_imports(import_entities(db_map, [("object_class", "object")]))
+        self._assert_imports(import_parameter_definitions(db_map, [("object_class", "parameter")]))
+        self._assert_imports(import_parameter_values(db_map, [("object_class", "object", "parameter", -23.0)]))
+        if commit:
+            db_map.commit_session("Add test data")
+
+    def _build_data_with_single_alternative(self, db_map, commit=True):
+        self._assert_imports(import_alternatives(db_map, ["alternative"]))
+        self._assert_imports(import_entity_classes(db_map, ["object_class"]))
+        self._assert_imports(import_entities(db_map, [("object_class", "object")]))
+        self._assert_imports(import_parameter_definitions(db_map, [("object_class", "parameter")]))
+        self._assert_imports(import_parameter_values(db_map, [("object_class", "object", "parameter", -1.0)]))
+        self._assert_imports(
+            import_parameter_values(db_map, [("object_class", "object", "parameter", -23.0, "alternative")])
+        )
+        if commit:
+            db_map.commit_session("Add test data")
+
+    def _add_value_in_alternative(self, db_map, value, alternative):
+        self._assert_imports(import_alternatives(db_map, [alternative]))
+        self._assert_imports(
+            import_parameter_values(db_map, [("object_class", "object", "parameter", value, alternative)])
+        )
+        db_map.commit_session(f"Add value in {alternative}")
 
 
 class TestAlternativeFilterWithoutDatabase(unittest.TestCase):

--- a/tests/filters/test_scenario_filter.py
+++ b/tests/filters/test_scenario_filter.py
@@ -32,12 +32,7 @@ from spinedb_api.filters.scenario_filter import (
 from tests.mock_helpers import AssertSuccessTestCase
 
 
-class TestScenarioFilterInMemory(unittest.TestCase):
-    def _assert_success(self, result):
-        item, error = result
-        self.assertIsNone(error)
-        return item
-
+class TestScenarioFilterInMemory(AssertSuccessTestCase):
     def test_filter_entities_with_default_activity_only(self):
         with DatabaseMapping("sqlite://", create=True) as db_map:
             self._assert_success(db_map.add_entity_class_item(name="visible", active_by_default=True))


### PR DESCRIPTION
Alternative filter now filters entities and parameter values based on entity alternatives as well as alternatives, scenarios and scenario alternatives, much like scenario filter does.

Resolves spine-tools/Spine-Toolbox#3004

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
