### PR TITLE
Fix scenario filter filtering entity alternatives

### DIFF
--- a/spinedb_api/filters/scenario_filter.py
+++ b/spinedb_api/filters/scenario_filter.py
@@ -305,6 +305,7 @@ def _make_scenario_filtered_entity_alternative_sq(db_map, state):
     ext_entity_sq = _ext_entity_sq(db_map, state)
     return (
         db_map.query(state.original_entity_alternative_sq)
+        .filter(state.original_entity_alternative_sq.c.alternative_id.in_(state.alternative_ids))
         .filter(state.original_entity_alternative_sq.c.entity_id == ext_entity_sq.c.id)
         .filter(
             ext_entity_sq.c.desc_rank_row_number == 1,


### PR DESCRIPTION
Scenario filter must drop entity alternatives that reference alternatives that are not in part of the scenario.

Fixes #spine-tools/Spine-Toolbox#3004

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
