### PR TITLE
Fix value types when value is list value

### DIFF
--- a/spinedb_api/mapped_items.py
+++ b/spinedb_api/mapped_items.py
@@ -541,11 +541,18 @@ class ParameterItemBase(ParsedValueBase):
     def list_value_id(self):
         return self["list_value_id"]
 
+    def _asdict(self):
+        d = super()._asdict()
+        if d[self.type_key] == "list_value_ref":
+            d[self.type_key] = self.__getitem__(self.type_key)
+        return d
+
     def resolve(self):
         d = super().resolve()
         list_value_id = d.get("list_value_id")
         if list_value_id is not None:
             d[self.value_key] = to_database(list_value_id)[0]
+            d[self.type_key] = "list_value_ref"
         return d
 
     def polish(self):


### PR DESCRIPTION
This fixes a bug where `_asdict()` method in parameter definition and value items could return a dictionary where the `default_type`/`type` field contained the private `"list_value_ref"` type.

No associated issue

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [ ] Unit tests pass
