### PR TITLE
Fix minor issues

### DIFF
--- a/spinedb_api/db_mapping_base.py
+++ b/spinedb_api/db_mapping_base.py
@@ -801,7 +801,7 @@ class MappedItemBase(dict):
         """Sets id as valid"""
         self._has_valid_id = True
 
-    def _extended(self):
+    def extended(self):
         """Returns a dict from this item's original fields plus all the references resolved statically.
 
         Returns:
@@ -836,7 +836,7 @@ class MappedItemBase(dict):
         other = self._strip_equal_fields(other)
         if not other:
             return None, ""
-        merged = {**self._extended(), **other}
+        merged = {**self.extended(), **other}
         if not isinstance(merged["id"], int):
             merged["id"] = dict.__getitem__(self, "id")
         return merged, ""
@@ -1177,7 +1177,7 @@ class MappedItemBase(dict):
 
     def __repr__(self):
         """Overridden to return a more verbose representation."""
-        return f"{self.item_type}{self._extended()}"
+        return f"{self.item_type}{self.extended()}"
 
     def __getattr__(self, name):
         """Overridden to return the dictionary key named after the attribute, or None if it doesn't exist."""
@@ -1294,7 +1294,7 @@ class PublicItem:
         return self._mapped_item[key]
 
     def __contains__(self, item):
-        return self._mapped_item._extended().__contains__(item)
+        return self._mapped_item.extended().__contains__(item)
 
     def __eq__(self, other):
         if isinstance(other, dict):
@@ -1322,8 +1322,8 @@ class PublicItem:
     def _asdict(self):
         return self._mapped_item._asdict()
 
-    def _extended(self):
-        return self._mapped_item._extended()
+    def extended(self):
+        return self._mapped_item.extended()
 
     def update(self, **kwargs):
         return self._mapped_item.db_map.update_item(self.item_type, id=self["id"], **kwargs)

--- a/spinedb_api/db_mapping_base.py
+++ b/spinedb_api/db_mapping_base.py
@@ -1243,8 +1243,11 @@ class MappedItemBase(dict):
         id_ = dict.__getitem__(self, "id")
         super().update(other)
         self["id"] = id_
-        if self._asdict() == self._backup:
-            self._status = Status.committed
+        if self._backup is not None:
+            backup = self._backup
+            as_dict = self._asdict()
+            if as_dict is not None and all(as_dict[key] == backup[key] for key in backup):
+                self._status = Status.committed
 
     def force_id(self, id_):
         """Makes sure this item's has the given id_, corresponding to the new id of the item

--- a/spinedb_api/mapped_items.py
+++ b/spinedb_api/mapped_items.py
@@ -96,7 +96,10 @@ class EntityClassItem(MappedItemBase):
     required_key_combinations = (("name",),)
     _references = {"dimension_id_list": "entity_class"}
     _weak_references = {"superclass_name": "superclass_subclass"}
-    _external_fields = {"dimension_name_list": ("dimension_id_list", "name")}
+    _external_fields = {
+        "dimension_name_list": ("dimension_id_list", "name"),
+        "entity_class_byname": ("dimension_id_list", "entity_class_byname"),
+    }
     _alt_references = {("dimension_name_list",): ("entity_class", ("name",))}
     _internal_fields = {"dimension_id_list": (("dimension_name_list",), "id")}
     _private_fields = {"dimension_count"}
@@ -153,7 +156,6 @@ class EntityItem(MappedItemBase):
     _references = {"class_id": "entity_class", "element_id_list": "entity"}
     _external_fields = {
         "entity_class_name": ("class_id", "name"),
-        "entity_class_byname": ("class_id", "entity_class_byname"),
         "dimension_id_list": ("class_id", "dimension_id_list"),
         "dimension_name_list": ("class_id", "dimension_name_list"),
         "superclass_id": ("class_id", "superclass_id"),

--- a/spinedb_api/server_client_helpers.py
+++ b/spinedb_api/server_client_helpers.py
@@ -68,7 +68,7 @@ class _TailJSONEncoder(json.JSONEncoder):
         if isinstance(o, SpineDBAPIError):
             return str(o)
         if isinstance(o, PublicItem):
-            return o._extended()
+            return o.extended()
         if isinstance(o, TempId):
             return o.private_id
         return super().default(o)


### PR DESCRIPTION
- Make entity_class_byname an entity class item-only field and make it show up in `_extended()`.
- Fix rolling back entity and entity class items.
- Rename `_extended()` to `extended()`. It is not a private method.

No associated issue.

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
