### PR TITLE
More SQLAlchemy compatibility

### DIFF
--- a/spinedb_api/alembic/versions/0c7d199ae915_add_list_value_table.py
+++ b/spinedb_api/alembic/versions/0c7d199ae915_add_list_value_table.py
@@ -22,7 +22,7 @@ depends_on = None
 def upgrade():
     # Rescue current data
     conn = op.get_bind()
-    Session = sessionmaker(bind=conn)
+    Session = sessionmaker(bind=conn, future=True)
     session = Session()
     Base = automap_base()
     Base.prepare(conn)

--- a/spinedb_api/alembic/versions/1e4997105288_separate_type_from_value.py
+++ b/spinedb_api/alembic/versions/1e4997105288_separate_type_from_value.py
@@ -23,7 +23,7 @@ LONGTEXT_LENGTH = 2**32 - 1
 
 def upgrade():
     conn = op.get_bind()
-    Session = sessionmaker(bind=conn)
+    Session = sessionmaker(bind=conn, future=True)
     session = Session()
     Base = automap_base()
     Base.prepare(conn)

--- a/spinedb_api/alembic/versions/39e860a11b05_add_alternatives_and_scenarios.py
+++ b/spinedb_api/alembic/versions/39e860a11b05_add_alternatives_and_scenarios.py
@@ -125,7 +125,7 @@ def alter_tables_after_update():
 
 def upgrade():
     create_new_tables()
-    Session = sessionmaker(bind=op.get_bind())
+    Session = sessionmaker(bind=op.get_bind(), future=True)
     session = Session()
     Base = automap_base()
     Base.prepare(op.get_bind())

--- a/spinedb_api/alembic/versions/989fccf80441_replace_values_with_reference_to_list_.py
+++ b/spinedb_api/alembic/versions/989fccf80441_replace_values_with_reference_to_list_.py
@@ -23,7 +23,7 @@ depends_on = None
 
 def upgrade():
     conn = op.get_bind()
-    Session = sessionmaker(bind=conn)
+    Session = sessionmaker(bind=conn, future=True)
     session = Session()
     meta = MetaData()
     meta.reflect(conn)

