### PR TITLE
Use StaticPool in SQLite engines

### DIFF
--- a/tests/test_DatabaseMapping.py
+++ b/tests/test_DatabaseMapping.py
@@ -11,7 +11,6 @@
 ######################################################################################################################
 """ Unit tests for DatabaseMapping class. """
 from collections import namedtuple
-import multiprocessing
 import os.path
 from tempfile import TemporaryDirectory
 import threading
@@ -1956,6 +1955,10 @@ class TestDatabaseMapping(AssertSuccessTestCase):
             SpineDBAPIError, msg="session is None; did you forget to use the DB map inside a 'with' block?"
         ):
             db_map.query(db_map.entity_sq)
+
+    def test_create_parameter_type_table(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            db_map.fetch_all("parameter_type")
 
 
 class TestDatabaseMappingLegacy(unittest.TestCase):


### PR DESCRIPTION
This should fix an issue with DB server where an in-memory database would not be transferred between the server worker thread and the main thread.

Resolves spine-tools/SpineOpt.jl#1158

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
