### PR TITLE
Fix scenario filter for parameter values of multidimensional entities

### DIFF
--- a/tests/filters/test_scenario_filter.py
+++ b/tests/filters/test_scenario_filter.py
@@ -965,6 +965,62 @@ class TestScenarioFilter(DataBuilderTestCase):
                 self.assertEqual(len(values), 1)
                 self.assertEqual(from_database(values[0]["value"], values[0]["type"]), -2.3)
 
+    def test_parameter_values_of_multidimensional_entity_whose_elements_have_entity_alternatives(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(db_map.add_scenario_item(name="base"))
+            self._assert_success(
+                db_map.add_scenario_alternative_item(scenario_name="base", alternative_name="Base", rank=1)
+            )
+            self._assert_success(db_map.add_entity_class_item(name="Object"))
+            self._assert_success(db_map.add_entity_item(name="visible", entity_class_name="Object"))
+            self._assert_success(
+                db_map.add_entity_alternative_item(
+                    entity_class_name="Object", entity_byname=("visible",), alternative_name="Base", active=True
+                )
+            )
+            self._assert_success(db_map.add_entity_item(name="invisible", entity_class_name="Object"))
+            self._assert_success(
+                db_map.add_entity_alternative_item(
+                    entity_class_name="Object", entity_byname=("invisible",), alternative_name="Base", active=False
+                )
+            )
+            self._assert_success(db_map.add_entity_class_item(name="Relationship", dimension_name_list=("Object",)))
+            self._assert_success(
+                db_map.add_entity_item(element_name_list=("visible",), entity_class_name="Relationship")
+            )
+            self._assert_success(
+                db_map.add_entity_item(element_name_list=("invisible",), entity_class_name="Relationship")
+            )
+            self._assert_success(db_map.add_parameter_definition_item(name="y", entity_class_name="Relationship"))
+            value, value_type = to_database(2.3)
+            self._assert_success(
+                db_map.add_parameter_value_item(
+                    entity_class_name="Relationship",
+                    entity_byname=("visible",),
+                    parameter_definition_name="y",
+                    alternative_name="Base",
+                    value=value,
+                    type=value_type,
+                )
+            )
+            value, value_type = to_database(-2.3)
+            self._assert_success(
+                db_map.add_parameter_value_item(
+                    entity_class_name="Relationship",
+                    entity_byname=("invisible",),
+                    parameter_definition_name="y",
+                    alternative_name="Base",
+                    value=value,
+                    type=value_type,
+                )
+            )
+            db_map.commit_session("Add test data")
+            config = scenario_filter_config("base")
+            scenario_filter_from_dict(db_map, config)
+            values = db_map.query(db_map.parameter_value_sq).all()
+            self.assertEqual(len(values), 1)
+            self.assertEqual(from_database(values[0].value, values[0].type), 2.3)
+
 
 class TestScenarioFilterUtils(DataBuilderTestCase):
     def test_scenario_filter_config(self):


### PR DESCRIPTION
Scenario filter must drop parameter values of multidimensional entities that will be dropped by the filter because they have elements that are inactive in the scenario.

No associated issue

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
