### PR TITLE
Add entity groups to alternative and scenario filters

### DIFF
--- a/spinedb_api/db_mapping_query_mixin.py
+++ b/spinedb_api/db_mapping_query_mixin.py
@@ -345,7 +345,7 @@ class DatabaseMappingQueryMixin:
             :class:`~sqlalchemy.sql.expression.Alias`
         """
         if self._entity_group_sq is None:
-            self._entity_group_sq = self._subquery("entity_group")
+            self._entity_group_sq = self._make_entity_group_sq()
         return self._entity_group_sq
 
     @property
@@ -1285,6 +1285,15 @@ class DatabaseMappingQueryMixin:
         """
         return self._subquery("entity_element")
 
+    def _make_entity_group_sq(self):
+        """
+        Creates a subquery for entity groups.
+
+        Returns:
+            Alias: an entity_group subquery
+        """
+        return self._subquery("entity_group")
+
     def _make_entity_alternative_sq(self):
         """
         Creates a subquery for entity-alternatives.
@@ -1416,6 +1425,17 @@ class DatabaseMappingQueryMixin:
         """
         self._make_entity_element_sq = MethodType(method, self)
         self._clear_subqueries("entity_element")
+
+    def override_entity_group_sq_maker(self, method):
+        """
+        Overrides the function that creates the ``entity_group_sq`` property.
+
+        Args:
+            method (Callable): a function that accepts a :class:`DatabaseMapping` as its argument and
+                returns entity_group subquery as an :class:`Alias` object
+        """
+        self._make_entity_group_sq = MethodType(method, self)
+        self._clear_subqueries("entity_group")
 
     def override_entity_alternative_sq_maker(self, method):
         """

--- a/tests/filters/test_alternative_filter.py
+++ b/tests/filters/test_alternative_filter.py
@@ -390,6 +390,179 @@ class TestAlternativeFilter(AssertSuccessTestCase):
             self.assertEqual(len(values), 1)
             self.assertEqual(from_database(values[0]["value"], values[0]["type"]), -2.3)
 
+    def test_entity_groups(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(db_map.add_entity_class_item(name="Visible", active_by_default=True))
+            self._assert_success(db_map.add_entity_item(name="default_active", entity_class_name="Visible"))
+            self._assert_success(db_map.add_entity_item(name="active", entity_class_name="Visible"))
+            self._assert_success(
+                db_map.add_entity_alternative_item(
+                    entity_byname=("active",), entity_class_name="Visible", alternative_name="Base", active=True
+                )
+            )
+            self._assert_success(db_map.add_entity_item(name="inactive", entity_class_name="Visible"))
+            self._assert_success(
+                db_map.add_entity_alternative_item(
+                    entity_byname=("inactive",), entity_class_name="Visible", alternative_name="Base", active=False
+                )
+            )
+            self._assert_success(db_map.add_entity_item(name="default_active_group", entity_class_name="Visible"))
+            self._assert_success(
+                db_map.add_entity_group_item(
+                    entity_class_name="Visible", group_name="default_active_group", member_name="default_active"
+                )
+            )
+            self._assert_success(
+                db_map.add_entity_group_item(
+                    entity_class_name="Visible", group_name="default_active_group", member_name="active"
+                )
+            )
+            self._assert_success(
+                db_map.add_entity_group_item(
+                    entity_class_name="Visible", group_name="default_active_group", member_name="inactive"
+                )
+            )
+            self._assert_success(db_map.add_entity_item(name="active_group", entity_class_name="Visible"))
+            self._assert_success(
+                db_map.add_entity_alternative_item(
+                    entity_byname=("active_group",), entity_class_name="Visible", alternative_name="Base", active=True
+                )
+            )
+            self._assert_success(
+                db_map.add_entity_group_item(
+                    entity_class_name="Visible", group_name="active_group", member_name="default_active"
+                )
+            )
+            self._assert_success(
+                db_map.add_entity_group_item(
+                    entity_class_name="Visible", group_name="active_group", member_name="active"
+                )
+            )
+            self._assert_success(
+                db_map.add_entity_group_item(
+                    entity_class_name="Visible", group_name="active_group", member_name="inactive"
+                )
+            )
+            self._assert_success(db_map.add_entity_item(name="inactive_group", entity_class_name="Visible"))
+            self._assert_success(
+                db_map.add_entity_alternative_item(
+                    entity_byname=("inactive_group",),
+                    entity_class_name="Visible",
+                    alternative_name="Base",
+                    active=False,
+                )
+            )
+            self._assert_success(
+                db_map.add_entity_group_item(
+                    entity_class_name="Visible", group_name="inactive_group", member_name="default_active"
+                )
+            )
+            self._assert_success(
+                db_map.add_entity_group_item(
+                    entity_class_name="Visible", group_name="inactive_group", member_name="active"
+                )
+            )
+            self._assert_success(
+                db_map.add_entity_group_item(
+                    entity_class_name="Visible", group_name="inactive_group", member_name="inactive"
+                )
+            )
+            self._assert_success(db_map.add_entity_class_item(name="Invisible", active_by_default=False))
+            self._assert_success(db_map.add_entity_item(name="default_inactive", entity_class_name="Invisible"))
+            self._assert_success(db_map.add_entity_item(name="active", entity_class_name="Invisible"))
+            self._assert_success(
+                db_map.add_entity_alternative_item(
+                    entity_byname=("active",), entity_class_name="Invisible", alternative_name="Base", active=True
+                )
+            )
+            self._assert_success(db_map.add_entity_item(name="inactive", entity_class_name="Invisible"))
+            self._assert_success(
+                db_map.add_entity_alternative_item(
+                    entity_byname=("inactive",), entity_class_name="Invisible", alternative_name="Base", active=False
+                )
+            )
+            self._assert_success(db_map.add_entity_item(name="default_inactive_group", entity_class_name="Invisible"))
+            self._assert_success(
+                db_map.add_entity_group_item(
+                    entity_class_name="Invisible", group_name="default_inactive_group", member_name="default_inactive"
+                )
+            )
+            self._assert_success(
+                db_map.add_entity_group_item(
+                    entity_class_name="Invisible", group_name="default_inactive_group", member_name="active"
+                )
+            )
+            self._assert_success(
+                db_map.add_entity_group_item(
+                    entity_class_name="Invisible", group_name="default_inactive_group", member_name="inactive"
+                )
+            )
+            self._assert_success(db_map.add_entity_item(name="active_group", entity_class_name="Invisible"))
+            self._assert_success(
+                db_map.add_entity_alternative_item(
+                    entity_byname=("active_group",), entity_class_name="Invisible", alternative_name="Base", active=True
+                )
+            )
+            self._assert_success(
+                db_map.add_entity_group_item(
+                    entity_class_name="Invisible", group_name="active_group", member_name="default_inactive"
+                )
+            )
+            self._assert_success(
+                db_map.add_entity_group_item(
+                    entity_class_name="Invisible", group_name="active_group", member_name="active"
+                )
+            )
+            self._assert_success(
+                db_map.add_entity_group_item(
+                    entity_class_name="Invisible", group_name="active_group", member_name="inactive"
+                )
+            )
+            self._assert_success(db_map.add_entity_item(name="inactive_group", entity_class_name="Invisible"))
+            self._assert_success(
+                db_map.add_entity_alternative_item(
+                    entity_byname=("inactive_group",),
+                    entity_class_name="Invisible",
+                    alternative_name="Base",
+                    active=False,
+                )
+            )
+            self._assert_success(
+                db_map.add_entity_group_item(
+                    entity_class_name="Invisible", group_name="inactive_group", member_name="default_inactive"
+                )
+            )
+            self._assert_success(
+                db_map.add_entity_group_item(
+                    entity_class_name="Invisible", group_name="inactive_group", member_name="active"
+                )
+            )
+            self._assert_success(
+                db_map.add_entity_group_item(
+                    entity_class_name="Invisible", group_name="inactive_group", member_name="inactive"
+                )
+            )
+            db_map.commit_session("Add test data.")
+            config = alternative_filter_config(["Base"])
+            alternative_filter_from_dict(db_map, config)
+            groups = db_map.query(db_map.entity_group_sq).all()
+            self.assertEqual(len(groups), 5)
+            class_names = {row["id"]: row["name"] for row in db_map.query(db_map.entity_class_sq)}
+            entity_names = {row["id"]: row["name"] for row in db_map.query(db_map.entity_sq)}
+            data = {}
+            for row in groups:
+                data.setdefault(class_names[row["entity_class_id"]], {}).setdefault(
+                    entity_names[row["entity_id"]], set()
+                ).add(entity_names[row["member_id"]])
+            expected = {
+                "Visible": {
+                    "default_active_group": {"default_active", "active"},
+                    "active_group": {"default_active", "active"},
+                },
+                "Invisible": {"active_group": {"active"}},
+            }
+            self.assertEqual(data, expected)
+
     def _build_data_without_alternatives(self, db_map, commit=True):
         self._assert_imports(import_entity_classes(db_map, ["object_class"]))
         self._assert_imports(import_entities(db_map, [("object_class", "object")]))

--- a/tests/filters/test_scenario_filter.py
+++ b/tests/filters/test_scenario_filter.py
@@ -101,6 +101,182 @@ class TestScenarioFilterInMemory(AssertSuccessTestCase):
             entities = db_map.query(db_map.wide_entity_sq).all()
             self.assertEqual(len(entities), 0)
 
+    def test_filter_entity_groups(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(db_map.add_scenario_item(name="scen"))
+            self._assert_success(
+                db_map.add_scenario_alternative_item(scenario_name="scen", alternative_name="Base", rank=0)
+            )
+            self._assert_success(db_map.add_entity_class_item(name="Visible", active_by_default=True))
+            self._assert_success(db_map.add_entity_item(name="default_active", entity_class_name="Visible"))
+            self._assert_success(db_map.add_entity_item(name="active", entity_class_name="Visible"))
+            self._assert_success(
+                db_map.add_entity_alternative_item(
+                    entity_byname=("active",), entity_class_name="Visible", alternative_name="Base", active=True
+                )
+            )
+            self._assert_success(db_map.add_entity_item(name="inactive", entity_class_name="Visible"))
+            self._assert_success(
+                db_map.add_entity_alternative_item(
+                    entity_byname=("inactive",), entity_class_name="Visible", alternative_name="Base", active=False
+                )
+            )
+            self._assert_success(db_map.add_entity_item(name="default_active_group", entity_class_name="Visible"))
+            self._assert_success(
+                db_map.add_entity_group_item(
+                    entity_class_name="Visible", group_name="default_active_group", member_name="default_active"
+                )
+            )
+            self._assert_success(
+                db_map.add_entity_group_item(
+                    entity_class_name="Visible", group_name="default_active_group", member_name="active"
+                )
+            )
+            self._assert_success(
+                db_map.add_entity_group_item(
+                    entity_class_name="Visible", group_name="default_active_group", member_name="inactive"
+                )
+            )
+            self._assert_success(db_map.add_entity_item(name="active_group", entity_class_name="Visible"))
+            self._assert_success(
+                db_map.add_entity_alternative_item(
+                    entity_byname=("active_group",), entity_class_name="Visible", alternative_name="Base", active=True
+                )
+            )
+            self._assert_success(
+                db_map.add_entity_group_item(
+                    entity_class_name="Visible", group_name="active_group", member_name="default_active"
+                )
+            )
+            self._assert_success(
+                db_map.add_entity_group_item(
+                    entity_class_name="Visible", group_name="active_group", member_name="active"
+                )
+            )
+            self._assert_success(
+                db_map.add_entity_group_item(
+                    entity_class_name="Visible", group_name="active_group", member_name="inactive"
+                )
+            )
+            self._assert_success(db_map.add_entity_item(name="inactive_group", entity_class_name="Visible"))
+            self._assert_success(
+                db_map.add_entity_alternative_item(
+                    entity_byname=("inactive_group",),
+                    entity_class_name="Visible",
+                    alternative_name="Base",
+                    active=False,
+                )
+            )
+            self._assert_success(
+                db_map.add_entity_group_item(
+                    entity_class_name="Visible", group_name="inactive_group", member_name="default_active"
+                )
+            )
+            self._assert_success(
+                db_map.add_entity_group_item(
+                    entity_class_name="Visible", group_name="inactive_group", member_name="active"
+                )
+            )
+            self._assert_success(
+                db_map.add_entity_group_item(
+                    entity_class_name="Visible", group_name="inactive_group", member_name="inactive"
+                )
+            )
+            self._assert_success(db_map.add_entity_class_item(name="Invisible", active_by_default=False))
+            self._assert_success(db_map.add_entity_item(name="default_inactive", entity_class_name="Invisible"))
+            self._assert_success(db_map.add_entity_item(name="active", entity_class_name="Invisible"))
+            self._assert_success(
+                db_map.add_entity_alternative_item(
+                    entity_byname=("active",), entity_class_name="Invisible", alternative_name="Base", active=True
+                )
+            )
+            self._assert_success(db_map.add_entity_item(name="inactive", entity_class_name="Invisible"))
+            self._assert_success(
+                db_map.add_entity_alternative_item(
+                    entity_byname=("inactive",), entity_class_name="Invisible", alternative_name="Base", active=False
+                )
+            )
+            self._assert_success(db_map.add_entity_item(name="default_inactive_group", entity_class_name="Invisible"))
+            self._assert_success(
+                db_map.add_entity_group_item(
+                    entity_class_name="Invisible", group_name="default_inactive_group", member_name="default_inactive"
+                )
+            )
+            self._assert_success(
+                db_map.add_entity_group_item(
+                    entity_class_name="Invisible", group_name="default_inactive_group", member_name="active"
+                )
+            )
+            self._assert_success(
+                db_map.add_entity_group_item(
+                    entity_class_name="Invisible", group_name="default_inactive_group", member_name="inactive"
+                )
+            )
+            self._assert_success(db_map.add_entity_item(name="active_group", entity_class_name="Invisible"))
+            self._assert_success(
+                db_map.add_entity_alternative_item(
+                    entity_byname=("active_group",), entity_class_name="Invisible", alternative_name="Base", active=True
+                )
+            )
+            self._assert_success(
+                db_map.add_entity_group_item(
+                    entity_class_name="Invisible", group_name="active_group", member_name="default_inactive"
+                )
+            )
+            self._assert_success(
+                db_map.add_entity_group_item(
+                    entity_class_name="Invisible", group_name="active_group", member_name="active"
+                )
+            )
+            self._assert_success(
+                db_map.add_entity_group_item(
+                    entity_class_name="Invisible", group_name="active_group", member_name="inactive"
+                )
+            )
+            self._assert_success(db_map.add_entity_item(name="inactive_group", entity_class_name="Invisible"))
+            self._assert_success(
+                db_map.add_entity_alternative_item(
+                    entity_byname=("inactive_group",),
+                    entity_class_name="Invisible",
+                    alternative_name="Base",
+                    active=False,
+                )
+            )
+            self._assert_success(
+                db_map.add_entity_group_item(
+                    entity_class_name="Invisible", group_name="inactive_group", member_name="default_inactive"
+                )
+            )
+            self._assert_success(
+                db_map.add_entity_group_item(
+                    entity_class_name="Invisible", group_name="inactive_group", member_name="active"
+                )
+            )
+            self._assert_success(
+                db_map.add_entity_group_item(
+                    entity_class_name="Invisible", group_name="inactive_group", member_name="inactive"
+                )
+            )
+            db_map.commit_session("Add test data.")
+            apply_filter_stack(db_map, [scenario_filter_config("scen")])
+            groups = db_map.query(db_map.entity_group_sq).all()
+            self.assertEqual(len(groups), 5)
+            class_names = {row["id"]: row["name"] for row in db_map.query(db_map.entity_class_sq)}
+            entity_names = {row["id"]: row["name"] for row in db_map.query(db_map.entity_sq)}
+            data = {}
+            for row in groups:
+                data.setdefault(class_names[row["entity_class_id"]], {}).setdefault(
+                    entity_names[row["entity_id"]], set()
+                ).add(entity_names[row["member_id"]])
+            expected = {
+                "Visible": {
+                    "default_active_group": {"default_active", "active"},
+                    "active_group": {"default_active", "active"},
+                },
+                "Invisible": {"active_group": {"active"}},
+            }
+            self.assertEqual(data, expected)
+
 
 class DataBuilderTestCase(AssertSuccessTestCase):
     def _build_data_with_single_scenario(self, db_map, commit=True):


### PR DESCRIPTION
This PR implements entity group filtering in scenario and alternative filters.

Resolves spine-tools/Spine-Toolbox#3004

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
