### PR TITLE
Experimental and incomplete Pandas dataframe and Apache Arrow support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- Support for Python 3.13.
-- It is now possible to use the ``parsed_value`` field when adding or updating
-  parameter definition, paramater value and list value items.
-  ``parsed_value`` replaces the ``value`` and ``type`` (``default_value`` and ``default_type`` for parameter definitions)
-  fields and accepts the value directly so manual conversion using ``to_database()`` is not needed anymore.
-- Added a read-only field ``entity_class_byname`` to EntityClassItem (accessible from EntityItem as well)
-  which works analogously to ``entity_byname``.
-
 ### Changed
 
 - **Breaking change:** The required SQLAlchemy version is now 1.4.
@@ -28,6 +18,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     the session is opened automatically as needed.
   - The low-level query interface requires the session to be opened manually,
     i.e. all queries must be done inside a `with` block.
+  - All locking primitives have been removed from `DatabaseMapping`.
+    Clients are now responsible for preventing race conditions, deadlocks
+    and other multithreading/multiprocessing issues.
+
+### Added
+
+- Support for Python 3.13.
+- Experimental and incomplete [Pandas](pandas.pydata.org) dataframe support added
+  in the form of a new module `dataframes`. See the module documentation for tutorial.
+- Experimental and incomplete [Arrow](arrow.apache.org) support added in the form of `arrow_value` module.
+- It is now possible to use the `parsed_value` field when adding or updating
+  parameter definition, paramater value and list value items.
+  `parsed_value` replaces the `value` and `type` (`default_value` and `default_type` for parameter definitions)
+  fields and accepts the value directly so manual conversion using `to_database()` is not needed anymore.
+- Added a read-only field `entity_class_byname` to EntityClassItem (accessible from EntityItem as well)
+  which works analogously to `entity_byname`.
 
 ### Deprecated
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,8 @@ dependencies = [
     "chardet >=4.0.0",
     "PyMySQL >=1.0.2",
     "psycopg2-binary",
+    "pyarrow >= 19.0",
+    "pandas >= 2.2.3",
 ]
 
 [project.urls]

--- a/spinedb_api/arrow_value.py
+++ b/spinedb_api/arrow_value.py
@@ -13,7 +13,7 @@
 Apache Arrow - Spine interoperability layer.
 
 
-.. note::
+.. warning::
 
   This is highly experimental API.
 

