### PR TITLE
Add 'entity_class_byname' field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   parameter definition, paramater value and list value items.
   ``parsed_value`` replaces the ``value`` and ``type`` (``default_value`` and ``default_type`` for parameter definitions)
   fields and accepts the value directly so manual conversion using ``to_database()`` is not needed anymore.
+- Added a read-only field ``entity_class_byname`` to EntityClassItem (accessible from EntityItem as well)
+  which works analogously to ``entity_byname``.
 
 ### Changed
 

--- a/tests/test_DatabaseMapping.py
+++ b/tests/test_DatabaseMapping.py
@@ -2039,6 +2039,19 @@ class TestDatabaseMapping(AssertSuccessTestCase):
             value_item.update(parsed_value=2.3)
             self.assertEqual(value_item["parsed_value"], 2.3)
 
+    def test_entity_class_bynames(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            item = self._assert_success(db_map.add_entity_class_item(name="Object"))
+            self.assertEqual(item["entity_class_byname"], ("Object",))
+            self._assert_success(db_map.add_entity_class_item(name="Subject"))
+            item = self._assert_success(db_map.add_entity_class_item(dimension_name_list=("Subject", "Object")))
+            self.assertEqual(item["entity_class_byname"], ("Subject", "Object"))
+            self._assert_success(db_map.add_entity_class_item(dimension_name_list=("Object", "Subject")))
+            item = self._assert_success(
+                db_map.add_entity_class_item(dimension_name_list=("Subject__Object", "Object__Subject"))
+            )
+            self.assertEqual(item["entity_class_byname"], ("Subject", "Object", "Object", "Subject"))
+
 
 class TestDatabaseMappingLegacy(unittest.TestCase):
     """'Backward compatibility' tests, i.e. pre-entity tests converted to work with the entity structure."""


### PR DESCRIPTION
The new field works pretty much like `entity_byname` but for entity classes.

Preparing for Pandas dataframes.

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
