### PR TITLE
Catch exceptions from Reader.get_data_iterator()

### DIFF
--- a/spinedb_api/spine_io/importers/reader.py
+++ b/spinedb_api/spine_io/importers/reader.py
@@ -167,7 +167,11 @@ class Reader:
             row_convert_fns = table_row_convert_specs.get(table, {})
             options = table_options.get(table, {})
             table_max_rows = self._resolve_max_rows(options, max_rows)
-            data_source, header = self.get_data_iterator(table, options, table_max_rows)
+            try:
+                data_source, header = self.get_data_iterator(table, options, table_max_rows)
+            except ReaderError as error:
+                errors.append(str(error))
+                continue
             mappings = []
             mapping_names = []
             for named_mapping_spec in named_mapping_specs:

--- a/tests/spine_io/importers/test_reader.py
+++ b/tests/spine_io/importers/test_reader.py
@@ -77,6 +77,29 @@ class TestReader(unittest.TestCase):
         self.assertEqual(len(mappings), 1)
         self.assertEqual(mappings[0], ("alternative mapping", AlternativeMapping(Position.hidden, value="cat")))
 
+    def test_reader_appends_data_iterator_exceptions_to_return_value(self):
+        def raise_exception(*args):
+            raise ReaderError("this is expected")
+
+        reader = Reader(None)
+        reader.get_data_iterator = raise_exception
+        table_mappings = {
+            "table 1": [{"entity mapping": {"mapping": [EntityClassMapping(0).to_dict(), EntityMapping(1).to_dict()]}}]
+        }
+        table_options = {}
+        table_column_convert_specs = {}
+        table_default_column_convert_fns = {}
+        table_row_convert_specs = {}
+        mapped_data, errors = reader.get_mapped_data(
+            table_mappings,
+            table_options,
+            table_column_convert_specs,
+            table_default_column_convert_fns,
+            table_row_convert_specs,
+        )
+        self.assertEqual(errors, ["this is expected"])
+        self.assertEqual(mapped_data, {})
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Errors from `Reader.get_data_iterator()` should be accumulated to the `errors` list in `get_mapped_data()`. Otherwise, import process will get stuck forever in Toolbox.

Re irena-flextool/flextool#242

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