--- a/spinedb_api/arrow_value.py
+++ b/spinedb_api/arrow_value.py
@@ -1,0 +1,298 @@
+######################################################################################################################
+# Copyright (C) 2017-2022 Spine project consortium
+# Copyright Spine Database API contributors
+# This file is part of Spine Database API.
+# Spine Database API is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+# General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+# Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+######################################################################################################################
+"""
+Apache Arrow - Spine interoperability layer.
+
+
+.. note::
+
+  This is highly experimental API.
+
+"""
+from collections import defaultdict
+import datetime
+from typing import SupportsFloat
+import numpy
+import pyarrow
+from .parameter_value import (
+    NUMPY_DATETIME_DTYPE,
+    TIME_SERIES_DEFAULT_RESOLUTION,
+    TIME_SERIES_DEFAULT_START,
+    ParameterValueFormatError,
+    duration_to_relativedelta,
+    load_db_value,
+)
+
+_DATA_TYPE_TO_ARROW_TYPE = {
+    "date_time": pyarrow.timestamp("s"),
+    "duration": pyarrow.duration("us"),
+    "float": pyarrow.float64(),
+    "str": pyarrow.string(),
+    "null": pyarrow.null(),
+}
+
+_ARROW_TYPE_TO_DATA_TYPE = dict(zip(_DATA_TYPE_TO_ARROW_TYPE.values(), _DATA_TYPE_TO_ARROW_TYPE.keys()))
+
+_DATA_CONVERTER = {
+    "date_time": lambda data: numpy.array(data, dtype="datetime64[s]"),
+}
+
+
+def from_database(db_value, value_type):
+    """Parses a database value.
+
+    Args:
+        db_value (bytes): binary blob from database
+        value_type (string, optional): value type
+
+    Returns:
+        Any: parsed value
+    """
+    if db_value is None:
+        return None
+    loaded = load_db_value(db_value, value_type)
+    if isinstance(loaded, dict):
+        return from_dict(loaded, value_type)
+    if isinstance(loaded, SupportsFloat) and not isinstance(loaded, bool):
+        return float(loaded)
+    return loaded
+
+
+def from_dict(loaded_value, value_type):
+    """Converts a value dict to parsed value.
+
+    Args:
+        loaded_value (dict): value dict
+        value_type (str): value type
+
+    Returns:
+        pyarrow.RecordBatch: parsed value
+    """
+    if value_type == "array":
+        data_type = loaded_value.get("value_type", "float")
+        data = loaded_value["data"]
+        if data_type in _DATA_CONVERTER:
+            data = _DATA_CONVERTER[data_type](data)
+        arrow_type = _DATA_TYPE_TO_ARROW_TYPE[data_type]
+        y_array = pyarrow.array(data, type=arrow_type)
+        x_array = pyarrow.array(range(0, len(y_array)), type=pyarrow.int64())
+        return pyarrow.RecordBatch.from_arrays([x_array, y_array], names=[loaded_value.get("index_name", "i"), "value"])
+    if value_type == "map":
+        return map_to_struct_array(loaded_value)
+    raise NotImplementedError(f"unknown value type {value_type}")
+
+
+def to_database(parsed_value):
+    """Converts parsed value into database value.
+
+    Args:
+        parsed_value (Any): parsed value
+
+    Returns:
+        tuple: database value and its type
+    """
+    raise NotImplementedError()
+
+
+def type_of_loaded(loaded_value):
+    """Infer the type of loaded value.
+
+    Args:
+        loaded_value (Any): loaded value
+
+    Returns:
+        str: value type
+    """
+    if isinstance(loaded_value, dict):
+        return loaded_value["type"]
+    elif isinstance(loaded_value, str):
+        return "str"
+    elif isinstance(loaded_value, bool):
+        return "bool"
+    elif isinstance(loaded_value, SupportsFloat):
+        return "float"
+    elif isinstance(loaded_value, datetime.datetime):
+        return "date_time"
+    elif loaded_value is None:
+        return "null"
+    raise RuntimeError(f"unknown type")
+
+
+def map_to_struct_array(loaded_value):
+    typed_xs, ys, index_names, depth = crawl_map_uneven(loaded_value)
+    if not ys:
+        return pyarrow.RecordBatch.from_arrays(
+            [
+                pyarrow.array([], _DATA_TYPE_TO_ARROW_TYPE[loaded_value["index_type"]]),
+                pyarrow.array([], pyarrow.null()),
+            ],
+            names=index_names + ["value"],
+        )
+    x_arrays = []
+    for i in range(depth):
+        x_arrays.append(build_x_array(typed_xs, i))
+    return pyarrow.RecordBatch.from_arrays(x_arrays + [build_y_array(ys)], names=index_names + ["value"])
+
+
+def crawl_map_uneven(loaded_value, root_index=None, root_index_names=None):
+    if root_index is None:
+        root_index = []
+        root_index_names = []
+    depth = len(root_index) + 1
+    typed_xs = []
+    ys = []
+    max_nested_depth = 0
+    index_names = root_index_names + [loaded_value.get("index_name", "x")]
+    deepest_nested_index_names = []
+    index_type = loaded_value["index_type"]
+    data = loaded_value["data"]
+    if isinstance(data, dict):
+        data = data.items()
+    for x, y in data:
+        index = root_index + [(index_type, x)]
+        if isinstance(y, dict):
+            y_is_scalar = False
+            y_type = y["type"]
+            if y_type == "date_time":
+                y = datetime.datetime.fromisoformat(y["data"])
+                y_is_scalar = True
+            if not y_is_scalar:
+                if y_type == "map":
+                    nested_xs, nested_ys, nested_index_names, nested_depth = crawl_map_uneven(y, index, index_names)
+                elif y_type == "time_series":
+                    nested_xs, nested_ys, nested_index_names, nested_depth = crawl_time_series(y, index, index_names)
+                else:
+                    raise RuntimeError(f"unknown nested type {y_type}")
+                typed_xs += nested_xs
+                ys += nested_ys
+                deepest_nested_index_names = collect_nested_index_names(nested_index_names, deepest_nested_index_names)
+                max_nested_depth = max(max_nested_depth, nested_depth)
+                continue
+        typed_xs.append(index)
+        ys.append(y)
+    index_names = index_names if not deepest_nested_index_names else deepest_nested_index_names
+    return typed_xs, ys, index_names, depth if max_nested_depth == 0 else max_nested_depth
+
+
+def crawl_time_series(loaded_value, root_index=None, root_index_names=None):
+    if root_index is None:
+        root_index = []
+        root_index_names = []
+    typed_xs = []
+    ys = []
+    data = loaded_value["data"]
+    if isinstance(data, list) and data and not isinstance(data[0], list):
+        loaded_index = loaded_value["index"]
+        start = numpy.datetime64(loaded_index.get("start", TIME_SERIES_DEFAULT_START))
+        resolution = loaded_index.get("resolution", TIME_SERIES_DEFAULT_RESOLUTION)
+        data = zip(time_stamps(start, resolution, len(data)), data)
+        for x, y in data:
+            index = root_index + [("date_time", x)]
+            typed_xs.append(index)
+            ys.append(y)
+    else:
+        if isinstance(data, dict):
+            data = data.items()
+        for x, y in data:
+            index = root_index + [("date_time", datetime.datetime.fromisoformat(x))]
+            typed_xs.append(index)
+            ys.append(y)
+    index_names = root_index_names + [loaded_value.get("index_name", "t")]
+    return typed_xs, ys, index_names, len(root_index) + 1
+
+
+def time_series_resolution(resolution):
+    """
+    Parses time series resolution string.
+
+    Args:
+        resolution (str or list of str): resolution or a list thereof
+
+    Returns:
+        list of relativedelta: resolution
+    """
+    if isinstance(resolution, str):
+        resolution = [duration_to_relativedelta(resolution)]
+    else:
+        resolution = list(map(duration_to_relativedelta, resolution))
+    if not resolution:
+        raise ParameterValueFormatError("Resolution cannot be empty or zero.")
+    return resolution
+
+
+def time_stamps(start, resolution, count):
+    resolution_as_deltas = time_series_resolution(resolution)
+    cycle_count = -(-count // len(resolution_as_deltas))
+    deltas = [start.tolist()] + (cycle_count * resolution_as_deltas)[: count - 1]
+    np_deltas = numpy.array(deltas)
+    return np_deltas.cumsum().astype(NUMPY_DATETIME_DTYPE)
+
+
+def collect_nested_index_names(index_names1, index_names2):
+    if len(index_names1) > len(index_names2):
+        longer = index_names1
+    else:
+        longer = index_names2
+    for name1, name2 in zip(index_names1, index_names2):
+        if name1 != name2:
+            raise RuntimeError(f"index name mismatch")
+    return longer
+
+
+def build_x_array(uneven_data, i):
+    by_type = defaultdict(list)
+    types_and_offsets = []
+    for row in uneven_data:
+        try:
+            data_type, x = row[i]
+        except IndexError:
+            x = None
+            data_type = "null"
+        x_list = by_type[data_type]
+        x_list.append(x)
+        types_and_offsets.append((data_type, len(x_list) - 1))
+    return union_array(by_type, types_and_offsets)
+
+
+def build_y_array(y_list):
+    by_type = defaultdict(list)
+    types_and_offsets = []
+    for y in y_list:
+        data_type = type_of_loaded(y)
+        y_list = by_type[data_type]
+        y_list.append(y)
+        types_and_offsets.append((data_type, len(y_list) - 1))
+    return union_array(by_type, types_and_offsets)
+
+
+def union_array(by_type, types_and_offsets):
+    if len(by_type) == 1:
+        data_type, data = next(iter(by_type.items()))
+        if data_type in _DATA_CONVERTER:
+            data = _DATA_CONVERTER[data_type](data)
+        return pyarrow.array(data, type=_DATA_TYPE_TO_ARROW_TYPE[data_type])
+    arrays = []
+    for type_, ys in by_type.items():
+        if type_ in _DATA_CONVERTER:
+            ys = _DATA_CONVERTER[type_](ys)
+        arrow_type = _DATA_TYPE_TO_ARROW_TYPE[type_]
+        array = pyarrow.array(ys, type=arrow_type)
+        arrays.append(array)
+    type_index = {y_type: i for i, y_type in enumerate(by_type)}
+    type_ids = []
+    value_offsets = []
+    for type_, offset in types_and_offsets:
+        type_ids.append(type_index[type_])
+        value_offsets.append(offset)
+    types = pyarrow.array(type_ids, type=pyarrow.int8())
+    offsets = pyarrow.array(value_offsets, type=pyarrow.int32())
+    return pyarrow.UnionArray.from_dense(types, offsets, arrays, field_names=list(by_type))

--- a/spinedb_api/dataframes.py
+++ b/spinedb_api/dataframes.py
@@ -1,0 +1,262 @@
+######################################################################################################################
+# Copyright (C) 2017-2022 Spine project consortium
+# Copyright Spine Database API contributors
+# This file is part of Spine Database API.
+# Spine Database API is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+# General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+# Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+######################################################################################################################
+"""This module offers a Pandas interoperability layer to `spinedb_api`.
+
+.. note::
+
+  This is highly experimental API.
+
+The functions here work at the database query level with as little overhead as possible.
+"""
+import collections
+import pandas as pd
+import pyarrow
+from spinedb_api import Map
+from spinedb_api.arrow_value import from_database
+from spinedb_api.parameter_value import RANK_1_TYPES, VALUE_TYPES
+
+
+class FetchedMaps:
+    def __init__(
+        self, list_value_map, entity_class_name_map, entity_name_and_class_map, entity_element_map, entity_dimension_map
+    ):
+        self.list_value_map = list_value_map
+        self.entity_class_name_map = entity_class_name_map
+        self.entity_name_and_class_map = entity_name_and_class_map
+        self.entity_element_map = entity_element_map
+        self.entity_dimension_map = entity_dimension_map
+
+    @classmethod
+    def fetch(cls, db_map):
+        return cls(
+            fetch_list_value_map(db_map),
+            fetch_entity_class_name_map(db_map),
+            fetch_entity_name_and_class_map(db_map),
+            fetch_entity_element_map(db_map),
+            fetch_entity_dimension_map(db_map),
+        )
+
+
+def parameter_value_sq(db_map):
+    return (
+        db_map.query(
+            db_map.entity_class_sq.c.id.label("entity_class_id"),
+            db_map.parameter_definition_sq.c.name.label("parameter_definition_name"),
+            db_map.entity_sq.c.id.label("entity_id"),
+            db_map.alternative_sq.c.name.label("alternative_name"),
+            db_map.parameter_value_sq.c.value,
+            db_map.parameter_value_sq.c.type,
+            db_map.parameter_value_sq.c.list_value_id,
+        )
+        .join(
+            db_map.parameter_definition_sq,
+            db_map.parameter_definition_sq.c.id == db_map.parameter_value_sq.c.parameter_definition_id,
+        )
+        .join(db_map.entity_sq, db_map.parameter_value_sq.c.entity_id == db_map.entity_sq.c.id)
+        .join(
+            db_map.entity_class_sq,
+            db_map.parameter_definition_sq.c.entity_class_id == db_map.entity_class_sq.c.id,
+        )
+        .join(db_map.alternative_sq, db_map.parameter_value_sq.c.alternative_id == db_map.alternative_sq.c.id)
+        .subquery()
+    )
+
+
+def fetch_list_value_map(db_map):
+    return {
+        row.id: (row.value, row.type)
+        for row in db_map.query(db_map.list_value_sq.c.id, db_map.list_value_sq.c.value, db_map.list_value_sq.c.type)
+    }
+
+
+def fetch_entity_name_and_class_map(db_map):
+    return {
+        row.id: (row.name, row.class_id)
+        for row in db_map.query(
+            db_map.entity_sq.c.id,
+            db_map.entity_sq.c.name,
+            db_map.entity_sq.c.class_id,
+        )
+    }
+
+
+def _expand_ids_iterative(entity_id, element_map):
+    expanded = []
+    for element_id in element_map[entity_id]:
+        if element_id not in element_map:
+            expanded.append(element_id)
+            continue
+        expanded.extend(_expand_ids_iterative(element_id, element_map))
+    return expanded
+
+
+def fetch_entity_element_map(db_map):
+    element_table = pd.DataFrame(
+        db_map.query(
+            db_map.entity_element_sq.c.entity_id,
+            db_map.entity_element_sq.c.element_id,
+            db_map.entity_element_sq.c.position,
+        ).order_by(db_map.entity_element_sq.c.entity_id, db_map.entity_element_sq.c.position)
+    )
+    if element_table.empty:
+        return {}
+    element_map = {}
+    for entity_id, element_group in element_table.groupby(["entity_id"], sort=False):
+        element_map[entity_id[0]] = element_group["element_id"]
+    return {entity_id: _expand_ids_iterative(entity_id, element_map) for entity_id in element_map}
+
+
+def fetch_entity_dimension_map(db_map):
+    return {
+        row.id: row.class_id
+        for row in db_map.query(
+            db_map.entity_sq.c.id,
+            db_map.entity_sq.c.class_id,
+        )
+    }
+
+
+def fetch_entity_class_name_map(db_map):
+    return {row.id: row.name for row in db_map.query(db_map.entity_class_sq.c.id, db_map.entity_class_sq.c.name)}
+
+
+def resolve_elements(dataframe, entity_class_name_map, entity_name_and_class_map, entity_element_map):
+    groups = dataframe.groupby("entity_class_id", sort=False)
+    resolved_groups = []
+    for _, group in groups:
+        resolved_columns = resolve_elements_for_single_class(
+            group["entity_id"], entity_class_name_map, entity_name_and_class_map, entity_element_map
+        )
+        group_frame = group.drop(columns=["entity_class_id", "entity_id"])
+        column_names = unique_series_names(resolved_columns)
+        for name, column in zip(reversed(column_names), reversed(resolved_columns)):
+            group_frame.insert(0, name, column)
+        resolved_groups.append(group_frame)
+    return pd.concat(resolved_groups)
+
+
+def resolve_elements_for_single_class(
+    entity_id_series, entity_class_name_map, entity_name_and_class_map, entity_element_map
+):
+    element_series = {}
+    for entity_id in entity_id_series:
+        try:
+            elements = entity_element_map[entity_id]
+        except KeyError:
+            elements = [entity_id]
+        for position, element_id in enumerate(elements):
+            entity_name, class_id = entity_name_and_class_map[element_id]
+            class_name = entity_class_name_map[class_id]
+            series = element_series.setdefault((class_name, position), [])
+            series.append(entity_name)
+    return [pd.Series(entities, name=class_name) for (class_name, _), entities in element_series.items()]
+
+
+def unique_series_names(series_list):
+    name_counts = collections.Counter()
+    for series in series_list:
+        name_counts[series.name] += 1
+    names = []
+    rename_counts = collections.Counter()
+    for series in series_list:
+        count = name_counts[series.name]
+        if count == 1:
+            names.append(series.name)
+        else:
+            rename_counts[series.name] += 1
+            names.append(series.name + f"_{rename_counts[series.name]}")
+    return names
+
+
+def convert_values_from_database(dataframe_row, list_value_map):
+    if dataframe_row.iloc[-1] is not None:
+        value, value_type = list_value_map[dataframe_row[-1]]
+    else:
+        value = dataframe_row.iloc[-3]
+        value_type = dataframe_row.iloc[-2]
+    value = from_database(value, value_type)
+    if isinstance(value, pyarrow.RecordBatch):
+        value = value.to_pandas()
+    return pd.Series({"value": value, "type": value_type})
+
+
+def expand_values(dataframe):
+    """Expands parsed values in a dataframe.
+
+    Consumes the 'type' column.
+
+    Args:
+        dataframe (pd.DataFrame): dataframe to expand
+
+    Returns:
+        pd.DataFrame: expanded dataframe
+    """
+    grouped = dataframe.groupby("type", sort=False)
+    expanded = []
+    rank_n_types = {Map.type_()}
+    for expandable_type in RANK_1_TYPES | rank_n_types:
+        try:
+            group = grouped.indices[expandable_type]
+        except KeyError:
+            continue
+        for row in dataframe.iloc[group].itertuples(index=False):
+            left = row._asdict()
+            del left["type"]
+            value = left.pop("value")
+            left = pd.DataFrame(value.shape[0] * [left])
+            expanded.append(pd.concat((left, value), axis="columns"))
+    for non_expandable_type in VALUE_TYPES - RANK_1_TYPES - rank_n_types:
+        try:
+            group = grouped.indices[non_expandable_type]
+        except KeyError:
+            continue
+        non_expanded = dataframe.iloc[group]
+        expanded.append(non_expanded.drop(columns=["type"]))
+    expanded = pd.concat(expanded, ignore_index=True)
+    if expanded.columns.get_loc("value") == expanded.shape[1] - 1:
+        return expanded
+    y_column = expanded.pop("value")
+    return pd.concat((expanded, y_column), axis="columns")
+
+
+def expand_real_value(x):
+    if isinstance(x, pyarrow.RecordBatch):
+        return x.to_pandas()
+    return x
+
+
+def fetch_as_dataframe(db_map, value_sq, fetched_maps):
+    """Fetches parameter values from database returning them as dataframe.
+
+    Args:
+        db_map (DatabaseMapping): database map
+        value_sq (Subquery): parameter value subquery
+        fetched_maps (FetchedMaps): extra data needed to construct the dataframe
+
+    Returns:
+        pd.DataFrame: value and all its dimensions in a dataframe
+    """
+    dataframe = pd.DataFrame(db_map.query(value_sq))
+    if dataframe.empty:
+        return dataframe
+    value_series = dataframe.apply(
+        convert_values_from_database, axis="columns", result_type="expand", args=(fetched_maps.list_value_map,)
+    )
+    dataframe = dataframe.drop(columns=["value", "type", "list_value_id"])
+    dataframe = pd.concat((dataframe, value_series), axis="columns")
+    dataframe = resolve_elements(
+        dataframe,
+        fetched_maps.entity_class_name_map,
+        fetched_maps.entity_name_and_class_map,
+        fetched_maps.entity_element_map,
+    )
+    return expand_values(dataframe)

--- a/spinedb_api/db_mapping.py
+++ b/spinedb_api/db_mapping.py
@@ -204,6 +204,14 @@ class DatabaseMapping(DatabaseMappingQueryMixin, DatabaseMappingCommitMixin, Dat
             self._session = None
         return False
 
+    def session(self):
+        """Returns current session or None if session is closed.
+
+        Returns:
+            Session: current session
+        """
+        return self._session
+
     @staticmethod
     def item_types():
         return [x for x in DatabaseMapping._sq_name_by_item_type if not item_factory(x).is_protected]

--- a/spinedb_api/parameter_value.py
+++ b/spinedb_api/parameter_value.py
@@ -95,12 +95,12 @@ import numpy as np
 from .exception import ParameterValueFormatError
 
 # Defaulting to seconds precision in numpy.
-_NUMPY_DATETIME_DTYPE = "datetime64[s]"
+NUMPY_DATETIME_DTYPE = "datetime64[s]"
 NUMPY_DATETIME64_UNIT = "s"
 # Default start time guess, actual value not currently given in the JSON specification.
-_TIME_SERIES_DEFAULT_START = "0001-01-01T00:00:00"
+TIME_SERIES_DEFAULT_START = "0001-01-01T00:00:00"
 # Default resolution if it is omitted from the index entry.
-_TIME_SERIES_DEFAULT_RESOLUTION = "1h"
+TIME_SERIES_DEFAULT_RESOLUTION = "1h"
 # Default unit if resolution is given as a number instead of a string.
 _TIME_SERIES_PLAIN_INDEX_UNIT = "m"
 FLOAT_VALUE_TYPE = "float"
@@ -499,8 +499,8 @@ def _time_series_from_single_column(value_dict):
     """
     if "index" in value_dict:
         value_index = value_dict["index"]
-        start = value_index["start"] if "start" in value_index else _TIME_SERIES_DEFAULT_START
-        resolution = value_index["resolution"] if "resolution" in value_index else _TIME_SERIES_DEFAULT_RESOLUTION
+        start = value_index["start"] if "start" in value_index else TIME_SERIES_DEFAULT_START
+        resolution = value_index["resolution"] if "resolution" in value_index else TIME_SERIES_DEFAULT_RESOLUTION
         if "ignore_year" in value_index:
             try:
                 ignore_year = bool(value_index["ignore_year"])
@@ -520,8 +520,8 @@ def _time_series_from_single_column(value_dict):
         else:
             repeat = "start" not in value_index
     else:
-        start = _TIME_SERIES_DEFAULT_START
-        resolution = _TIME_SERIES_DEFAULT_RESOLUTION
+        start = TIME_SERIES_DEFAULT_START
+        resolution = TIME_SERIES_DEFAULT_RESOLUTION
         ignore_year = True
         repeat = True
     if isinstance(resolution, str) or not isinstance(resolution, Sequence):
@@ -1362,7 +1362,7 @@ class TimeSeriesFixedResolution(TimeSeries):
         resolution = (cycle_count * self.resolution)[: len(self) - 1]
         resolution.insert(0, self._start)
         resolution_arr = np.array(resolution)
-        memoized_indexes = self._memoized_indexes[key] = resolution_arr.cumsum().astype(_NUMPY_DATETIME_DTYPE)
+        memoized_indexes = self._memoized_indexes[key] = resolution_arr.cumsum().astype(NUMPY_DATETIME_DTYPE)
         return memoized_indexes
 
     @property
@@ -1474,7 +1474,7 @@ class TimeSeriesVariableResolution(TimeSeries):
         if len(indexes) != len(values):
             raise ParameterValueFormatError("Length of values does not match length of indexes")
         if not isinstance(indexes, np.ndarray):
-            date_times = np.empty(len(indexes), dtype=_NUMPY_DATETIME_DTYPE)
+            date_times = np.empty(len(indexes), dtype=NUMPY_DATETIME_DTYPE)
             for i, index in enumerate(indexes):
                 if isinstance(index, DateTime):
                     date_times[i] = np.datetime64(index.value, NUMPY_DATETIME64_UNIT)

--- a/tests/test_arrow_value.py
+++ b/tests/test_arrow_value.py
@@ -1,0 +1,214 @@
+######################################################################################################################
+# Copyright (C) 2017-2022 Spine project consortium
+# Copyright Spine Database API contributors
+# This file is part of Spine Database API.
+# Spine Database API is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+# General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+# Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+######################################################################################################################
+""" Unit tests for the `arrow_value` module. """
+import datetime
+import unittest
+import pyarrow
+from spinedb_api import arrow_value, parameter_value
+
+
+class DatabaseUsingTest(unittest.TestCase):
+    def _assert_success(self, result):
+        item, error = result
+        self.assertIsNone(error)
+        return item
+
+
+class TestFromDatabaseForArrays(unittest.TestCase):
+    def test_empty_array(self):
+        value, value_type = parameter_value.to_database(parameter_value.Array([]))
+        record_batch = arrow_value.from_database(value, value_type)
+        self.assertEqual(len(record_batch), 0)
+        self.assertEqual(record_batch.column_names, ["i", "value"])
+        self.assertEqual(record_batch.column("i").type, pyarrow.int64())
+        self.assertEqual(record_batch.column("value").type, pyarrow.float64())
+
+    def test_floats_with_index_name(self):
+        value, value_type = parameter_value.to_database(parameter_value.Array([2.3], index_name="my index"))
+        record_batch = arrow_value.from_database(value, value_type)
+        self.assertEqual(len(record_batch), 1)
+        self.assertEqual(record_batch.column_names, ["my index", "value"])
+        indices = record_batch.column("my index")
+        self.assertEqual(indices.type, pyarrow.int64())
+        self.assertEqual(indices, pyarrow.array([0]))
+        ys = record_batch.column("value")
+        self.assertEqual(ys.type, pyarrow.float64())
+        self.assertEqual(ys, pyarrow.array([2.3]))
+
+    def test_date_times_with_index_name(self):
+        value, value_type = parameter_value.to_database(
+            parameter_value.Array([parameter_value.DateTime("2024-09-02T05:51:00")], index_name="my index")
+        )
+        record_batch = arrow_value.from_database(value, value_type)
+        self.assertEqual(len(record_batch), 1)
+        self.assertEqual(record_batch.column_names, ["my index", "value"])
+        indices = record_batch.column("my index")
+        self.assertEqual(indices.type, pyarrow.int64())
+        self.assertEqual(indices, pyarrow.array([0]))
+        ys = record_batch.column("value")
+        self.assertEqual(ys.type, pyarrow.timestamp("s"))
+        self.assertEqual(ys.tolist(), [datetime.datetime(2024, 9, 2, 5, 51)])
+
+
+class TestFromDatabaseForMaps(unittest.TestCase):
+    def test_empty_map(self):
+        value, value_type = parameter_value.to_database(parameter_value.Map([], [], str))
+        map_ = arrow_value.from_database(value, value_type)
+        self.assertEqual(len(map_), 0)
+        self.assertEqual(map_.column_names, ["x", "value"])
+        self.assertEqual(map_.column("x").type, pyarrow.string())
+        self.assertEqual(map_.column("value").type, pyarrow.null())
+
+    def test_string_to_string_map_with_index_name(self):
+        value, value_type = parameter_value.to_database(parameter_value.Map(["key"], ["value"], index_name="Keys"))
+        map_ = arrow_value.from_database(value, value_type)
+        self.assertEqual(len(map_), 1)
+        self.assertEqual(map_.column_names, ["Keys", "value"])
+        self.assertEqual(map_.column("Keys").type, pyarrow.string())
+        self.assertEqual(map_.column("Keys")[0].as_py(), "key")
+        self.assertEqual(map_.column("value").type, pyarrow.string())
+        self.assertEqual(map_.column("value")[0].as_py(), "value")
+
+    def test_date_time_to_different_simple_types_map_with_index_name(self):
+        value, value_type = parameter_value.to_database(
+            parameter_value.Map(
+                [parameter_value.DateTime("2024-02-09T10:00"), parameter_value.DateTime("2024-02-09T11:00")],
+                ["value", 2.3],
+                index_name="timestamps",
+            )
+        )
+        map_ = arrow_value.from_database(value, value_type)
+        self.assertEqual(len(map_), 2)
+        self.assertEqual(map_.column_names, ["timestamps", "value"])
+        self.assertEqual(map_.column("timestamps").type, pyarrow.timestamp("s"))
+        self.assertEqual(
+            map_.column("timestamps").to_pylist(),
+            [datetime.datetime(2024, 2, 9, 10), datetime.datetime(2024, 2, 9, 11)],
+        )
+        self.assertEqual(
+            map_.column("value").type,
+            pyarrow.dense_union([pyarrow.field("str", pyarrow.string()), pyarrow.field("float", pyarrow.float64())]),
+        )
+        self.assertEqual(map_.column("value").to_pylist(), ["value", 2.3])
+
+    def test_nested_maps(self):
+        string_map = parameter_value.Map([11.0], ["value"], index_name="nested index")
+        float_map = parameter_value.Map(["key"], [22.0], index_name="nested index")
+        value, value_type = parameter_value.to_database(
+            parameter_value.Map(["strings", "floats"], [string_map, float_map], index_name="main index")
+        )
+        map_ = arrow_value.from_database(value, value_type)
+        self.assertEqual(len(map_), 2)
+        self.assertEqual(map_.column_names, ["main index", "nested index", "value"])
+        self.assertEqual(map_.column("main index").type, pyarrow.string())
+        self.assertEqual(map_.column("main index").to_pylist(), ["strings", "floats"])
+        self.assertEqual(
+            map_.column("nested index").type,
+            pyarrow.dense_union([pyarrow.field("float", pyarrow.float64()), pyarrow.field("str", pyarrow.string())]),
+        )
+        self.assertEqual(map_.column("nested index").to_pylist(), [11.0, "key"])
+        self.assertEqual(
+            map_.column("value").type,
+            pyarrow.dense_union([pyarrow.field("str", pyarrow.string()), pyarrow.field("float", pyarrow.float64())]),
+        )
+        self.assertEqual(map_.column("value").to_pylist(), ["value", 22.0])
+
+    def test_unevenly_nested_map_with_fixed_resolution_time_series(self):
+        string_map = parameter_value.Map([11.0], ["value"], index_name="nested index")
+        float_map = parameter_value.Map(["key"], [22.0], index_name="nested index")
+        time_series = parameter_value.TimeSeriesFixedResolution(
+            "2025-02-26T09:00:00", "1h", [2.3, 23.0], ignore_year=False, repeat=False
+        )
+        time_series_map = parameter_value.Map([parameter_value.DateTime("2024-02-26T16:45:00")], [time_series])
+        nested_time_series_map = parameter_value.Map(
+            ["ts", "no ts"], [time_series_map, "empty"], index_name="nested index"
+        )
+        value, value_type = parameter_value.to_database(
+            parameter_value.Map(
+                ["not nested", "strings", "time series", "floats"],
+                ["none", string_map, nested_time_series_map, float_map],
+                index_name="main index",
+            )
+        )
+        map_ = arrow_value.from_database(value, value_type)
+        self.assertEqual(len(map_), 6)
+        self.assertEqual(map_.column_names, ["main index", "nested index", "x", "t", "value"])
+        self.assertEqual(map_.column("main index").type, pyarrow.string())
+        self.assertEqual(
+            map_.column("main index").to_pylist(),
+            ["not nested", "strings", "time series", "time series", "time series", "floats"],
+        )
+        self.assertEqual(map_.column("nested index").to_pylist(), [None, 11.0, "ts", "ts", "no ts", "key"])
+        self.assertEqual(
+            map_.column("x").to_pylist(),
+            [
+                None,
+                None,
+                datetime.datetime.fromisoformat("2024-02-26T16:45:00"),
+                datetime.datetime.fromisoformat("2024-02-26T16:45:00"),
+                None,
+                None,
+            ],
+        )
+        self.assertEqual(
+            map_.column("t").to_pylist(),
+            [
+                None,
+                None,
+                datetime.datetime.fromisoformat("2025-02-26T09:00:00"),
+                datetime.datetime.fromisoformat("2025-02-26T10:00:00"),
+                None,
+                None,
+            ],
+        )
+        self.assertEqual(map_.column("value").to_pylist(), ["none", "value", 2.3, 23.0, "empty", 22.0])
+
+    def test_unevenly_nested_map(self):
+        string_map = parameter_value.Map([11.0], ["value"], index_name="nested index")
+        float_map = parameter_value.Map(["key"], [22.0], index_name="nested index")
+        datetime_map = parameter_value.Map(["time of my life"], [parameter_value.DateTime("2024-02-26T16:45:00")])
+        another_string_map = parameter_value.Map([parameter_value.DateTime("2024-02-26T17:45:00")], ["future"])
+        nested_map = parameter_value.Map(
+            ["date time", "more date time", "non nested"],
+            [datetime_map, another_string_map, "empty"],
+            index_name="nested index",
+        )
+        value, value_type = parameter_value.to_database(
+            parameter_value.Map(
+                ["not nested", "strings", "date times", "floats"],
+                ["none", string_map, nested_map, float_map],
+                index_name="main index",
+            )
+        )
+        map_ = arrow_value.from_database(value, value_type)
+        self.assertEqual(len(map_), 6)
+        self.assertEqual(map_.column_names, ["main index", "nested index", "x", "value"])
+        self.assertEqual(map_.column("main index").type, pyarrow.string())
+        self.assertEqual(
+            map_.column("main index").to_pylist(),
+            ["not nested", "strings", "date times", "date times", "date times", "floats"],
+        )
+        self.assertEqual(
+            map_.column("nested index").to_pylist(), [None, 11.0, "date time", "more date time", "non nested", "key"]
+        )
+        self.assertEqual(
+            map_.column("x").to_pylist(),
+            [None, None, "time of my life", datetime.datetime.fromisoformat("2024-02-26T17:45:00"), None, None],
+        )
+        self.assertEqual(
+            map_.column("value").to_pylist(),
+            ["none", "value", datetime.datetime.fromisoformat("2024-02-26T16:45:00"), "future", "empty", 22.0],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dataframes.py
+++ b/tests/test_dataframes.py
@@ -1,0 +1,230 @@
+######################################################################################################################
+# Copyright (C) 2017-2022 Spine project consortium
+# Copyright Spine Database API contributors
+# This file is part of Spine Database API.
+# Spine Database API is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+# General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+# Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+######################################################################################################################
+import unittest
+import numpy as np
+import pandas as pd
+from spinedb_api import DatabaseMapping, Map, to_database
+import spinedb_api.dataframes as spine_df
+from spinedb_api.parameter_value import FLOAT_VALUE_TYPE
+from tests.mock_helpers import AssertSuccessTestCase
+
+
+class TestFetchAsDataframe(AssertSuccessTestCase):
+    def test_fetch_from_empty_database(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            sq = spine_df.parameter_value_sq(db_map)
+            fetched_maps = spine_df.FetchedMaps.fetch(db_map)
+            dataframe = spine_df.fetch_as_dataframe(db_map, sq, fetched_maps)
+            self.assertTrue(dataframe.empty)
+
+    def test_fetch_scalar(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(db_map.add_entity_class_item(name="Object"))
+            self._assert_success(db_map.add_parameter_definition_item(name="y", entity_class_name="Object"))
+            self._assert_success(db_map.add_entity_item(name="octopus", entity_class_name="Object"))
+            value, value_type = to_database(2.3)
+            self._assert_success(
+                db_map.add_parameter_value_item(
+                    entity_class_name="Object",
+                    entity_byname=("octopus",),
+                    parameter_definition_name="y",
+                    alternative_name="Base",
+                    value=value,
+                    type=value_type,
+                )
+            )
+            db_map.commit_session("Add test data")
+            sq = spine_df.parameter_value_sq(db_map)
+            fetched_maps = spine_df.FetchedMaps.fetch(db_map)
+            dataframe = spine_df.fetch_as_dataframe(db_map, sq, fetched_maps)
+            expected = pd.DataFrame(
+                {"Object": ["octopus"], "parameter_definition_name": ["y"], "alternative_name": ["Base"], "value": 2.3}
+            )
+            self.assertTrue(dataframe.equals(expected))
+
+    def test_fetch_simple_map(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(db_map.add_entity_class_item(name="Object"))
+            self._assert_success(db_map.add_parameter_definition_item(name="y", entity_class_name="Object"))
+            self._assert_success(db_map.add_entity_item(name="octopus", entity_class_name="Object"))
+            value, value_type = to_database(Map(["A", "B"], [2.3, 2.4], index_name="Letter"))
+            self._assert_success(
+                db_map.add_parameter_value_item(
+                    entity_class_name="Object",
+                    entity_byname=("octopus",),
+                    parameter_definition_name="y",
+                    alternative_name="Base",
+                    value=value,
+                    type=value_type,
+                )
+            )
+            db_map.commit_session("Add test data")
+            sq = spine_df.parameter_value_sq(db_map)
+            fetched_maps = spine_df.FetchedMaps.fetch(db_map)
+            dataframe = spine_df.fetch_as_dataframe(db_map, sq, fetched_maps)
+            expected = pd.DataFrame(
+                {
+                    "Object": ["octopus", "octopus"],
+                    "parameter_definition_name": ["y", "y"],
+                    "alternative_name": ["Base", "Base"],
+                    "Letter": ["A", "B"],
+                    "value": [2.3, 2.4],
+                }
+            )
+            self.assertTrue(dataframe.equals(expected))
+
+
+class TestFetchEntityElementMap(AssertSuccessTestCase):
+    def test_two_dimensional_entity(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(db_map.add_entity_class_item(name="Subject"))
+            self._assert_success(db_map.add_entity_class_item(name="Verb"))
+            self._assert_success(db_map.add_entity_class_item(name="Phrase", dimension_name_list=("Verb", "Subject")))
+            subject = self._assert_success(db_map.add_entity_item(name="me", entity_class_name="Subject"))
+            verb = self._assert_success(db_map.add_entity_item(name="walk", entity_class_name="Verb"))
+            phrase = self._assert_success(
+                db_map.add_entity_item(entity_byname=("walk", "me"), entity_class_name="Phrase")
+            )
+            db_map.commit_session("Add test data.")
+            element_map = spine_df.fetch_entity_element_map(db_map)
+            self.assertEqual(len(element_map), 1)
+            self.assertEqual(element_map[phrase["id"].db_id], [verb["id"].db_id, subject["id"].db_id])
+
+
+class TestResolveElements(unittest.TestCase):
+    def test_single_value(self):
+        raw_data = pd.DataFrame(
+            {
+                "entity_class_id": [1],
+                "parameter_definition_name": ["Y"],
+                "entity_id": [2],
+                "alternative_name": ["Base"],
+                "value": 2.3,
+            }
+        )
+        entity_class_name_map = {1: "Object"}
+        entity_name_and_class_map = {2: ("fork", 1)}
+        entity_element_map = {}
+        resolved = spine_df.resolve_elements(
+            raw_data, entity_class_name_map, entity_name_and_class_map, entity_element_map
+        )
+        expected = pd.DataFrame(
+            {"Object": ["fork"], "parameter_definition_name": ["Y"], "alternative_name": ["Base"], "value": [2.3]}
+        )
+        self.assertTrue(resolved.equals(expected))
+
+    def test_multidimensional_entity(self):
+        raw_data = pd.DataFrame(
+            {
+                "entity_class_id": [1],
+                "parameter_definition_name": ["Y"],
+                "entity_id": [3],
+                "alternative_name": ["Base"],
+                "value": 2.3,
+            }
+        )
+        entity_class_name_map = {1: "Relationship", 2: "Right", 3: "Left"}
+        entity_name_and_class_map = {1: ("right", 2), 2: ("left", 3), 3: ("left__right", 1)}
+        entity_element_map = {3: [2, 1]}
+        resolved = spine_df.resolve_elements(
+            raw_data, entity_class_name_map, entity_name_and_class_map, entity_element_map
+        )
+        expected = pd.DataFrame(
+            {
+                "Left": ["left"],
+                "Right": ["right"],
+                "parameter_definition_name": ["Y"],
+                "alternative_name": ["Base"],
+                "value": [2.3],
+            }
+        )
+        self.assertTrue(resolved.equals(expected))
+
+    def test_relationship_with_same_class_in_both_dimensions(self):
+        raw_data = pd.DataFrame(
+            {
+                "entity_class_id": [2],
+                "parameter_definition_name": ["Y"],
+                "entity_id": [2],
+                "alternative_name": ["Base"],
+                "value": 2.3,
+            }
+        )
+        entity_class_name_map = {1: "Both", 2: "Relationship"}
+        entity_name_and_class_map = {1: ("both", 1), 2: ("both__both", 2)}
+        entity_element_map = {2: [1, 1]}
+        resolved = spine_df.resolve_elements(
+            raw_data, entity_class_name_map, entity_name_and_class_map, entity_element_map
+        )
+        expected = pd.DataFrame(
+            {
+                "Both_1": ["both"],
+                "Both_2": ["both"],
+                "parameter_definition_name": ["Y"],
+                "alternative_name": ["Base"],
+                "value": [2.3],
+            }
+        )
+        self.assertTrue(resolved.equals(expected))
+
+
+class TestExpandValues(unittest.TestCase):
+    def test_scalar_wont_get_expanded(self):
+        value = 2.3
+        dataframe = pd.DataFrame({"Object": ["spoon"], "value": [value], "type": [FLOAT_VALUE_TYPE]})
+        resolved = spine_df.expand_values(dataframe)
+        expected = pd.DataFrame({"Object": ["spoon"], "value": [2.3]})
+        self.assertTrue(resolved.equals(expected))
+
+    def test_expand_simple_map(self):
+        value = pd.DataFrame({"x": ["A"], "value": [2.3]})
+        dataframe = pd.DataFrame({"Object": ["spoon"], "value": [value], "type": [Map.type_()]})
+        resolved = spine_df.expand_values(dataframe)
+        expected = pd.DataFrame({"Object": ["spoon"], "x": ["A"], "value": [2.3]})
+        self.assertTrue(resolved.equals(expected))
+
+    def test_expand_multirow_map(self):
+        value = pd.DataFrame({"x": ["A", "B"], "value": [2.3, 2.4]})
+        dataframe = pd.DataFrame({"Object": ["spoon"], "value": [value], "type": [Map.type_()]})
+        resolved = spine_df.expand_values(dataframe)
+        expected = pd.DataFrame({"Object": ["spoon", "spoon"], "x": ["A", "B"], "value": [2.3, 2.4]})
+        self.assertTrue(resolved.equals(expected))
+
+    def test_expand_multiple_multirow_maps_with_same_indexes(self):
+        value1 = pd.DataFrame({"x": ["A", "B"], "value": [2.3, 2.4]})
+        value2 = pd.DataFrame({"x": ["C", "D"], "value": [2.5, 2.6]})
+        dataframe = pd.DataFrame(
+            {"Object": ["spoon", "fork"], "value": [value1, value2], "type": [Map.type_(), Map.type_()]}
+        )
+        resolved = spine_df.expand_values(dataframe)
+        expected = pd.DataFrame(
+            {"Object": ["spoon", "spoon", "fork", "fork"], "x": ["A", "B", "C", "D"], "value": [2.3, 2.4, 2.5, 2.6]}
+        )
+        self.assertTrue(resolved.equals(expected))
+
+    def test_expand_multiple_multirow_maps_with_overlapping_indexes(self):
+        value1 = pd.DataFrame({"i": ["A", "B"], "j": ["a", "b"], "value": [2.3, 2.4]})
+        value2 = pd.DataFrame({"j": ["C", "D"], "k": ["c", "d"], "value": [2.5, 2.6]})
+        dataframe = pd.DataFrame(
+            {"Object": ["spoon", "fork"], "value": [value1, value2], "type": [Map.type_(), Map.type_()]}
+        )
+        resolved = spine_df.expand_values(dataframe)
+        expected = pd.DataFrame(
+            {
+                "Object": ["spoon", "spoon", "fork", "fork"],
+                "i": ["A", "B", np.nan, np.nan],
+                "j": ["a", "b", "C", "D"],
+                "k": [np.nan, np.nan, "c", "d"],
+                "value": [2.3, 2.4, 2.5, 2.6],
+            }
+        )
+        self.assertTrue(resolved.equals(expected))

--- a/tests/test_dataframes.py
+++ b/tests/test_dataframes.py
@@ -41,10 +41,10 @@ class TestToDataframe(AssertSuccessTestCase):
             dataframe = spine_df.to_dataframe(value_item)
             expected = pd.DataFrame(
                 {
-                    "entity_class_name": ["Object"],
-                    "Object": ["fork"],
-                    "parameter_definition_name": ["y"],
-                    "alternative_name": ["Base"],
+                    "entity_class_name": pd.Series(["Object"], dtype="category"),
+                    "Object": pd.Series(["fork"], dtype="string"),
+                    "parameter_definition_name": pd.Series(["y"], dtype="category"),
+                    "alternative_name": pd.Series(["Base"], dtype="category"),
                     "value": [2.3],
                 }
             )
@@ -67,10 +67,10 @@ class TestToDataframe(AssertSuccessTestCase):
             dataframe = spine_df.to_dataframe(value_item)
             expected = pd.DataFrame(
                 {
-                    "entity_class_name": 2 * ["Object"],
-                    "Object": ["fork", "fork"],
-                    "parameter_definition_name": ["y", "y"],
-                    "alternative_name": ["Base", "Base"],
+                    "entity_class_name": pd.Series(2 * ["Object"], dtype="category"),
+                    "Object": pd.Series(["fork", "fork"], dtype="string"),
+                    "parameter_definition_name": pd.Series(["y", "y"], dtype="category"),
+                    "alternative_name": pd.Series(["Base", "Base"], dtype="category"),
                     "letter": ["A", "B"],
                     "value": [1.1, 1.2],
                 }
@@ -197,10 +197,10 @@ class TestFetchAsDataframe(AssertSuccessTestCase):
             dataframe = spine_df.fetch_as_dataframe(db_map, sq, fetched_maps)
             expected = pd.DataFrame(
                 {
-                    "entity_class_name": ["Object"],
-                    "Object": ["octopus"],
-                    "parameter_definition_name": ["y"],
-                    "alternative_name": ["Base"],
+                    "entity_class_name": pd.Series(["Object"], dtype="category"),
+                    "Object": pd.Series(["octopus"], dtype="string"),
+                    "parameter_definition_name": pd.Series(["y"], dtype="category"),
+                    "alternative_name": pd.Series(["Base"], dtype="category"),
                     "value": 2.3,
                 }
             )
@@ -228,10 +228,10 @@ class TestFetchAsDataframe(AssertSuccessTestCase):
             dataframe = spine_df.fetch_as_dataframe(db_map, sq, fetched_maps)
             expected = pd.DataFrame(
                 {
-                    "entity_class_name": 2 * ["Object"],
-                    "Object": ["octopus", "octopus"],
-                    "parameter_definition_name": ["y", "y"],
-                    "alternative_name": ["Base", "Base"],
+                    "entity_class_name": pd.Series(2 * ["Object"], dtype="category"),
+                    "Object": pd.Series(["octopus", "octopus"], dtype="string"),
+                    "parameter_definition_name": pd.Series(["y", "y"], dtype="category"),
+                    "alternative_name": pd.Series(["Base", "Base"], dtype="category"),
                     "Letter": ["A", "B"],
                     "value": [2.3, 2.4],
                 }
@@ -312,11 +312,11 @@ class TestResolveElements(unittest.TestCase):
         raw_data = pd.DataFrame(
             {
                 "entity_class_id": [1],
-                "entity_class_name": ["Object"],
+                "entity_class_name": pd.Series(["Object"], dtype="category"),
                 "entity_id": [2],
-                "parameter_definition_name": ["Y"],
-                "alternative_name": ["Base"],
-                "value": 2.3,
+                "parameter_definition_name": pd.Series(["Y"], dtype="category"),
+                "alternative_name": pd.Series(["Base"], dtype="category"),
+                "value": [2.3],
             }
         )
         entity_class_name_map = {1: "Object"}
@@ -327,10 +327,10 @@ class TestResolveElements(unittest.TestCase):
         )
         expected = pd.DataFrame(
             {
-                "entity_class_name": ["Object"],
-                "Object": ["fork"],
-                "parameter_definition_name": ["Y"],
-                "alternative_name": ["Base"],
+                "entity_class_name": pd.Series(["Object"], dtype="category"),
+                "Object": pd.Series(["fork"], dtype="string"),
+                "parameter_definition_name": pd.Series(["Y"], dtype="category"),
+                "alternative_name": pd.Series(["Base"], dtype="category"),
                 "value": [2.3],
             }
         )
@@ -340,10 +340,10 @@ class TestResolveElements(unittest.TestCase):
         raw_data = pd.DataFrame(
             {
                 "entity_class_id": [1],
-                "entity_class_name": ["Relationship"],
+                "entity_class_name": pd.Series(["Relationship"], dtype="category"),
                 "entity_id": [3],
-                "parameter_definition_name": ["Y"],
-                "alternative_name": ["Base"],
+                "parameter_definition_name": pd.Series(["Y"], dtype="category"),
+                "alternative_name": pd.Series(["Base"], dtype="category"),
                 "value": 2.3,
             }
         )
@@ -355,11 +355,11 @@ class TestResolveElements(unittest.TestCase):
         )
         expected = pd.DataFrame(
             {
-                "entity_class_name": ["Relationship"],
-                "Left": ["left"],
-                "Right": ["right"],
-                "parameter_definition_name": ["Y"],
-                "alternative_name": ["Base"],
+                "entity_class_name": pd.Series(["Relationship"], dtype="category"),
+                "Left": pd.Series(["left"], dtype="string"),
+                "Right": pd.Series(["right"], dtype="string"),
+                "parameter_definition_name": pd.Series(["Y"], dtype="category"),
+                "alternative_name": pd.Series(["Base"], dtype="category"),
                 "value": [2.3],
             }
         )
@@ -369,10 +369,10 @@ class TestResolveElements(unittest.TestCase):
         raw_data = pd.DataFrame(
             {
                 "entity_class_id": [2],
-                "entity_class_name": ["Relationship"],
+                "entity_class_name": pd.Series(["Relationship"], dtype="category"),
                 "entity_id": [2],
-                "parameter_definition_name": ["Y"],
-                "alternative_name": ["Base"],
+                "parameter_definition_name": pd.Series(["Y"], dtype="category"),
+                "alternative_name": pd.Series(["Base"], dtype="category"),
                 "value": 2.3,
             }
         )
@@ -384,11 +384,11 @@ class TestResolveElements(unittest.TestCase):
         )
         expected = pd.DataFrame(
             {
-                "entity_class_name": ["Relationship"],
-                "Both_1": ["both"],
-                "Both_2": ["both"],
-                "parameter_definition_name": ["Y"],
-                "alternative_name": ["Base"],
+                "entity_class_name": pd.Series(["Relationship"], dtype="category"),
+                "Both_1": pd.Series(["both"], dtype="string"),
+                "Both_2": pd.Series(["both"], dtype="string"),
+                "parameter_definition_name": pd.Series(["Y"], dtype="category"),
+                "alternative_name": pd.Series(["Base"], dtype="category"),
                 "value": [2.3],
             }
         )

--- a/tests/test_dataframes.py
+++ b/tests/test_dataframes.py
@@ -14,7 +14,7 @@ import numpy as np
 import pandas as pd
 from spinedb_api import DatabaseMapping, Map, to_database
 import spinedb_api.dataframes as spine_df
-from spinedb_api.parameter_value import FLOAT_VALUE_TYPE
+from spinedb_api.parameter_value import FLOAT_VALUE_TYPE, TimeSeriesVariableResolution
 from tests.mock_helpers import AssertSuccessTestCase
 
 # Copy-on-write will become default in Pandas 3.0.
@@ -76,6 +76,36 @@ class TestToDataframe(AssertSuccessTestCase):
                 }
             )
             self.assertTrue(dataframe.equals(expected))
+
+    def test_time_series_value(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(db_map.add_entity_class_item(name="Object"))
+            self._assert_success(db_map.add_parameter_definition_item(name="y", entity_class_name="Object"))
+            self._assert_success(db_map.add_entity_item(name="fork", entity_class_name="Object"))
+            value_item = self._assert_success(
+                db_map.add_parameter_value_item(
+                    entity_class_name="Object",
+                    entity_byname=("fork",),
+                    parameter_definition_name="y",
+                    alternative_name="Base",
+                    parsed_value=TimeSeriesVariableResolution(
+                        ["2025-02-05T12:30", "2025-02-05T12:45"], [1.1, 1.2], repeat=False, ignore_year=False
+                    ),
+                )
+            )
+            dataframe = spine_df.to_dataframe(value_item)
+            expected = pd.DataFrame(
+                {
+                    "entity_class_name": pd.Series(2 * ["Object"], dtype="category"),
+                    "Object": pd.Series(["fork", "fork"], dtype="string"),
+                    "parameter_definition_name": pd.Series(["y", "y"], dtype="category"),
+                    "alternative_name": pd.Series(["Base", "Base"], dtype="category"),
+                    "t": np.array(["2025-02-05T12:30", "2025-02-05T12:45"], dtype="datetime64[s]"),
+                    "value": [1.1, 1.2],
+                }
+            )
+            self.assertTrue(dataframe.equals(expected))
+            self.assertEqual(dataframe.attrs, {"t": {"ignore_year": "false", "repeat": "false"}})
 
 
 class TestAddOrUpdateFrom(AssertSuccessTestCase):


### PR DESCRIPTION
This PR introduces two new modules, `arrow_value` and `dataframes`. The most interesting function in `arrow_value` is `from_database()` which works just like the function with the same name in `parameter_value` but returns `pyarrow.RecordBatch` objects instead of `Map`s or other `IndexedValue`s. Currently it supports only limited set of arrays, maps and time series. There is no `to_database()` equivalent yet. The `dataframes` module, on the other hand, contains functions that return dataframes from database mapping's parameter value items or queries. There is also a function to add/update a value from dataframe. As with `arrow_value`, the functionality is limited and not all value types are supported.

Implements #353

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
