### PR TITLE
Support Python 3.13

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -2,7 +2,6 @@
 
 name: Unit tests
 
-# Run workflow on every push
 on:
   push:
     paths:
@@ -17,8 +16,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        os: [ubuntu-latest, windows-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v4
       with:
@@ -61,7 +60,7 @@ jobs:
     name: Toolbox unit tests
     uses: spine-tools/Spine-Toolbox/.github/workflows/unit_tests.yml@master
     with:
-      host-os: ubuntu-22.04
+      host-os: ubuntu-latest
       python-version: 3.9
       repository: spine-tools/Spine-Toolbox
       coverage: false
@@ -71,7 +70,7 @@ jobs:
     name: Toolbox execution tests
     uses: spine-tools/Spine-Toolbox/.github/workflows/execution_tests.yml@master
     with:
-      host-os: ubuntu-22.04
+      host-os: ubuntu-latest
       python-version: 3.9
       repository: spine-tools/Spine-Toolbox
       post-installation-command: python -m pip install git+${{ github.server_url }}/${{ github.repository }}.git@${{ github.ref_name }}
@@ -80,9 +79,9 @@ jobs:
     name: SpineInterface.jl test
     uses: spine-tools/SpineInterface.jl/.github/workflows/Test.yml@master
     with:
-      host-os: ubuntu-22.04
+      host-os: ubuntu-latest
       julia-version: "1"
-      python-version: "3.12"
+      python-version: "3.13"
       repository: spine-tools/SpineInterface.jl
       spinedb-api-ref-name: ${{ github.ref_name }}
       coverage: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Support for Python 3.13.
+
 ### Changed
 
 ### Deprecated

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ classifiers = [
     "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
     "Operating System :: OS Independent",
 ]
-requires-python = ">=3.9, <3.13"
+requires-python = ">=3.9"
 dependencies = [
     # v1.4 does not pass tests
     "SQLAlchemy >=1.3, <1.4",
@@ -25,7 +25,7 @@ dependencies = [
     "ijson >=3.1.4",
     "chardet >=4.0.0",
     "PyMySQL >=1.0.2",
-    "psycopg2",
+    "psycopg2-binary",
 ]
 
 [project.urls]


### PR DESCRIPTION
psycopg2 binaries should now be available for Python 3.13

Resolves spine-tools/Spine-Toolbox#2986

## Checklist before merging
- [x] Release notes have been updated
- [x] Unit tests pass
