### PR TITLE
Fix SQLAlchemy warnings

### DIFF
--- a/spinedb_api/alembic/versions/0c7d199ae915_add_list_value_table.py
+++ b/spinedb_api/alembic/versions/0c7d199ae915_add_list_value_table.py
@@ -25,7 +25,7 @@ def upgrade():
     Session = sessionmaker(bind=conn)
     session = Session()
     Base = automap_base()
-    Base.prepare(conn, reflect=True)
+    Base.prepare(conn)
     pvl = session.query(Base.classes.parameter_value_list).all()
     tfm = session.query(Base.classes.tool_feature_method).all()
     session.query(Base.classes.parameter_value_list).delete()
@@ -81,7 +81,7 @@ def upgrade():
         for x in tfm
     ]
     NewBase = automap_base()
-    NewBase.prepare(conn, reflect=True)
+    NewBase.prepare(conn)
     session.bulk_insert_mappings(NewBase.classes.parameter_value_list, pvl_items)
     session.bulk_insert_mappings(NewBase.classes.list_value, lv_items)
     session.bulk_insert_mappings(NewBase.classes.tool_feature_method, tfm_items)

--- a/spinedb_api/alembic/versions/1e4997105288_separate_type_from_value.py
+++ b/spinedb_api/alembic/versions/1e4997105288_separate_type_from_value.py
@@ -26,7 +26,7 @@ def upgrade():
     Session = sessionmaker(bind=conn)
     session = Session()
     Base = automap_base()
-    Base.prepare(conn, reflect=True)
+    Base.prepare(conn)
     # Get items to update
     pd_items = _get_items(session, Base, "parameter_definition")
     pv_items = _get_items(session, Base, "parameter_value")
@@ -46,7 +46,7 @@ def upgrade():
         batch_op.add_column(sa.Column("value", sa.LargeBinary(LONGTEXT_LENGTH), server_default=sa.null()))
     # Do update items
     Base = automap_base()
-    Base.prepare(conn, reflect=True)
+    Base.prepare(conn)
     session.bulk_update_mappings(Base.classes.parameter_definition, pd_items)
     session.bulk_update_mappings(Base.classes.parameter_value, pv_items)
     session.bulk_update_mappings(Base.classes.parameter_value_list, pvl_items)

--- a/spinedb_api/alembic/versions/39e860a11b05_add_alternatives_and_scenarios.py
+++ b/spinedb_api/alembic/versions/39e860a11b05_add_alternatives_and_scenarios.py
@@ -128,7 +128,7 @@ def upgrade():
     Session = sessionmaker(bind=op.get_bind())
     session = Session()
     Base = automap_base()
-    Base.prepare(op.get_bind(), reflect=True)
+    Base.prepare(op.get_bind())
     upgrade_commit_id = add_upgrade_comment_to_commits(session, Base)
     add_base_alternative(upgrade_commit_id, session, Base)
     commit_ids_for_types(upgrade_commit_id, session, Base)