--- a/spinedb_api/db_mapping.py
+++ b/spinedb_api/db_mapping.py
@@ -196,7 +196,7 @@ class DatabaseMapping(DatabaseMappingQueryMixin, DatabaseMappingCommitMixin, Dat
             return None
         self._context_open_count += 1
         if self._session is None:
-            self._session = Session(self.engine)
+            self._session = Session(self.engine, future=True)
         return self
 
     def __exit__(self, _exc_type, _exc_val, _exc_tb):

--- a/spinedb_api/spine_io/exporters/sql_writer.py
+++ b/spinedb_api/spine_io/exporters/sql_writer.py
@@ -9,10 +9,7 @@
 # Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
-"""
-Module contains an SQL writer implementation.
-
-"""
+""" Module contains an SQL writer implementation. """
 from sqlalchemy import Boolean, Column, DateTime, Float, Integer, MetaData, String, Table, create_engine
 from sqlalchemy.orm import Session
 from spinedb_api import parameter_value
@@ -32,11 +29,11 @@ class SqlWriter(Writer):
         self._overwrite_existing = overwrite_existing
         if database.find("://") < 0:
             database = "sqlite:///" + database
-        self._engine = create_engine(database)
+        self._engine = create_engine(database, future=True)
         self._connection = self._engine.connect()
         self._metadata = MetaData()
         self._metadata.reflect(bind=self._engine)
-        self._session = Session(self._engine)
+        self._session = Session(self._engine, future=True)
         self._table_name = None
         self._column_names = None
         self._column_converters = None

--- a/spinedb_api/spine_io/importers/sqlalchemy_connector.py
+++ b/spinedb_api/spine_io/importers/sqlalchemy_connector.py
@@ -45,9 +45,9 @@ class SqlAlchemyConnector(SourceConnection):
             **extras: optional database schema
         """
         self._connection_string = source
-        self._engine = create_engine(source)
+        self._engine = create_engine(source, future=True)
         self._connection = self._engine.connect()
-        self._session = Session(self._engine)
+        self._session = Session(self._engine, future=True)
         self._schema = extras.get("schema")
         self._metadata = MetaData(schema=self._schema)
         self._metadata.reflect(bind=self._engine)

--- a/tests/spine_io/exporters/test_sql_writer.py
+++ b/tests/spine_io/exporters/test_sql_writer.py
@@ -65,11 +65,11 @@ class TestSqlWriter(AssertSuccessTestCase):
                 writer = SqlWriter(str(out_path), overwrite_existing=True)
                 write(db_map, writer, root_mapping)
                 self.assertTrue(out_path.exists())
-                engine = create_engine("sqlite:///" + str(out_path))
+                engine = create_engine("sqlite:///" + str(out_path), future=True)
                 with engine.begin():
                     metadata = MetaData()
                     metadata.reflect(bind=engine)
-                    session = Session(engine)
+                    session = Session(engine, future=True)
                     self.assertIn("table 1", metadata.tables)
                     table = metadata.tables["table 1"]
                     column_names = [str(c) for c in table.c]
@@ -94,11 +94,11 @@ class TestSqlWriter(AssertSuccessTestCase):
                 writer = SqlWriter(str(out_path), overwrite_existing=True)
                 write(db_map, writer, root_mapping)
                 self.assertTrue(out_path.exists())
-                engine = create_engine("sqlite:///" + str(out_path))
+                engine = create_engine("sqlite:///" + str(out_path), future=True)
                 with engine.begin():
                     metadata = MetaData()
                     metadata.reflect(bind=engine)
-                    session = Session(engine)
+                    session = Session(engine, future=True)
                     self.assertIn("table 1", metadata.tables)
                     table = metadata.tables["table 1"]
                     column_names = [str(c) for c in table.c]
@@ -132,11 +132,11 @@ class TestSqlWriter(AssertSuccessTestCase):
                 writer = SqlWriter(str(out_path), overwrite_existing=True)
                 write(db_map, writer, root_mapping)
                 self.assertTrue(out_path.exists())
-                engine = create_engine("sqlite:///" + str(out_path))
+                engine = create_engine("sqlite:///" + str(out_path), future=True)
                 with engine.begin():
                     metadata = MetaData()
                     metadata.reflect(bind=engine)
-                    session = Session(engine)
+                    session = Session(engine, future=True)
                     self.assertIn("table 1", metadata.tables)
                     table = metadata.tables["table 1"]
                     column_names = [str(c) for c in table.c]
@@ -169,11 +169,11 @@ class TestSqlWriter(AssertSuccessTestCase):
                 writer = SqlWriter(str(out_path), overwrite_existing=True)
                 write(db_map, writer, root_mapping)
                 self.assertTrue(out_path.exists())
-                engine = create_engine("sqlite:///" + str(out_path))
+                engine = create_engine("sqlite:///" + str(out_path), future=True)
                 with engine.begin():
                     metadata = MetaData()
                     metadata.reflect(bind=engine)
-                    session = Session(engine)
+                    session = Session(engine, future=True)
                     self.assertIn("table 1", metadata.tables)
                     table = metadata.tables["table 1"]
                     column_names = [str(c) for c in table.c]
@@ -201,11 +201,11 @@ class TestSqlWriter(AssertSuccessTestCase):
                 write(db_map, writer, root_mapping1)
                 write(db_map, writer, root_mapping2)
                 self.assertTrue(out_path.exists())
-                engine = create_engine("sqlite:///" + str(out_path))
+                engine = create_engine("sqlite:///" + str(out_path), future=True)
                 with engine.begin():
                     metadata = MetaData()
                     metadata.reflect(bind=engine)
-                    session = Session(engine)
+                    session = Session(engine, future=True)
                     self.assertIn("oc", metadata.tables)
                     table = metadata.tables["oc"]
                     column_names = [str(c) for c in table.c]
@@ -235,11 +235,11 @@ class TestSqlWriter(AssertSuccessTestCase):
                 writer = SqlWriter(str(out_path), overwrite_existing=False)
                 write(db_map, writer, root_mapping)
                 self.assertTrue(out_path.exists())
-                engine = create_engine("sqlite:///" + str(out_path))
+                engine = create_engine("sqlite:///" + str(out_path), future=True)
                 with engine.begin():
                     metadata = MetaData()
                     metadata.reflect(bind=engine)
-                    session = Session(engine)
+                    session = Session(engine, future=True)
                     self.assertIn("oc", metadata.tables)
                     table = metadata.tables["oc"]
                     column_names = [str(c) for c in table.c]


### PR DESCRIPTION
With this, `spinedb_api` should be ready for SQLAlchemy 2.0.

Resolves #477

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
