### PR TITLE
Writable parsed_value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support for Python 3.13.
+- It is now possible to use the ``parsed_value`` field when adding or updating
+  parameter definition, paramater value and list value items.
+  ``parsed_value`` replaces the ``value`` and ``type`` (``default_value`` and ``default_type`` for parameter definitions)
+  fields and accepts the value directly so manual conversion using ``to_database()`` is not needed anymore.
 
 ### Changed
 

--- a/docs/source/front_matter.rst
+++ b/docs/source/front_matter.rst
@@ -35,7 +35,7 @@ Dependencies
 ------------
 
 Spine database API's install process will ensure that SQLAlchemy_ is installed,
-in addition to other dependencies. Spine database API will work with SQLAlchemy as of version 1.3.0.
+in addition to other dependencies. Spine database API will work with SQLAlchemy version 1.4.
 
 
 Bugs

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -99,20 +99,14 @@ Let's add a parameter definition for one of our entity classes::
 
     db_map.add_parameter_definition_item(entity_class_name="fish", name="color")
 
-Finally, let's specify a parameter value for one of our entities.
-First, we use :func:`.to_database` to convert the value we want to give into a tuple of ``value`` and ``type``::
-
-    value, type_ = api.to_database("mainly orange")
-
-Now we create our parameter value::
+Finally, let's specify a parameter value for one of our entities::
 
     db_map.add_parameter_value_item(
         entity_class_name="fish",
         entity_byname=("Nemo",),
         parameter_definition_name="color",
         alternative_name="Base",
-        value=value,
-        type=type_
+        parsed_value="mainly orange"
     )
 
 Note that in the above, we refer to the entity by its *byname*.