--- a/spinedb_api/alembic/versions/bba1e2ef5153_move_to_entity_based_design.py
+++ b/spinedb_api/alembic/versions/bba1e2ef5153_move_to_entity_based_design.py
@@ -306,8 +306,7 @@ def update_tables(meta, obj_cls_to_ent_cls, rel_cls_to_ent_cls, obj_to_ent, rel_
     for object_class_id, entity_class_id in obj_cls_to_ent_cls.items():
         conn.execute(
             text("UPDATE object_class SET entity_class_id = :entity_class_id, type_id = 1 WHERE id = :object_class_id"),
-            entity_class_id=entity_class_id,
-            object_class_id=object_class_id,
+            {"entity_class_id": entity_class_id, "object_class_id": object_class_id},
         )
         conn.execute(
             text(
@@ -316,8 +315,10 @@ def update_tables(meta, obj_cls_to_ent_cls, rel_cls_to_ent_cls, obj_to_ent, rel_
             WHERE object_class_id = :object_class_id
             """
             ),
-            entity_class_id=entity_class_id,
-            object_class_id=object_class_id,
+            {
+                "entity_class_id": entity_class_id,
+                "object_class_id": object_class_id,
+            },
         )
     for relationship_class_id, entity_class_id in rel_cls_to_ent_cls.items():
         conn.execute(
@@ -327,14 +328,18 @@ def update_tables(meta, obj_cls_to_ent_cls, rel_cls_to_ent_cls, obj_to_ent, rel_
             WHERE relationship_class_id = :relationship_class_id
             """
             ),
-            entity_class_id=entity_class_id,
-            relationship_class_id=relationship_class_id,
+            {
+                "entity_class_id": entity_class_id,
+                "relationship_class_id": relationship_class_id,
+            },
         )
     for object_id, entity_id in obj_to_ent.items():
         conn.execute(
             text("UPDATE object SET entity_id = :entity_id, type_id = 1 WHERE id = :object_id"),
-            entity_id=entity_id,
-            object_id=object_id,
+            {
+                "entity_id": entity_id,
+                "object_id": object_id,
+            },
         )
         entity_class_id = ent_to_ent_cls[entity_id]
         conn.execute(
@@ -344,9 +349,11 @@ def update_tables(meta, obj_cls_to_ent_cls, rel_cls_to_ent_cls, obj_to_ent, rel_
             WHERE object_id = :object_id
             """
             ),
-            entity_id=entity_id,
-            entity_class_id=entity_class_id,
-            object_id=object_id,
+            {
+                "entity_id": entity_id,
+                "entity_class_id": entity_class_id,
+                "object_id": object_id,
+            },
         )
     for relationship_id, entity_id in rel_to_ent.items():
         entity_class_id = ent_to_ent_cls[entity_id]
@@ -357,9 +364,11 @@ def update_tables(meta, obj_cls_to_ent_cls, rel_cls_to_ent_cls, obj_to_ent, rel_
             WHERE relationship_id = :relationship_id
             """
             ),
-            entity_id=entity_id,
-            entity_class_id=entity_class_id,
-            relationship_id=relationship_id,
+            {
+                "entity_id": entity_id,
+                "entity_class_id": entity_class_id,
+                "relationship_id": relationship_id,
+            },
         )
     # Clean our potential mess.
     # E.g., I've seen parameter definitions with an invalid relationship_class_id for some reason...!
@@ -386,10 +395,12 @@ def update_tables(meta, obj_cls_to_ent_cls, rel_cls_to_ent_cls, obj_to_ent, rel_
             entity_id = :entity_id
         """
         ),
-        user=user,
-        date=date,
-        entity_class_id=entity_class_id,
-        entity_id=entity_id,
+        {
+            "user": user,
+            "date": date,
+            "entity_class_id": entity_class_id,
+            "entity_id": entity_id,
+        },
     )
 
 

--- a/spinedb_api/alembic/versions/ca7a13da8ff6_add_type_info_for_scalars.py
+++ b/spinedb_api/alembic/versions/ca7a13da8ff6_add_type_info_for_scalars.py
@@ -49,5 +49,5 @@ def _get_scalar_values_by_id(table, value_label, type_label, connection):
     type_column = getattr(table.c, type_label)
     return {
         row.id: row._mapping[value_label]
-        for row in connection.execute(sa.select([table.c.id, value_column]).where(type_column == None))
+        for row in connection.execute(sa.select(table.c.id, value_column).where(type_column == None))
     }

--- a/spinedb_api/compatibility.py
+++ b/spinedb_api/compatibility.py
@@ -40,7 +40,7 @@ def convert_tool_feature_method_to_active_by_default(conn, use_existing_tool_fea
             lv_id_by_pdef_id = {
                 x["parameter_definition_id"]: x["id"]
                 for x in conn.execute(
-                    sa.select([lv_table.c.id, f_table.c.parameter_definition_id])
+                    sa.select(lv_table.c.id, f_table.c.parameter_definition_id)
                     .where(tfm_table.c.parameter_value_list_id == lv_table.c.parameter_value_list_id)
                     .where(tfm_table.c.method_index == lv_table.c.index)
                     .where(tf_table.c.id == tfm_table.c.tool_feature_id)
@@ -55,7 +55,7 @@ def convert_tool_feature_method_to_active_by_default(conn, use_existing_tool_fea
         lv_id_by_pdef_id = {
             x.parameter_definition_id: x.id
             for x in conn.execute(
-                sa.select([lv_table.c.id, lv_table.c.value, pd_table.c.id.label("parameter_definition_id")])
+                sa.select(lv_table.c.id, lv_table.c.value, pd_table.c.id.label("parameter_definition_id"))
                 .where(lv_table.c.parameter_value_list_id == pd_table.c.parameter_value_list_id)
                 .where(pd_table.c.name == "is_active")
                 .where(lv_table.c.value.in_((b'"yes"', b"true")))
@@ -69,11 +69,9 @@ def convert_tool_feature_method_to_active_by_default(conn, use_existing_tool_fea
         {c: x._mapping[c] for c in ("entity_class_id", "parameter_definition_id", "list_value_id")}
         for x in conn.execute(
             sa.select(
-                [
-                    pd_table.c.entity_class_id,
-                    pd_table.c.id.label("parameter_definition_id"),
-                    list_value_id.label("list_value_id"),
-                ]
+                pd_table.c.entity_class_id,
+                pd_table.c.id.label("parameter_definition_id"),
+                list_value_id.label("list_value_id"),
             ).where(pd_table.c.id.in_(lv_id_by_pdef_id))
         )
     ]
@@ -128,7 +126,7 @@ def convert_tool_feature_method_to_entity_alternative(conn, use_existing_tool_fe
             lv_id_by_pdef_id = {
                 x["parameter_definition_id"]: x["id"]
                 for x in conn.execute(
-                    sa.select([lv_table.c.id, f_table.c.parameter_definition_id])
+                    sa.select(lv_table.c.id, f_table.c.parameter_definition_id)
                     .where(tfm_table.c.parameter_value_list_id == lv_table.c.parameter_value_list_id)
                     .where(tfm_table.c.method_index == lv_table.c.index)
                     .where(tf_table.c.id == tfm_table.c.tool_feature_id)
@@ -144,7 +142,7 @@ def convert_tool_feature_method_to_entity_alternative(conn, use_existing_tool_fe
         lv_id_by_pdef_id = {
             x.parameter_definition_id: x.id
             for x in conn.execute(
-                sa.select([lv_table.c.id, lv_table.c.value, pd_table.c.id.label("parameter_definition_id")])
+                sa.select(lv_table.c.id, lv_table.c.value, pd_table.c.id.label("parameter_definition_id"))
                 .where(lv_table.c.parameter_value_list_id == pd_table.c.parameter_value_list_id)
                 .where(pd_table.c.name == "is_active")
                 .where(lv_table.c.value.in_((b'"yes"', b"true")))
@@ -155,14 +153,14 @@ def convert_tool_feature_method_to_entity_alternative(conn, use_existing_tool_fe
     is_active_pvals = [
         {c: x._mapping[c] for c in ("id", "entity_id", "alternative_id", "parameter_definition_id", "list_value_id")}
         for x in conn.execute(
-            sa.select([pv_table, list_value_id.label("list_value_id")]).where(
+            sa.select(pv_table, list_value_id.label("list_value_id")).where(
                 pv_table.c.parameter_definition_id.in_(lv_id_by_pdef_id)
             )
         )
     ]
     # Compute new entity_alternative items from 'is_active' parameter values,
     # where 'active' is True if the value of 'is_active' is the one from the tool_feature_method specification
-    current_ea_ids = {(x.entity_id, x.alternative_id): x.id for x in conn.execute(sa.select([ea_table]))}
+    current_ea_ids = {(x.entity_id, x.alternative_id): x.id for x in conn.execute(sa.select(ea_table))}
     new_ea_items = {
         (x["entity_id"], x["alternative_id"]): {
             "entity_id": x["entity_id"],

--- a/spinedb_api/db_mapping.py
+++ b/spinedb_api/db_mapping.py
@@ -269,7 +269,7 @@ class DatabaseMapping(DatabaseMappingQueryMixin, DatabaseMappingCommitMixin, Dat
                     folder_name = os.path.expanduser("~")
                     file_name = sa_url.database
                 database = os.path.join(folder_name, file_name + "." + v_err.current)
-                backup_url = str(URL("sqlite", database=database))
+                backup_url = str(URL.create("sqlite", database=database))
                 option_to_kwargs = {
                     "Backup and upgrade": {"upgrade": True, "backup_url": backup_url},
                     "Just upgrade": {"upgrade": True},

--- a/spinedb_api/db_mapping.py
+++ b/spinedb_api/db_mapping.py
@@ -42,7 +42,7 @@ from .helpers import (
     _create_first_spine_database,
     compare_schemas,
     copy_database_bind,
-    create_new_spine_database_from_bind,
+    create_new_spine_database_from_engine,
     model_meta,
 )
 from .mapped_items import item_factory
@@ -338,49 +338,50 @@ class DatabaseMapping(DatabaseMappingQueryMixin, DatabaseMappingCommitMixin, Dat
                 current = migration_context.get_current_revision()
             except DatabaseError as error:
                 raise SpineDBAPIError(str(error)) from None
-            if current is None:
-                # No revision information. Check that the schema of the given url corresponds to a 'first' Spine db
-                # Otherwise we either raise or create a new Spine db at the url.
-                ref_engine = _create_first_spine_database("sqlite://")
-                if not compare_schemas(engine, ref_engine):
-                    if not create or inspect(engine).get_table_names():
-                        raise SpineDBAPIError(
-                            "Unable to determine db revision. "
-                            f"Please check that\n\n\t{sa_url}\n\nis the URL of a valid Spine db."
-                        )
-                    create_new_spine_database_from_bind(connection)
-                    return engine
-            config = Config()
-            config.set_main_option("script_location", "spinedb_api:alembic")
-            script = ScriptDirectory.from_config(config)
-            head = script.get_current_head()
-            if current != head:
-                if not upgrade:
-                    try:
-                        script.get_revision(current)  # Check if current revision is part of alembic rev. history
-                    except CommandError:
-                        # Can't find 'current' revision
-                        raise SpineDBVersionError(
-                            url=sa_url, current=current, expected=head, upgrade_available=False
-                        ) from None
-                    raise SpineDBVersionError(url=sa_url, current=current, expected=head)
-                if backup_url:
-                    dst_engine = create_engine(backup_url)
-                    copy_database_bind(dst_engine, engine)
+        if current is None:
+            # No revision information. Check that the schema of the given url corresponds to a 'first' Spine db
+            # Otherwise we either raise or create a new Spine db at the url.
+            ref_engine = _create_first_spine_database("sqlite://")
+            if not compare_schemas(engine, ref_engine):
+                if not create or inspect(engine).get_table_names():
+                    raise SpineDBAPIError(
+                        "Unable to determine db revision. "
+                        f"Please check that\n\n\t{sa_url}\n\nis the URL of a valid Spine db."
+                    )
+                create_new_spine_database_from_engine(engine)
+                return engine
+        config = Config()
+        config.set_main_option("script_location", "spinedb_api:alembic")
+        script = ScriptDirectory.from_config(config)
+        head = script.get_current_head()
+        if current != head:
+            if not upgrade:
+                try:
+                    script.get_revision(current)  # Check if current revision is part of alembic rev. history
+                except CommandError:
+                    # Can't find 'current' revision
+                    raise SpineDBVersionError(
+                        url=sa_url, current=current, expected=head, upgrade_available=False
+                    ) from None
+                raise SpineDBVersionError(url=sa_url, current=current, expected=head)
+            if backup_url:
+                dst_engine = create_engine(backup_url)
+                copy_database_bind(dst_engine, engine)
 
-                # Upgrade function
-                def upgrade_to_head(rev, context):
-                    return script._upgrade_revs("head", rev)
+            # Upgrade function
+            def upgrade_to_head(rev, context):
+                return script._upgrade_revs("head", rev)
 
-                with EnvironmentContext(
-                    config,
-                    script,
-                    fn=upgrade_to_head,
-                    as_sql=False,
-                    starting_rev=None,
-                    destination_rev="head",
-                    tag=None,
-                ) as environment_context:
+            with EnvironmentContext(
+                config,
+                script,
+                fn=upgrade_to_head,
+                as_sql=False,
+                starting_rev=None,
+                destination_rev="head",
+                tag=None,
+            ) as environment_context:
+                with engine.begin() as connection:
                     environment_context.configure(connection=connection, target_metadata=model_meta)
                     with environment_context.begin_transaction():
                         environment_context.run_migrations()

--- a/spinedb_api/db_mapping_query_mixin.py
+++ b/spinedb_api/db_mapping_query_mixin.py
@@ -875,7 +875,6 @@ class DatabaseMappingQueryMixin:
                 )
                 .filter(self.object_sq.c.class_id == self.object_class_sq.c.id)
                 .outerjoin(self.entity_group_sq, self.entity_group_sq.c.entity_id == self.object_sq.c.id)
-                .distinct(self.entity_group_sq.c.entity_id)
                 .subquery()
             )
         return self._ext_object_sq

--- a/spinedb_api/export_mapping/export_mapping.py
+++ b/spinedb_api/export_mapping/export_mapping.py
@@ -965,12 +965,14 @@ class ParameterValueMapping(ExportMapping):
                 and_(
                     db_map.parameter_value_sq.c.entity_id == db_map.entity_element_sq.c.element_id,
                     db_map.parameter_value_sq.c.parameter_definition_id == db_map.parameter_definition_sq.c.id,
+                    db_map.parameter_value_sq.c.alternative_id == db_map.alternative_sq.c.id,
                 )
             )
         return query.filter(
             and_(
                 db_map.parameter_value_sq.c.entity_id == db_map.wide_entity_sq.c.id,
                 db_map.parameter_value_sq.c.parameter_definition_id == db_map.parameter_definition_sq.c.id,
+                db_map.parameter_value_sq.c.alternative_id == db_map.alternative_sq.c.id,
             )
         )
 

--- a/spinedb_api/filters/value_transformer.py
+++ b/spinedb_api/filters/value_transformer.py
@@ -173,14 +173,12 @@ def _make_parameter_value_transforming_sq(db_map, state):
     # Little optimization: SqlAlchemy can infer types from the first row, so we need to use cast only on that.
     statements = [
         select(
-            [
-                cast(literal(transformed_rows[0][0]), Integer()).label("id"),
-                cast(literal(transformed_rows[0][1]), LargeBinary(LONGTEXT_LENGTH)).label("transformed_value"),
-                cast(literal(transformed_rows[0][2]), String()).label("transformed_type"),
-            ]
+            cast(literal(transformed_rows[0][0]), Integer()).label("id"),
+            cast(literal(transformed_rows[0][1]), LargeBinary(LONGTEXT_LENGTH)).label("transformed_value"),
+            cast(literal(transformed_rows[0][2]), String()).label("transformed_type"),
         )
     ]
-    statements += [select([literal(i), literal(v), literal(t)]) for i, v, t in transformed_rows[1:]]
+    statements += [select(literal(i), literal(v), literal(t)) for i, v, t in transformed_rows[1:]]
     temp_sq = union_all(*statements).alias("transformed_values")
     new_value = case((temp_sq.c.transformed_value != None, temp_sq.c.transformed_value), else_=subquery.c.value)
     new_type = case((temp_sq.c.transformed_type != None, temp_sq.c.transformed_type), else_=subquery.c.type)

--- a/spinedb_api/helpers.py
+++ b/spinedb_api/helpers.py
@@ -49,7 +49,6 @@ from sqlalchemy import (
     true,
 )
 from sqlalchemy.dialects.mysql import DOUBLE, TINYINT
-from sqlalchemy.engine import Connection
 from sqlalchemy.exc import DatabaseError, IntegrityError
 from sqlalchemy.ext.automap import generate_relationship
 from sqlalchemy.ext.compiler import compiles

--- a/tests/filters/test_alternative_filter.py
+++ b/tests/filters/test_alternative_filter.py
@@ -41,7 +41,7 @@ from tests.mock_helpers import AssertSuccessTestCase
 class TestAlternativeFilter(AssertSuccessTestCase):
     def test_alternative_filter_without_scenarios_or_alternatives(self):
         with TemporaryDirectory() as temp_dir:
-            url = URL("sqlite", database=Path(temp_dir, "test_scenario_filter_mapping.sqlite").as_posix())
+            url = URL.create("sqlite", database=Path(temp_dir, "test_scenario_filter_mapping.sqlite").as_posix())
             with DatabaseMapping(url, create=True) as db_map:
                 self._build_data_without_alternatives(db_map)
             with DatabaseMapping(url) as db_map:
@@ -51,7 +51,7 @@ class TestAlternativeFilter(AssertSuccessTestCase):
 
     def test_alternative_filter_without_scenarios_or_alternatives_uncommitted_data(self):
         with TemporaryDirectory() as temp_dir:
-            url = URL("sqlite", database=Path(temp_dir, "test_scenario_filter_mapping.sqlite").as_posix())
+            url = URL.create("sqlite", database=Path(temp_dir, "test_scenario_filter_mapping.sqlite").as_posix())
             with DatabaseMapping(url, create=True) as db_map:
                 self._build_data_without_alternatives(db_map, commit=False)
                 apply_alternative_filter_to_parameter_value_sq(db_map, alternatives=[])
@@ -61,7 +61,7 @@ class TestAlternativeFilter(AssertSuccessTestCase):
 
     def test_alternative_filter(self):
         with TemporaryDirectory() as temp_dir:
-            url = URL("sqlite", database=Path(temp_dir, "test_scenario_filter_mapping.sqlite").as_posix())
+            url = URL.create("sqlite", database=Path(temp_dir, "test_scenario_filter_mapping.sqlite").as_posix())
             with DatabaseMapping(url, create=True) as db_map:
                 self._build_data_with_single_alternative(db_map)
             with DatabaseMapping(url) as db_map:
@@ -72,7 +72,7 @@ class TestAlternativeFilter(AssertSuccessTestCase):
 
     def test_alternative_filter_uncommitted_data(self):
         with TemporaryDirectory() as temp_dir:
-            url = URL("sqlite", database=Path(temp_dir, "test_scenario_filter_mapping.sqlite").as_posix())
+            url = URL.create("sqlite", database=Path(temp_dir, "test_scenario_filter_mapping.sqlite").as_posix())
             with DatabaseMapping(url, create=True) as db_map:
                 self._build_data_with_single_alternative(db_map, commit=False)
                 with self.assertRaises(SpineDBAPIError):
@@ -83,7 +83,7 @@ class TestAlternativeFilter(AssertSuccessTestCase):
 
     def test_alternative_filter_from_dict(self):
         with TemporaryDirectory() as temp_dir:
-            url = URL("sqlite", database=Path(temp_dir, "test_scenario_filter_mapping.sqlite").as_posix())
+            url = URL.create("sqlite", database=Path(temp_dir, "test_scenario_filter_mapping.sqlite").as_posix())
             with DatabaseMapping(url, create=True) as db_map:
                 self._build_data_with_single_alternative(db_map)
             with DatabaseMapping(url) as db_map:
@@ -123,7 +123,7 @@ class TestAlternativeFilter(AssertSuccessTestCase):
             alternative_filter_from_dict(db_map, config)
             alternatives = db_map.query(db_map.alternative_sq).all()
             self.assertEqual(len(alternatives), 1)
-            self.assertEqual(alternatives[0]["name"], "visible")
+            self.assertEqual(alternatives[0].name, "visible")
 
     def test_filters_scenarios(self):
         with DatabaseMapping("sqlite://", create=True) as db_map:
@@ -151,7 +151,7 @@ class TestAlternativeFilter(AssertSuccessTestCase):
             alternative_filter_from_dict(db_map, config)
             scenarios = db_map.query(db_map.scenario_sq).all()
             self.assertEqual(len(scenarios), 2)
-            self.assertCountEqual([s["name"] for s in scenarios], ["Empty", "Visible only"])
+            self.assertCountEqual([s.name for s in scenarios], ["Empty", "Visible only"])
 
     def test_filters_scenario_alternatives(self):
         with DatabaseMapping("sqlite://", create=True) as db_map:
@@ -198,7 +198,7 @@ class TestAlternativeFilter(AssertSuccessTestCase):
             alternative_filter_from_dict(db_map, config)
             entities = db_map.query(db_map.entity_sq).all()
             self.assertEqual(len(entities), 2)
-            self.assertCountEqual([e["name"] for e in entities], ["visible", "visible_by_default"])
+            self.assertCountEqual([e.name for e in entities], ["visible", "visible_by_default"])
 
     def test_filters_entities_in_class_that_isnt_active_by_default(self):
         with DatabaseMapping("sqlite://", create=True) as db_map:
@@ -229,7 +229,7 @@ class TestAlternativeFilter(AssertSuccessTestCase):
             alternative_filter_from_dict(db_map, config)
             entities = db_map.query(db_map.entity_sq).all()
             self.assertEqual(len(entities), 1)
-            self.assertCountEqual([e["name"] for e in entities], ["visible"])
+            self.assertCountEqual([e.name for e in entities], ["visible"])
 
     def test_filters_multidimensional_entities_that_have_inactive_elements(self):
         with DatabaseMapping("sqlite://", create=True) as db_map:
@@ -254,7 +254,7 @@ class TestAlternativeFilter(AssertSuccessTestCase):
             alternative_filter_from_dict(db_map, config)
             entities = db_map.query(db_map.entity_sq).all()
             self.assertEqual(len(entities), 2)
-            self.assertCountEqual([e["name"] for e in entities], ["visible", "visible__"])
+            self.assertCountEqual([e.name for e in entities], ["visible", "visible__"])
 
     def test_filters_parameters_values_of_inactive_entities(self):
         with DatabaseMapping("sqlite://", create=True) as db_map:
@@ -299,7 +299,7 @@ class TestAlternativeFilter(AssertSuccessTestCase):
             alternative_filter_from_dict(db_map, config)
             values = db_map.query(db_map.parameter_value_sq).all()
             self.assertEqual(len(values), 1)
-            self.assertEqual(from_database(values[0]["value"], values[0]["type"]), 2.3)
+            self.assertEqual(from_database(values[0].value, values[0].type), 2.3)
 
     def test_filters_parameters_values_by_active_by_default(self):
         with DatabaseMapping("sqlite://", create=True) as db_map:
@@ -336,7 +336,7 @@ class TestAlternativeFilter(AssertSuccessTestCase):
             alternative_filter_from_dict(db_map, config)
             values = db_map.query(db_map.parameter_value_sq).all()
             self.assertEqual(len(values), 1)
-            self.assertEqual(from_database(values[0]["value"], values[0]["type"]), -2.3)
+            self.assertEqual(from_database(values[0].value, values[0].type), -2.3)
 
     def test_filters_parameter_values_of_multidimensional_entities_inactive_by_elements(self):
         with DatabaseMapping("sqlite://", create=True) as db_map:
@@ -388,7 +388,7 @@ class TestAlternativeFilter(AssertSuccessTestCase):
             alternative_filter_from_dict(db_map, config)
             values = db_map.query(db_map.parameter_value_sq).all()
             self.assertEqual(len(values), 1)
-            self.assertEqual(from_database(values[0]["value"], values[0]["type"]), -2.3)
+            self.assertEqual(from_database(values[0].value, values[0].type), -2.3)
 
     def test_entity_groups(self):
         with DatabaseMapping("sqlite://", create=True) as db_map:
@@ -547,13 +547,13 @@ class TestAlternativeFilter(AssertSuccessTestCase):
             alternative_filter_from_dict(db_map, config)
             groups = db_map.query(db_map.entity_group_sq).all()
             self.assertEqual(len(groups), 5)
-            class_names = {row["id"]: row["name"] for row in db_map.query(db_map.entity_class_sq)}
-            entity_names = {row["id"]: row["name"] for row in db_map.query(db_map.entity_sq)}
+            class_names = {row.id: row.name for row in db_map.query(db_map.entity_class_sq)}
+            entity_names = {row.id: row.name for row in db_map.query(db_map.entity_sq)}
             data = {}
             for row in groups:
-                data.setdefault(class_names[row["entity_class_id"]], {}).setdefault(
-                    entity_names[row["entity_id"]], set()
-                ).add(entity_names[row["member_id"]])
+                data.setdefault(class_names[row.entity_class_id], {}).setdefault(
+                    entity_names[row.entity_id], set()
+                ).add(entity_names[row.member_id])
             expected = {
                 "Visible": {
                     "default_active_group": {"default_active", "active"},

--- a/tests/filters/test_scenario_filter.py
+++ b/tests/filters/test_scenario_filter.py
@@ -261,13 +261,13 @@ class TestScenarioFilterInMemory(AssertSuccessTestCase):
             apply_filter_stack(db_map, [scenario_filter_config("scen")])
             groups = db_map.query(db_map.entity_group_sq).all()
             self.assertEqual(len(groups), 5)
-            class_names = {row["id"]: row["name"] for row in db_map.query(db_map.entity_class_sq)}
-            entity_names = {row["id"]: row["name"] for row in db_map.query(db_map.entity_sq)}
+            class_names = {row.id: row.name for row in db_map.query(db_map.entity_class_sq)}
+            entity_names = {row.id: row.name for row in db_map.query(db_map.entity_sq)}
             data = {}
             for row in groups:
-                data.setdefault(class_names[row["entity_class_id"]], {}).setdefault(
-                    entity_names[row["entity_id"]], set()
-                ).add(entity_names[row["member_id"]])
+                data.setdefault(class_names[row.entity_class_id], {}).setdefault(
+                    entity_names[row.entity_id], set()
+                ).add(entity_names[row.member_id])
             expected = {
                 "Visible": {
                     "default_active_group": {"default_active", "active"},

--- a/tests/filters/test_tools.py
+++ b/tests/filters/test_tools.py
@@ -81,13 +81,13 @@ class TestLoadFilters(unittest.TestCase):
 
 
 class TestApplyFilterStack(unittest.TestCase):
-    _db_url = URL.create("sqlite")
+    _db_url = None
     _dir = None
 
     @classmethod
     def setUpClass(cls):
         cls._dir = TemporaryDirectory()
-        cls._db_url = cls._db_url.set(database=os.path.join(cls._dir.name, ".sqlite"))
+        cls._db_url = URL.create("sqlite", database=os.path.join(cls._dir.name, ".sqlite"))
         with DatabaseMapping(cls._db_url, create=True) as db_map:
             count, errors = import_object_classes(db_map, ("object_class",))
             if errors:
@@ -119,7 +119,7 @@ class TestApplyFilterStack(unittest.TestCase):
 
 
 class TestFilteredDatabaseMap(unittest.TestCase):
-    _db_url = URL("sqlite")
+    _db_url = URL.create("sqlite")
     _dir = None
 
     @classmethod

--- a/tests/spine_io/exporters/test_sql_writer.py
+++ b/tests/spine_io/exporters/test_sql_writer.py
@@ -225,14 +225,11 @@ class TestSqlWriter(AssertSuccessTestCase):
                 db_map.commit_session("Add test data.")
                 out_path = Path(temp_dir, "out.sqlite")
                 out_engine = create_engine("sqlite:///" + str(out_path))
-                out_connection = out_engine.connect()
-                try:
+                with out_engine.begin() as out_connection:
                     metadata = MetaData()
                     object_table = Table("oc", metadata, Column("objects", String))
                     metadata.create_all(out_engine)
-                    out_connection.execute(object_table.insert(), objects="initial_object")
-                finally:
-                    out_connection.close()
+                    out_connection.execute(object_table.insert(), {"objects": "initial_object"})
                 root_mapping = entity_export(Position.table_name, 0)
                 root_mapping.child.header = "objects"
                 writer = SqlWriter(str(out_path), overwrite_existing=False)

--- a/tests/test_DatabaseMapping.py
+++ b/tests/test_DatabaseMapping.py
@@ -3225,7 +3225,7 @@ class TestDatabaseMappingAdd(AssertSuccessTestCase):
                 .first()
                 .id
             )
-            nemo_row = db_map.query(db_map.object_sq).filter(db_map.entity_sq.c.name == "nemo").first()
+            nemo_row = db_map.query(db_map.object_sq).filter(db_map.object_sq.c.name == "nemo").first()
             value1, type1 = to_database("orange")
             value2, type2 = to_database("blue")
             db_map.add_items(

--- a/tests/test_DatabaseMapping.py
+++ b/tests/test_DatabaseMapping.py
@@ -1942,7 +1942,7 @@ class TestDatabaseMapping(AssertSuccessTestCase):
             with DatabaseMapping(url, create=True) as db_map:
                 self._assert_success(db_map.add_parameter_value_list_item(name="my_enum"))
                 db_map.commit_session("Add value list.")
-                list_id = db_map.query(db_map.parameter_value_list_sq).first()["id"]
+                list_id = db_map.query(db_map.parameter_value_list_sq).first().id
             with DatabaseMapping(url) as db_map:
                 self._assert_success(db_map.remove_item("parameter_value_list", list_id))
                 db_map.commit_session("Remove value list")
@@ -4631,8 +4631,8 @@ class TestDatabaseMappingConcurrent(AssertSuccessTestCase):
             c1.join()
             c2.join()
             with DatabaseMapping(url) as db_map:
-                commit_msgs = {x["comment"] for x in db_map.query(db_map.commit_sq)}
-                entity_class_names = [x["name"] for x in db_map.query(db_map.entity_class_sq)]
+                commit_msgs = {x.comment for x in db_map.query(db_map.commit_sq)}
+                entity_class_names = [x.name for x in db_map.query(db_map.entity_class_sq)]
                 self.assertEqual(commit_msgs, {"Create the database", "one", "two"})
                 self.assertCountEqual(entity_class_names, ["cat", "dog"])
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -50,7 +50,8 @@ class TestCreateNewSpineEngine(unittest.TestCase):
     def test_different_schema(self):
         engine1 = create_new_spine_database("sqlite://")
         engine2 = create_new_spine_database("sqlite://")
-        engine2.execute(text("drop table entity"))
+        with engine2.begin() as connection:
+            connection.execute(text("drop table entity"))
         self.assertFalse(compare_schemas(engine1, engine2))
 
 

--- a/tests/test_import_functions.py
+++ b/tests/test_import_functions.py
@@ -146,7 +146,7 @@ class TestImportObject(AssertSuccessTestCase):
                 o.class_name: o.name
                 for o in db_map.query(
                     db_map.object_sq.c.name.label("name"), db_map.object_class_sq.c.name.label("class_name")
-                )
+                ).join(db_map.object_class_sq, db_map.object_sq.c.class_id == db_map.object_class_sq.c.id)
             }
             expected = {"object_class1": "object", "object_class2": "object"}
             self.assertEqual(objects, expected)
@@ -281,6 +281,10 @@ class TestImportRelationshipClassParameter(AssertSuccessTestCase):
                 for d in db_map.query(
                     db_map.relationship_parameter_definition_sq.c.parameter_name.label("name"),
                     db_map.relationship_class_sq.c.name.label("class_name"),
+                ).join(
+                    db_map.relationship_class_sq,
+                    db_map.relationship_parameter_definition_sq.c.relationship_class_id
+                    == db_map.relationship_class_sq.c.id,
                 )
             }
             expected = {"relationship_class": "new_parameter"}
@@ -311,6 +315,10 @@ class TestImportRelationshipClassParameter(AssertSuccessTestCase):
                 for d in db_map.query(
                     db_map.relationship_parameter_definition_sq.c.parameter_name.label("name"),
                     db_map.relationship_class_sq.c.name.label("class_name"),
+                ).join(
+                    db_map.relationship_class_sq,
+                    db_map.relationship_parameter_definition_sq.c.relationship_class_id
+                    == db_map.relationship_class_sq.c.id,
                 )
             }
             expected = {"relationship_class1": "new_parameter", "relationship_class2": "new_parameter"}

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -29,58 +29,59 @@ class TestMigration(unittest.TestCase):
             db_url = URL.create("sqlite", database=os.path.join(temp_dir, "test_upgrade_content.sqlite"))
             engine = _create_first_spine_database(db_url)
             # Insert basic stuff
-            engine.execute(text("INSERT INTO object_class (id, name) VALUES (1, 'dog')"))
-            engine.execute(text("INSERT INTO object_class (id, name) VALUES (2, 'fish')"))
-            engine.execute(text("INSERT INTO object (id, class_id, name) VALUES (1, 1, 'pluto')"))
-            engine.execute(text("INSERT INTO object (id, class_id, name) VALUES (2, 1, 'scooby')"))
-            engine.execute(text("INSERT INTO object (id, class_id, name) VALUES (3, 2, 'nemo')"))
-            engine.execute(
-                text(
-                    "INSERT INTO relationship_class (id, name, dimension, object_class_id) VALUES (1, 'dog__fish', 0, 1)"
+            with engine.begin() as connection:
+                connection.execute(text("INSERT INTO object_class (id, name) VALUES (1, 'dog')"))
+                connection.execute(text("INSERT INTO object_class (id, name) VALUES (2, 'fish')"))
+                connection.execute(text("INSERT INTO object (id, class_id, name) VALUES (1, 1, 'pluto')"))
+                connection.execute(text("INSERT INTO object (id, class_id, name) VALUES (2, 1, 'scooby')"))
+                connection.execute(text("INSERT INTO object (id, class_id, name) VALUES (3, 2, 'nemo')"))
+                connection.execute(
+                    text(
+                        "INSERT INTO relationship_class (id, name, dimension, object_class_id) VALUES (1, 'dog__fish', 0, 1)"
+                    )
                 )
-            )
-            engine.execute(
-                text(
-                    "INSERT INTO relationship_class (id, name, dimension, object_class_id) VALUES (1, 'dog__fish', 1, 2)"
+                connection.execute(
+                    text(
+                        "INSERT INTO relationship_class (id, name, dimension, object_class_id) VALUES (1, 'dog__fish', 1, 2)"
+                    )
                 )
-            )
-            engine.execute(
-                text(
-                    "INSERT INTO relationship (id, class_id, name, dimension, object_id) VALUES (1, 1, 'pluto__nemo', 0, 1)"
+                connection.execute(
+                    text(
+                        "INSERT INTO relationship (id, class_id, name, dimension, object_id) VALUES (1, 1, 'pluto__nemo', 0, 1)"
+                    )
                 )
-            )
-            engine.execute(
-                text(
-                    "INSERT INTO relationship (id, class_id, name, dimension, object_id) VALUES (1, 1, 'pluto__nemo', 1, 3)"
+                connection.execute(
+                    text(
+                        "INSERT INTO relationship (id, class_id, name, dimension, object_id) VALUES (1, 1, 'pluto__nemo', 1, 3)"
+                    )
                 )
-            )
-            engine.execute(
-                text(
-                    "INSERT INTO relationship (id, class_id, name, dimension, object_id) VALUES (2, 1, 'scooby__nemo', 0, 2)"
+                connection.execute(
+                    text(
+                        "INSERT INTO relationship (id, class_id, name, dimension, object_id) VALUES (2, 1, 'scooby__nemo', 0, 2)"
+                    )
                 )
-            )
-            engine.execute(
-                text(
-                    "INSERT INTO relationship (id, class_id, name, dimension, object_id) VALUES (2, 1, 'scooby__nemo', 1, 3)"
+                connection.execute(
+                    text(
+                        "INSERT INTO relationship (id, class_id, name, dimension, object_id) VALUES (2, 1, 'scooby__nemo', 1, 3)"
+                    )
                 )
-            )
-            engine.execute(text("INSERT INTO parameter (id, object_class_id, name) VALUES (1, 1, 'breed')"))
-            engine.execute(text("INSERT INTO parameter (id, object_class_id, name) VALUES (2, 2, 'water')"))
-            engine.execute(
-                text("INSERT INTO parameter (id, relationship_class_id, name) VALUES (3, 1, 'relative_speed')")
-            )
-            engine.execute(
-                text("INSERT INTO parameter_value (parameter_id, object_id, value) VALUES (1, 1, '\"labrador\"')")
-            )
-            engine.execute(
-                text("INSERT INTO parameter_value (parameter_id, object_id, value) VALUES (1, 2, '\"big dane\"')")
-            )
-            engine.execute(
-                text("INSERT INTO parameter_value (parameter_id, relationship_id, value) VALUES (3, 1, '100')")
-            )
-            engine.execute(
-                text("INSERT INTO parameter_value (parameter_id, relationship_id, value) VALUES (3, 2, '-1')")
-            )
+                connection.execute(text("INSERT INTO parameter (id, object_class_id, name) VALUES (1, 1, 'breed')"))
+                connection.execute(text("INSERT INTO parameter (id, object_class_id, name) VALUES (2, 2, 'water')"))
+                connection.execute(
+                    text("INSERT INTO parameter (id, relationship_class_id, name) VALUES (3, 1, 'relative_speed')")
+                )
+                connection.execute(
+                    text("INSERT INTO parameter_value (parameter_id, object_id, value) VALUES (1, 1, '\"labrador\"')")
+                )
+                connection.execute(
+                    text("INSERT INTO parameter_value (parameter_id, object_id, value) VALUES (1, 2, '\"big dane\"')")
+                )
+                connection.execute(
+                    text("INSERT INTO parameter_value (parameter_id, relationship_id, value) VALUES (3, 1, '100')")
+                )
+                connection.execute(
+                    text("INSERT INTO parameter_value (parameter_id, relationship_id, value) VALUES (3, 2, '-1')")
+                )
             # Upgrade the db and check that our stuff is still there
             with DatabaseMapping(db_url, upgrade=True) as db_map:
                 object_classes = {x.id: x.name for x in db_map.query(db_map.object_class_sq)}


### PR DESCRIPTION
This PR fixes SQLAlchemy warnings including all deprecation warnings from unit tests. No functional changes intended. This should bring us a step closer to SQLAlchemy 2.0.

Re #477

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
