### PR TITLE
Fix JSONConnector on Python 3.13

### DIFF
--- a/spinedb_api/spine_io/importers/json_reader.py
+++ b/spinedb_api/spine_io/importers/json_reader.py
@@ -16,6 +16,7 @@ import os
 import sys
 import ijson
 from ijson import IncompleteJSONError
+from ijson.backends.python import UnexpectedSymbol
 from ...exception import ConnectorError
 from .reader import SourceConnection
 
@@ -72,7 +73,7 @@ class JSONConnector(SourceConnection):
                             return
                         yield x[:max_depth]
                         row += 1
-            except IncompleteJSONError as error:
+            except (IncompleteJSONError, UnexpectedSymbol) as error:
                 raise ConnectorError(f"failed to read JSON: {error}") from error
 
     def get_data_iterator(self, table, options, max_rows=-1):


### PR DESCRIPTION
Accidentally pushed a commit to master branch which, of course, makes unit tests fail on Python 3.13. This should fix the issue.

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