@@ -173,6 +167,13 @@ To retrieve all the items of a given type, we use :meth:`~.DatabaseMapping.get_i
 
 Now you should use the above to try and find Nemo.
 
+.. note::
+
+  Retrieving a large number of items one-by-one using the ``get_*_item()`` function e.g. in a loop
+  might be slow since each call may cause a database query.
+  Before such operations, it might be wise to prefetch the data.
+  For example, before getting a bunch of entity items, you could call
+  ``db_map.fetch_all("entity")``.
 
 Updating data
 -------------
@@ -185,15 +186,15 @@ Let's rename our fish entity to avoid any copyright infringements::
 
 To be safe, let's also change the color::
 
-    new_value, new_type = api.to_database("not that orange")
     db_map.get_parameter_value_item(
         entity_class_name="fish",
         entity_byname=("NotNemo",),
         parameter_definition_name="color",
         alternative_name="Base",
-    ).update(value=new_value, type=new_type)
+    ).update(parsed_value="not that orange")
 
-Note how we need to use then new entity name ``NotNemo`` to retrieve the parameter value. This makes sense.
+Note how we need to use the new entity name ``NotNemo`` to retrieve the parameter value
+since we just renamed it.
 
 Removing data
 -------------

--- a/spinedb_api/mapped_items.py
+++ b/spinedb_api/mapped_items.py
@@ -442,8 +442,11 @@ class ParsedValueBase(MappedItemBase):
     type_key: ClassVar[str] = "type"
 
     def __init__(self, *args, **kwargs):
+        parsed_value = kwargs.pop("parsed_value", None)
+        if parsed_value is not None:
+            kwargs[self.value_key], kwargs[self.type_key] = to_database(parsed_value)
         super().__init__(*args, **kwargs)
-        self._parsed_value = None
+        self._parsed_value = parsed_value
 
     @property
     def parsed_value(self):

--- a/spinedb_api/mapped_items.py
+++ b/spinedb_api/mapped_items.py
@@ -12,6 +12,7 @@
 import inspect
 from operator import itemgetter
 import re
+from typing import ClassVar
 from .db_mapping_base import MappedItemBase
 from .exception import SpineDBAPIError
 from .helpers import DisplayStatus, name_from_dimensions, name_from_elements
@@ -437,6 +438,8 @@ class EntityClassDisplayModeItem(MappedItemBase):
 
 class ParsedValueBase(MappedItemBase):
     _private_fields = {"list_value_id"}
+    value_key: ClassVar[str] = "value"
+    type_key: ClassVar[str] = "type"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -451,14 +454,6 @@ class ParsedValueBase(MappedItemBase):
     def has_value_been_parsed(self):
         """Returns True if parsed_value property has been used."""
         return self._parsed_value is not None
-
-    @property
-    def value_key(self) -> str:
-        raise NotImplementedError()
-
-    @property
-    def type_key(self) -> str:
-        raise NotImplementedError()
 
     def first_invalid_key(self):
         invalid_key = super().first_invalid_key()
@@ -506,14 +501,6 @@ class ParsedValueBase(MappedItemBase):
 
 
 class ParameterItemBase(ParsedValueBase):
-    @property
-    def value_key(self):
-        raise NotImplementedError()
-
-    @property
-    def type_key(self):
-        raise NotImplementedError()
-
     def _value_not_in_list_error(self, parsed_value, list_name):
         raise NotImplementedError()
 
@@ -567,6 +554,8 @@ class ParameterItemBase(ParsedValueBase):
 
 class ParameterDefinitionItem(ParameterItemBase):
     item_type = "parameter_definition"
+    value_key = "default_value"
+    type_key = "default_type"
     fields = {
         "entity_class_name": {"type": str, "value": "The entity class name."},
         "name": {"type": str, "value": "The parameter name."},
@@ -604,14 +593,6 @@ class ParameterDefinitionItem(ParameterItemBase):
     def __init__(self, db_map, **kwargs):
         super().__init__(db_map, **kwargs)
         self._init_type_list = kwargs.get("parameter_type_list")
-
-    @property
-    def value_key(self):
-        return "default_value"
-
-    @property
-    def type_key(self):
-        return "default_type"
 
     def __getitem__(self, key):
         if key == "parameter_type_id_list":
@@ -873,14 +854,6 @@ class ParameterValueItem(ParameterItemBase):
         "alternative_id": (("alternative_name",), "id"),
     }
 
-    @property
-    def value_key(self):
-        return "value"
-
-    @property
-    def type_key(self):
-        return "type"
-
     def __getitem__(self, key):
         if key == "parameter_id":
             return super().__getitem__("parameter_definition_id")
@@ -932,14 +905,6 @@ class ListValueItem(ParsedValueBase):
     _external_fields = {"parameter_value_list_name": ("parameter_value_list_id", "name")}
     _alt_references = {("parameter_value_list_name",): ("parameter_value_list", ("name",))}
     _internal_fields = {"parameter_value_list_id": (("parameter_value_list_name",), "id")}
-
-    @property
-    def value_key(self):
-        return "value"
-
-    @property
-    def type_key(self):
-        return "type"
 
     def __getitem__(self, key):
         if key == "value_and_type":

--- a/tests/test_DatabaseMapping.py
+++ b/tests/test_DatabaseMapping.py
@@ -1960,6 +1960,47 @@ class TestDatabaseMapping(AssertSuccessTestCase):
         with DatabaseMapping("sqlite://", create=True) as db_map:
             db_map.fetch_all("parameter_type")
 
+    def test_add_list_value_item_with_parsed_value(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(db_map.add_parameter_value_list_item(name="my list"))
+            list_value = self._assert_success(
+                db_map.add_list_value_item(parameter_value_list_name="my list", parsed_value=2.3, index=0)
+            )
+            self.assertTrue(list_value.mapped_item.has_value_been_parsed())
+            value = from_database(list_value["value"], list_value["type"])
+            self.assertEqual(value, 2.3)
+            self.assertEqual(list_value["parsed_value"], 2.3)
+
+    def test_add_parameter_definition_item_with_parsed_value(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(db_map.add_entity_class_item(name="Ring"))
+            definition = self._assert_success(
+                db_map.add_parameter_definition_item(name="radius", entity_class_name="Ring", parsed_value=2.3)
+            )
+            self.assertTrue(definition.mapped_item.has_value_been_parsed())
+            value = from_database(definition["default_value"], definition["default_type"])
+            self.assertEqual(value, 2.3)
+            self.assertEqual(definition["parsed_value"], 2.3)
+
+    def test_add_parameter_value_item_with_parsed_value(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(db_map.add_entity_class_item(name="Ring"))
+            self._assert_success(db_map.add_parameter_definition_item(name="radius", entity_class_name="Ring"))
+            self._assert_success(db_map.add_entity_item(name="master", entity_class_name="Ring"))
+            parameter_value = self._assert_success(
+                db_map.add_parameter_value_item(
+                    entity_class_name="Ring",
+                    parameter_definition_name="radius",
+                    entity_byname=("master",),
+                    alternative_name="Base",
+                    parsed_value=2.3,
+                )
+            )
+            self.assertTrue(parameter_value.mapped_item.has_value_been_parsed())
+            value = from_database(parameter_value["value"], parameter_value["type"])
+            self.assertEqual(value, 2.3)
+            self.assertEqual(parameter_value["parsed_value"], 2.3)
+
 
 class TestDatabaseMappingLegacy(unittest.TestCase):
     """'Backward compatibility' tests, i.e. pre-entity tests converted to work with the entity structure."""


### PR DESCRIPTION
Parameter definition, parameter value and list value items can now be added and updated using the `parsed_value` field directly. This removes the need to call `to_database()` each time before calling these operations.

Implements #479

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [ ] Unit tests pass
