### PR TITLE
New interface to manage items in DatabaseMapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `item()` method to `DatabaseMapping` that supersedes `get_item()`.
+  The new method takes `MappedTable` instance instead of item type,
+  returns a single `PublicItem`,
+  raises `SpineDBAPIError` on errors
+  and does not support legacy item types like objects or relationships.
+- Added convenience methods such as `entity()` and `entity_class()` that
+  supersede the `get_entity_item()` etc. methods.
+- Added `find()` method to `DatabaseMapping` that supersedes `get_items()`.
+  Its convenience methods are `find_entities()`, `find_entity_classes()` etc.
+- Added `add()` and convenience methods to `DatabaseMapping` that supersede `add_item()`.
+- Added `update()` and convenience methods to `DatabaseMapping` that supersede `update_item()`.
+- Added `remove()` and convenience methods to `DatabaseMapping` that supersede `remove_item()`.
+- Added `add_or_update()` and convenience methods to `DatabaseMapping` that supersede `add_update_item()`.
+
 ### Changed
 
+- `PublicItem.add()`, `PublicItem.update()` and `PublicItem.remove()` do not return an error anymore.
+  Instead, they raise `SpineDBAPIError`.
 - Many modules and classes in `spinedb_api.spine_io.importer` have been renamed for consistency: 'connector'
   is now 'reader'.
 

--- a/docs/source/front_matter.rst
+++ b/docs/source/front_matter.rst
@@ -4,9 +4,9 @@
 .. _SQLAlchemy: http://www.sqlalchemy.org/
 
 
-***************
+************
 Front matter
-***************
+************
 
 Information about the Spine database API project.
 
@@ -26,10 +26,14 @@ under the Spine project.
 Installation
 ------------
 
-Install released versions of Spine database API from the project repository with pip or a similar tool::
+If you have installed `Spine Toolbox <https://github.com/spine-tools/Spine-Toolbox>`_,
+you should readily have Spine database API.
+Just activate the Python environment for Toolbox and you are good to go.
 
-  pip install git+https://github.com/spine-tools/Spine-Database-API.git
+Otherwise, you can install released versions of Spine database API with Pip
+into the current Python environment::
 
+  pip install spinedb-api
 
 Dependencies
 ------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,6 +16,7 @@ Welcome to Spine Database API's documentation!
 
    front_matter
    tutorial
+   user_guide
    db_mapping_schema
    filters
    parameter_value_format

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -3,6 +3,7 @@
 
 .. _SQLAlchemy: http://www.sqlalchemy.org/
 
+.. _tutorial:
 
 ********
 Tutorial
@@ -32,7 +33,7 @@ To create a :class:`.DatabaseMapping`, we just pass the URL of the DB to the cla
         pass
 
 The URL should be formatted following the RFC-1738 standard, as described
-`here <https://docs.sqlalchemy.org/en/13/core/engines.html?highlight=database%20urls#database-urls>`_.
+`here <https://docs.sqlalchemy.org/en/14/core/engines.html?highlight=database%20urls#database-urls>`_.
 
 .. note::
 
@@ -66,42 +67,63 @@ if it does not exists already.
 Adding data
 -----------
 
-To insert data, we use e.g. :meth:`~.DatabaseMapping.add_entity_class_item`, :meth:`~.DatabaseMapping.add_entity_item`,
+To insert data, we use e.g. :meth:`~.DatabaseMapping.add_entity_class`, :meth:`~.DatabaseMapping.add_entity`,
 and so on.
 
-Let's begin the party by adding a couple of entity classes::
+Let's begin the party by adding an entity class::
 
-    db_map.add_entity_class_item(name="fish", description="It swims.")
-    db_map.add_entity_class_item(name="cat", description="Eats fish.")
+    db_map.add_entity_class(name="fish", description="It swims.")
 
-Now let's add a multi-dimensional entity class between the two above. For this we need to specify the class names
-as ``dimension_name_list``::
+The ``add_*`` methods return the added items as instances of :class:`~.PublicItem` that behave like dicts.
+Let's add another entity class and check some of its properties::
 
-    db_map.add_entity_class_item(
-        name="fish__cat",
+    cat_class = db_map.add_entity_class(name="cat", description="Eats fish.")
+    print(f"{cat_class['name']} is known for: {cat_class['description']}")
+
+The insertion methods will raise :class:`~.SpineDBAPIError` if database integrity would be lost
+with the insertion, e.g. if you try to add a duplicate fish class::
+
+    try:
+        db_map.add_entity_class(name="fish")
+    except api.SpineDBAPIError:
+        print("We almost had too many classes of fish.")
+
+Now let's add a multi-dimensional entity class to create a relationship between cat and fish.
+For this we need to specify the class names as ``dimension_name_list``::
+
+    relationship_class = db_map.add_entity_class(
         dimension_name_list=("fish", "cat"),
         description="A fish getting eaten by a cat?",
     )
+    print(f"The generated class name was: {relationship_class['name']}")
+
+In the above, we omitted the ``name`` parameter in which case the multi-dimensional class
+gets named after its dimensions automatically.
+If you do not fancy auto-generated names, just assign the desired value to the ``name`` parameter.
 
 Let's add entities to our zero-dimensional classes::
 
-    db_map.add_entity_item(entity_class_name="fish", name="Nemo", description="Lost (for now).")
-    db_map.add_entity_item(
+    db_map.add_entity(entity_class_name="fish", name="Nemo", description="Lost (for now).")
+    db_map.add_entity(
         entity_class_name="cat", name="Felix", description="The wonderful wonderful cat."
     )
 
 Let's add a multi-dimensional entity to our multi-dimensional class. For this we need to specify the entity names
 as ``element_name_list``::
 
-    db_map.add_entity_item(entity_class_name="fish__cat", element_name_list=("Nemo", "Felix"))
+    relationship = db_map.add_entity(entity_class_name="fish__cat", element_name_list=("Nemo", "Felix"))
+    print(f"The generated entity name was {relationship['name']}")
+
+Similarly to entity classes, multi-dimensional entities are named after their elements in ``element_name_list``
+unless ``name`` is given explicitly.
 
 Let's add a parameter definition for one of our entity classes::
 
-    db_map.add_parameter_definition_item(entity_class_name="fish", name="color")
+    db_map.add_parameter_definition(entity_class_name="fish", name="color")
 
 Finally, let's specify a parameter value for one of our entities::
 
-    db_map.add_parameter_value_item(
+    db_map.add_parameter_value(
         entity_class_name="fish",
         entity_byname=("Nemo",),
         parameter_definition_name="color",
@@ -126,50 +148,74 @@ which is readily available in new databases.
   The data we've added so far is not yet in the DB, but only in an in-memory mapping within our ``db_map`` object.
   Don't worry, we will save it to the DB soon (see `Committing data`_ if you're impatient).
 
-Retrieving data
----------------
+Finding and retrieving data
+---------------------------
 
-To retrieve data, we use e.g. :meth:`~.DatabaseMapping.get_entity_class_item`,
-:meth:`~.DatabaseMapping.get_entity_item`, etc.
+To retrieve existing items, we use e.g. :meth:`~.DatabaseMapping.entity_class`,
+:meth:`~.DatabaseMapping.entity`, etc.
 This implicitly fetches data from the DB
 into the in-memory mapping, if not already there.
 For example, let's find one of the entities we inserted above::
 
-    felix_item = db_map.get_entity_item(entity_class_name="cat", name="Felix")
+    felix_item = db_map.entity(entity_class_name="cat", name="Felix")
     assert felix_item["description"] == "The wonderful wonderful cat."
 
-Above, ``felix_item`` is a :class:`~.PublicItem` object, representing an item.
+Above, ``felix_item`` is an instance of :class:`~.PublicItem`, a dict-like object representing an item.
 
 Let's find our multi-dimensional entity::
 
-    nemo_felix_item = db_map.get_entity_item("entity", entity_class_name="fish__cat", element_name_list=("Nemo", "Felix"))
+    nemo_felix_item = db_map.entity(entity_class_name="fish__cat", element_name_list=("Nemo", "Felix"))
     assert nemo_felix_item["dimension_name_list"] == ('fish', 'cat')
 
 Now let's retrieve our parameter value::
 
-    nemo_color_item = db_map.get_parameter_value_item(
+    nemo_color_item = db_map.parameter_value(
         entity_class_name="fish",
         entity_byname=("Nemo",),
         parameter_definition_name="color",
         alternative_name="Base"
     )
 
-We can use the ``"parsed_value"`` field to access our original value::
+We can use the ``"parsed_value"`` field to access Nemo's color::
 
     nemo_color = nemo_color_item["parsed_value"]
     assert nemo_color == "mainly orange"
 
-To retrieve all the items of a given type, we use :meth:`~.DatabaseMapping.get_items`::
+The above methods return a single item and raise a :class:`~.SpineDBAPIError` if the item is not found::
 
-    assert [entity["entity_byname"] for entity in db_map.get_items("entity")] == [
-        ("Nemo",), ("Felix",), ("Nemo", "Felix")
-    ]
+    try:
+        item = db_map.scenario(name="cats swim, fishes walk")
+    except api.SpineDBAPIError as error:
+        print(f"Failed to retrieve scenario: {error}")
+
+To find multiple items of a given type, we use :meth:`~.DatabaseMapping.find_entities` etc.::
+
+    print("Begin list of all entities:")
+    for entity in db_map.find_entities():
+        print(entity["name"])
+    print("End list.")
+
+The ``find_*`` methods returns all items when called without arguments.
+You can narrow the results by giving keyword arguments.
+Let's find all parameters we have in the fish class::
+
+    for definition in db_map.find_parameter_definitions(entity_class_name="fish"):
+        for entity in db_map.find_entities(entity_class_name="fish"):
+            value_item = db_map.parameter_value(
+                entity_class_name="fish",
+                parameter_definition_name=definition["name"],
+                entity_byname=entity["entity_byname"],
+                alternative_name="Base",
+            )
+            print(f"{definition['name']} of {entity['name']} is {value_item['parsed_value']}")
+
+When no items are found, the ``find_*`` methods return an empty list.
 
 Now you should use the above to try and find Nemo.
 
 .. note::
 
-  Retrieving a large number of items one-by-one using the ``get_*_item()`` function e.g. in a loop
+  Retrieving a large number of items one-by-one using the single item retrieval functions e.g. in a loop
   might be slow since each call may cause a database query.
   Before such operations, it might be wise to prefetch the data.
   For example, before getting a bunch of entity items, you could call
@@ -182,33 +228,76 @@ To update data, we use the :meth:`~.PublicItem.update` method of :class:`~.Publi
 
 Let's rename our fish entity to avoid any copyright infringements::
 
-    db_map.get_entity_item(entity_class_name="fish", name="Nemo").update(name="NotNemo")
+    db_map.entity(entity_class_name="fish", name="Nemo").update(name="NotNemo")
 
 To be safe, let's also change the color::
 
-    db_map.get_parameter_value_item(
+    value_item = db_map.parameter_value(
         entity_class_name="fish",
         entity_byname=("NotNemo",),
         parameter_definition_name="color",
         alternative_name="Base",
-    ).update(parsed_value="not that orange")
+    )
+    value_item.update(parsed_value="not that orange")
+    print(f"{value_item['parameter_definition_name']} of {value_item['entity_byname']} is now {value_item['parsed_value']}")
 
 Note how we need to use the new entity name ``NotNemo`` to retrieve the parameter value
 since we just renamed it.
+
+The above allows modifying any property of an item as long as it makes sense.
+Let's try to turn ``"Felix"`` into something entirely different::
+
+    try:
+        db_map.entity(entity_class_name="cat", name="Felix").update(entity_class_name="ferret")
+    except api.SpineDBAPIError as error:
+        print(f"Failed to turn Felix into ferret: {error}")
+
+An ``update`` method also exists in :class:`.DatabaseMapping`.
+Since our fishes are not encumbered by intellectual property rights anymore,
+let's update the entity class description::
+
+    db_map.update_entity_class(name="fish", description="It swims free of copyrights.")
+
+Note, that if we wanted to update the *name* or any other property that is needed to identify an item this way,
+we must provide its id so :class:`.DatabaseMapping` can find the right item to update.
+Our cat class contains only wonderful cats so let's update its name to reflect the fact::
+
+    cat_class = db_map.entity_class(name="cat")
+    db_map.update_entity_class(id=cat_class["id"], name="wonderful_cat")
+    print(f"The new class name is {cat_class['name']}")
+
+Updating an item directly using the :class:`.DatabaseMapping` instance also updates existing :class:`~.PublicItem` objects.
 
 Removing data
 -------------
 
 You know what, let's just remove the entity entirely.
-To do this we use the :meth:`~.PublicItem.remove` method of :class:`~.PublicItem`::
+To do this we can use the :meth:`~.PublicItem.remove` method of :class:`~.PublicItem`::
 
-    not_nemo = db_map.get_entity_item(entity_class_name="fish", name="NotNemo")
+    not_nemo = db_map.entity(entity_class_name="fish", name="NotNemo")
     not_nemo.remove()
 
 Note that the above call removes items in *cascade*,
 meaning that items that depend on ``"NotNemo"`` will get removed as well.
 We have one such item in the database, namely the ``"color"`` parameter value
 which also gets dropped when the above method is called.
+
+Another way to remove items is to use the ``remove_*`` methods of :class:`.DatabaseMapping`.
+Let's try to remove the ``"color"`` value again.
+This time will raise a :class:`.SpineDBAPIError` because the item has been removed already::
+
+    try:
+        db_map.remove_parameter_value(
+            entity_class_name="fish",
+            parameter_definition_name="color",
+            entity_byname=not_nemo["entity_byname"],
+            alternative_name="Base",
+        )
+    except SpineDBAPIError as error:
+        print(f"Failed to remove value a second time: {error}")
+
+Perhaps surprisingly, we could still use the ``not_nemo`` item above to provide the ``entity_byname`` argument.
+As we will soon see, it is sometimes useful to keep the dead around.
 
 Restoring data
 --------------
@@ -222,14 +311,6 @@ The above will also bring back the ``"color"`` parameter value.
 
 Luckily, we stored ``"NotNemo"`` in a variable ``not_nemo`` before removing it
 so it was possible to call :meth:`~.PublicItem.restore` on it.
-What if you had removed ``"NotNemo"`` with the following::
-
-   db_map.get_entity_item(entity_class_name="fish", name="NotNemo").remove()
-
-It is still possible to access removed items by passing ``skip_removed=False`` to the ``get_*_item()`` methods::
-
-   not_nemo = db_map.get_entity_item(entity_class_name="fish", name="NotNemo", skip_removed=False)
-   not_nemo.restore()
 
 Committing data
 ---------------

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -1,0 +1,409 @@
+.. _user_guide:
+
+**********
+User guide
+**********
+
+It is recommended to go through the :ref:`tutorial` if you have not already
+to get a grasp of the basic concepts of Spine Database API.
+
+The code snippets in this chapter expect you to have imported :mod:`spinedb_api` as :literal:`api`.
+
+Using an existing database
+--------------------------
+
+If you have a URL of an existing Spine database, you can create a database mapping by::
+
+    with api.DatabaseMapping(url) as db_map:
+        ...
+
+The URL can be a string or an :class:`sqlalchemy.engine.url.URL` object.
+Currently supported URL schemas are :literal:`sqlite` and :literal:`mysql`.
+Note, that absolute file paths to SQLite files on Windows systems require an extra :literal:`/` before the path::
+
+    url = "sqlite:///C:\\path\\to\\database.sqlite"
+
+:class:`.DatabaseMapping` raises a :class:`~.SpineDBAPIError`
+if it fails to open the database.
+If the exception is :class:`~.SpineDBVersionError` then the database is not compatible with
+the current version of :mod:`spinedb_api`.
+In this case the database can be migrated to the latest schema version with the :literal:`upgrade` flag::
+
+    with api.DatabaseMapping(url, upgrade=True) as db_map:
+        ...
+
+Optionally, you can back up the database before the upgrade::
+
+    backup_url = "sqlite:///c:\\backups\\database.sqlite"
+    with api.DatabaseMapping(url, upgrade=True, backup_url=backup_url):
+        ...
+
+Creating a new database
+-----------------------
+
+A new database can be created with the :literal:`create` flag::
+
+    with api.DatabaseMapping(url, create=True) as db_map:
+        ...
+
+The flag has no effect if the URL points to an existing Spine database.
+The contents of such databases will be spared.
+
+.. warning::
+
+    If an existing database contains tables that are not in the Spine database schema, the tables will be dropped
+    when ``create=True``.
+
+.. note::
+
+    Freshly created Spine databases are otherwise empty except for an alternative called *Base*
+    and a corresponding commit.
+
+For a hassle-free experience, you may want to use both ``create`` and ``upgrade`` flags
+which create a new database if it does not exist
+and upgrade it automatically if it does::
+
+    with api.DatabaseMapping(url, create=True, upgrade=True):
+        ...
+
+Sometimes it is useful to have a temporary in-memory database for testing purposes.
+Such a database can be created with a special URL::
+
+    with api.DatabaseMapping("sqlite://", create=True) as db_map:
+        ...
+
+The in-memory database will vanish when the ``with`` block ends.
+
+About items
+-----------
+
+The public methods of :class:`.DatabaseMapping` often return :class:`~.PublicItem` objects.
+These are dict-like objects that are backed by the :class:`.DatabaseMapping`.
+They are dynamic:
+all updates to the :class:`.DatabaseMapping` are instantly seen by its :class:`~.PublicItem` objects.
+
+The values of an item can be accessed with the usual subscript operator::
+
+    with api.DatabaseMapping(url) as db_map:
+        alternative = db_map.alternative(name="Base")
+        name = alternative["name"]
+        description = alternative["description"]
+
+A :class:`~.PublicItem` can be converted to regular dict by its :meth:`~.PublicItem._asdict` method.
+
+While it is not possible to set the values of a :class:`~.PublicItem` with the subscript operator,
+its :meth:`~.PublicItem.update` method will do the job::
+
+    with api.DatabaseMapping(url) as db_map:
+        alternative = db_map.alternative(name="Base")
+        alternative.update(description="Contains data common to all scenarios.")
+
+Refer to `Updating items`_ for updating items directly with :class:`.DatabaseMapping`.
+
+The item can be removed from :class:`.DatabaseMapping` with :meth:`~.PublicItem.remove`
+and restored back with :meth:`~.PublicItem.restore`.
+A removed item is also *invalid*::
+
+    with api.DatabaseMapping(url) as db_map:
+        alternative = db_map.alternative(name="Base")
+        alternative.remove()
+        assert not alternative.is_valid()
+        alternative.restore()
+        assert alternative.is_valid()
+
+Refer to `Removing items and purging`_ and `Restoring items`_ for removing and restoring items directly with :class:`.DatabaseMapping`.
+
+.. note::
+
+    Items of the *commit* type are special:
+    they cannot be added, updated or removed.
+    Commits are added to :class:`.DatabaseMapping` automatically
+    when saving changes with the :meth:`.DatabaseMapping.commit_session` method.
+
+Unique keys and ids
+-------------------
+
+There is two ways of identifying an item in :class:`.DatabaseMapping`: *unique key* and *id*.
+Any item can be identified by either of those.
+
+Unique key means the names or records that are needed to identify an item uniquely.
+It comes from the uniqueness constraints of the Spine database schema.
+For example, an entity class can be identified solely by its name.
+However, to identify an entity, both its name and its entity class' name are required
+since entity names are unique only within a class.
+Unique keys are global in the sense that they can be used interchangeably between different :class:`.DatabaseMapping` instances.
+
+Ids, on the other hand, are negative integers that identify an item directly.
+Unlike unique keys, they are specific to a :class:`.DatabaseMapping` instance.
+An entity id in one :class:`.DatabaseMapping` may refer to a different entity or be absent in another :class:`DatabaseMapping`.
+The ids are represented by :class:`~.TempId` objects
+and can be accessed by the ``"id"`` field of :class:`~.PublicItem`::
+
+    with api.DatabaseMapping(url) as db_map:
+        alternative = db_map.alternative(name="Base")
+        item_id = alternative["id"]
+        db_map.update_alternative(id=item_id, description="Basis of all scenarios.")
+
+.. note::
+
+    The ids used by :class:`.DatabaseMapping` objects are not equal to whatever ids the backing database may have.
+    A :class:`DatabaseMapping` may contain items that have not yet been committed to a database but still need an id.
+    If needed, the database id can be accesses using the :attr:`~.TempId.db_id` property of :class:`~.TempId`.
+
+Which identification method should be used, then?
+Unique keys are the only way when the id is not known.
+A specific case is before an id has been assigned, i.e. before adding an item to :class:`.DatabaseMapping`.
+Also, when accessing the same item in multiple instances of :class:`.DatabaseMapping`
+a unique key must be used.
+However, unique keys need a complex lookup and are therefore slower to use than ids.
+If performance is a priority, ids should be preferred.
+They may also result in simpler code,
+e.g. the unique key for parameter values consists of
+entity class name, entity byname, parameter definition name and alternative name
+whereas their ids are just single entries.
+
+.. note::
+
+    If id is given to any :class:`.DatabaseMapping` method that accepts it,
+    it will be used over any other keyword arguments given to the method.
+    This allows, for example, renaming items with the update methods
+    since the ``name``, which is usually the unique key, can then be used as the new name.
+
+Finding items
+-------------
+
+The simplest way of getting a specific item out of a :class:`.DatabaseMapping` is to use one of its convenience methods::
+
+    with api.DatabaseMapping(url) as db_map:
+        spoon = db_map.entity(entity_class_name="utensil", name="spoon")
+
+A full unique key or id must be provided as keyword arguments to identify the item.
+:class:`~.SpineDBAPIError` will be raised if the item is not found.
+
+:meth:`.DatabaseMapping.find` and its convenience methods are useful
+when searching for multiple items or when the full unique key is not available::
+
+    with api.DatabaseMapping(url) as db_map:
+        utensils = db_map.find_entities(entity_class_name="utensil")
+        for utensil in utensils:
+            print(f"{utensil['name']}: {utensil['description']}")
+
+The find methods return lists of all items of given type when called without keyword arguments.
+For example, this gives all parameter definition items::
+
+    with api.DatabaseMapping(url) as db_map:
+        all_definitions = db_map.find_parameter_definitions()
+
+It is also possible to search using other fields than unique keys::
+
+    with api.DatabaseMapping(url) as db_map:
+        pointy_items = db_map.find_entities(description="Pointy one.")
+        print("Pointy items:")
+        for item in pointy_items:
+            print(item["name"])
+
+Bare :meth:`.DatabaseMapping.find` might be useful when more generic programming is required::
+
+    with api.DatabaseMapping(url) as db_map:
+        stuff = {}
+        for item_type in ("scenario", "alternative"):
+            table = db_map.mapped_table(item_type)
+            stuff[item_type] = db_map.find(table)
+
+Adding items
+------------
+
+Adding just a few item is best done using the convenience methods::
+
+    with api.DatabaseMapping(url) as db_map:
+        db_map.add_entity_class(name="utensil")
+        db_map.add_entity(entity_class_name="utensil", name="spoon")
+
+Methods that add a single item return the added item as :class:`PublicItem`.
+
+Multiple items can be added using the pluralized convenience methods::
+
+    with api.DatabaseMapping(url) as db_map:
+        db_map.add_entity_class(name="utensil")
+        db_map.add_entities(
+            [
+                {"entity_class_name": "utensil", "name": "spoon"},
+                {"entity_class_name": "utensil", "name": "fork", "description": "Spiky one."}
+            ]
+        )
+
+The common entries in the dicts above can be given as keyword arguments::
+
+    with api.DatabaseMapping(url) as db_map:
+        db_map.add_entity_class(name="utensil")
+        db_map.add_entities(
+            [{"name": "spoon"}, {"name": "fork", "description": "Spiky one."}],
+            entity_class_name="utensil"
+        )
+
+
+The pluralized add methods may not be ideal e.g. when you have the items types available as strings.
+In this case you can use :meth:`.DatabaseMapping.add` directly::
+
+    with api.DatabaseMapping(url) as db_map:
+        additional_items = {
+            "entity_class": [{"name": "utensil"}],
+            "entity": [
+                {"entity_class_name": "utensil", "name": "spoon"},
+                {"entity_class_name": "utensil", "name": "fork", "description": "Spiky one."}
+            ],
+        }
+        for item_type, items in additional_items.items():
+            table = db_map.mapped_table(item_type)
+            for item in items:
+                db_map.add(table, **item)
+
+The methods that add a single item also return the added item as :class:`~.PublicItem`.
+
+All methods that add items will raise :class:`~.SpineDBAPIError` if something goes wrong,
+e.g. when adding a duplicate item.
+
+.. note::
+
+    Items can be added only when the items they depend on are already in the database mapping.
+    For example, an entity class must exist before entities can be added to it.
+
+Updating items
+--------------
+
+Besides the :meth:`~.PublicItem.update` method of :class:`~.PublicItem` discussed in `About items`_,
+:class:`.DatabaseMapping` offers methods to update and modify items.
+
+Single items can be updated with the convenience update methods::
+
+    with api.DatabaseMapping(url) as db_map:
+        db_map.update_entity_class(name="utensil", description="Tools for eating.")
+
+In the above, ``name`` is used as a unique key to find the entity class item.
+If the unique key is going to be modified, the id of the item must be used for identification::
+
+    with api.DatabaseMapping(url) as db_map:
+        entity_class = db_map.entity_class(name="utensil")
+        db_map.update_entity_class(id=entity_class["id"], name="tableware")
+
+The methods that update a single single also return that item as :class:`PublicItem`.
+
+The pluralized update methods allow updating multiple items in one go.
+Update data is supplied as list of dicts and common entries can optionally be given as keyword arguments::
+
+    with api.DatabaseMapping(url) as db_map:
+        new_weights = [
+            {"entity_byname": ("fork",), "alternative_name": "Base", "parsed_value": 0.02},
+            {"entity_byname": ("fork",), "alternative_name": "heavy_pointy_things", "parsed_value": 0.03},
+            {"entity_byname": ("spoon",), "alternative_name": "Base", "parsed_value": 0.02},
+        ]
+        db_map.update_parameter_values(
+            new_weights,
+            entity_class_name="utensil",
+            parameter_definition_name="weight",
+        )
+
+Under the hood, every update method uses :meth:`.DatabaseMapping.update`.
+Sometimes it makes sense to use it directly::
+
+    description_updates = {
+        "alternative": [
+            {"name": "heavy_pointy_things", "description": "Forks made of wolfram?"}
+        ],
+        "scenario": [
+            {"name": "all_things_wolfram", "description": "When eating becomes a workout."},
+        ],
+    }
+    with api.DatabaseMapping(url) as db_map:
+        for item_type, updates in description_update.items():
+            table = db_map.mapped_table(item_type)
+            for update in updates:
+                db_map.update(table, **update)
+
+The update methods will raise :class:`~.SpineDBAPIError` in case of errors.
+
+Flexible adds/updates
+---------------------
+
+Sometimes there is need to modify an item and, if it does not exists, create it.
+This common operation is somewhat tedious with the update and add methods.
+Therefore, :class:`.DatabaseMapping` provides :meth:`.DatabaseMapping.add_or_update`
+and its convenience methods.
+They work much like the add and update methods described above.
+
+Removing items and purging
+--------------------------
+
+.. note::
+
+    Items are removed in *cascade* meaning that all items that depend on the removed item are also removed.
+
+If you have an instance of :class:`~.PublicItem`, you can just call its :meth:`~.PublicItem.remove` method
+to remove it as discussed in `About items`_,
+:class:`.DatabaseMapping` has further methods to remove items::
+
+    with api.DatabaseMapping(url) as db_map:
+        db_map.remove_entity(entity_class_name="cutlery", name="spoon")
+
+Pluralized versions of the convenience methods are useful when removing multiple items::
+
+    with api.DatabaseMapping(url) as db_map:
+        db_map.remove_entities([{"name": "fork"}, {"name": "spoon"}], entity_class_name="cutlery")
+
+The base :meth:`.DatabaseMapping.remove` is sometimes useful as well::
+
+    for_removal = {
+        "alternative": ["heavy_pointy_things", "dull_pointy_things"],
+        "scenario": ["all_things_wolfram",],
+    }
+    with api.DatabaseMapping(url) as db_map:
+        for item_type, names in for_removal.items():
+            table = db_map.mapped_table(item_type)
+            for name in names:
+                db_map.remove(table, name=name)
+
+The remove methods will raise :class:`~.SpineDBAPIError` if the item is not found.
+
+Restoring items
+---------------
+
+While :class:`~.PublicItem` offers the :meth:`~.PublicItem.restore` method,
+also :class:`.DatabaseMapping` has ways to restore removed items::
+
+    with api.DatabaseMapping(url) as db_map:
+        spoon = db_map.entity(entity_class_name="cutlery", name="spoon")
+        spoon.remove()
+        db_map.restore_entity(id=spoon["id"])
+
+The restore methods return the restored item as :class:`~.PublicItem`.
+
+Multiple items can be restored in a single call with the pluralized methods::
+
+    removed_cutlery = ["spoon", "fork"]
+    with api.DatabaseMapping(url) as db_map:
+        items_to_restore = [{"name": name} for name in removed_cutlery]
+        db_map.restore_entities(items_to_restore, entity_class_name="cutlery")
+
+The base :meth:`.DatabaseMapping.restore` can be used too::
+
+    with api.DatabaseMapping(url) as db_map:
+        table = db_map.mapped_table("entity")
+        db_map.restore(table, entity_class_name="cutlery", name="fork")
+
+The restore methods will raise :class:`~.SpineDBAPIError` in case the operation failed.
+
+Committing changes
+------------------
+
+No changes are made to the backing database unless explicitly committed with :meth:`.DatabaseMapping.commit_session`.
+The method requires a commit message which should describe the changes.
+Most items have a *commit_id* property that references the commit item of their last modification.
+This excludes structural items such as entity classes.
+
+:meth:`.DatabaseMapping.commit_session` returns a data structure that describes any compatibility transforms
+that took place during the commit
+such as replacing the legacy ``"is_active"`` flags by entity alternatives.
+This structure has some specialized uses in Spine Toolbox and can usually be ignored.
+
+:meth:`.DatabaseMapping.commit_session` raises :class:`NothingToCommit` when there are no changes to save.
+Other errors raise :class:`SpineDBAPIError`.

--- a/tests/test_db_mapping_interface.py
+++ b/tests/test_db_mapping_interface.py
@@ -1,0 +1,192 @@
+######################################################################################################################
+# Copyright (C) 2017-2022 Spine project consortium
+# Copyright Spine Database API contributors
+# This file is part of Spine Database API.
+# Spine Database API is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+# General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+# Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+######################################################################################################################
+import unittest
+from spinedb_api import DatabaseMapping, SpineDBAPIError
+
+
+class TestItem(unittest.TestCase):
+    def test_normal_operation(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            mapped_table = db_map.mapped_table("alternative")
+            alternative = db_map.item(mapped_table, name="Base")
+            self.assertEqual(alternative["name"], "Base")
+
+    def test_raises_when_find_args_are_wrong(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            with self.assertRaisesRegex(SpineDBAPIError, "no such item"):
+                mapped_table = db_map.mapped_table("alternative")
+                db_map.item(mapped_table, name="non-existent")
+
+    def test_does_not_return_removed_item(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            mapped_table = db_map.mapped_table("alternative")
+            db_map.item(mapped_table, name="Base").remove()
+            with self.assertRaisesRegex(SpineDBAPIError, "no such item"):
+                db_map.item(mapped_table, name="Base")
+
+
+class TestAdd(unittest.TestCase):
+    def test_normal_operation(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            mapped_table = db_map.mapped_table("alternative")
+            alternative = db_map.add(mapped_table, name="new", description="New alternative.")
+            self.assertEqual(alternative["name"], "new")
+            self.assertEqual(alternative["description"], "New alternative.")
+            alternative_in_mapping = db_map.alternative(name="new")
+            self.assertEqual(alternative, alternative_in_mapping)
+
+    def test_raises_when_item_is_wrong(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            with self.assertRaisesRegex(SpineDBAPIError, "missing name"):
+                mapped_table = db_map.mapped_table("alternative")
+                db_map.add(mapped_table, entity_class="new")
+
+
+class TestAddByType(unittest.TestCase):
+    def test_normal_operation(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            added = db_map.add_by_type("alternative", name="new")
+            self.assertEqual(added.item_type, "alternative")
+            self.assertEqual(added["name"], "new")
+            item = db_map.alternative(name="new")
+            self.assertEqual(item["name"], "new")
+
+
+class TestApplyManyByType(unittest.TestCase):
+    def test_apply_add(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            db_map.apply_many_by_type("alternative", "add", [{"name": "new"}])
+            item = db_map.alternative(name="new")
+            self.assertEqual(item["name"], "new")
+
+
+class TestFind(unittest.TestCase):
+    def test_returns_empty_list_when_no_items_exist(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            mapped_table = db_map.mapped_table("entity")
+            found = db_map.find(mapped_table)
+            self.assertEqual(found, [])
+
+    def test_returns_found_items(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            mapped_table = db_map.mapped_table("alternative")
+            found = db_map.find(mapped_table, name="Base")
+            self.assertEqual(len(found), 1)
+            self.assertEqual(found[0]["name"], "Base")
+
+    def test_returns_all_items(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            db_map.add_alternative(name="new")
+            mapped_table = db_map.mapped_table("alternative")
+            found = db_map.find(mapped_table)
+            self.assertEqual(len(found), 2)
+            self.assertCountEqual([i["name"] for i in found], ["Base", "new"])
+
+
+class TestFindByType(unittest.TestCase):
+    def test_returns_entities_of_class(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            db_map.add_entity_class(name="Object")
+            db_map.add_entities([{"name": "gadget"}, {"name": "widget"}], entity_class_name="Object")
+            db_map.add_entity_class(name="Subject")
+            db_map.add_entities([{"name": "mockup"}, {"name": "slush"}], entity_class_name="Subject")
+            entities = db_map.find_by_type("entity", entity_class_name="Object")
+            self.assertCountEqual([entity["name"] for entity in entities], ["widget", "gadget"])
+
+
+class TestUpdate(unittest.TestCase):
+    def test_update_alternative_description(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            alternative = db_map.add_alternative(name="new")
+            mapped_table = db_map.mapped_table("alternative")
+            updated = db_map.update(mapped_table, name="new", description="Updated description.")
+            self.assertEqual(updated["name"], "new")
+            self.assertEqual(updated["description"], "Updated description.")
+            self.assertEqual(alternative["name"], "new")
+            self.assertEqual(alternative["description"], "Updated description.")
+
+
+class TestAddOrUpdate(unittest.TestCase):
+    def test_adds_alternative_if_it_doesnt_exist(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            mapped_table = db_map.mapped_table("alternative")
+            alternative = db_map.add_or_update(mapped_table, name="new", description="New alternative.")
+            self.assertEqual(alternative["name"], "new")
+            self.assertEqual(alternative["description"], "New alternative.")
+
+    def test_updates_existing_alternative(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            added = db_map.add_alternative(name="new", description="New alternative.")
+            mapped_table = db_map.mapped_table("alternative")
+            updated = db_map.add_or_update(mapped_table, name="new", description="Modified description.")
+            self.assertEqual(updated["name"], "new")
+            self.assertEqual(updated["description"], "Modified description.")
+            self.assertEqual(added["name"], "new")
+            self.assertEqual(added["description"], "Modified description.")
+
+
+class TestRemove(unittest.TestCase):
+    def test_removes_item(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            db_map.add_alternative(name="new")
+            mapped_table = db_map.mapped_table("alternative")
+            db_map.remove(mapped_table, name="new")
+            alternatives = db_map.find_alternatives(name="new")
+            self.assertEqual(alternatives, [])
+
+    def test_raises_when_items_doesnt_exist(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            mapped_table = db_map.mapped_table("alternative")
+            with self.assertRaisesRegex(SpineDBAPIError, "no such item"):
+                db_map.remove(mapped_table, name="non-existent")
+
+
+class TestRestore(unittest.TestCase):
+    def test_restore_by_id(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            item = db_map.add_scenario(name="new")
+            item.remove()
+            self.assertFalse(item.is_valid())
+            mapped_table = db_map.mapped_table("scenario")
+            db_map.restore(mapped_table, id=item["id"])
+            self.assertTrue(item.is_valid())
+
+    def test_restore_by_unique_key(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            item = db_map.add_scenario(name="new")
+            item.remove()
+            self.assertFalse(item.is_valid())
+            mapped_table = db_map.mapped_table("scenario")
+            db_map.restore(mapped_table, name="new")
+            self.assertTrue(item.is_valid())
+
+    def test_raises_if_id_is_not_found(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            item = db_map.add_scenario(name="new")
+            item.remove()
+            self.assertFalse(item.is_valid())
+            mapped_table = db_map.mapped_table("scenario")
+            with self.assertRaisesRegex(SpineDBAPIError, "failed to restore item"):
+                db_map.restore(mapped_table, id=99)
+
+    def test_raises_if_unique_key_is_wrong(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            item = db_map.add_scenario(name="new")
+            item.remove()
+            self.assertFalse(item.is_valid())
+            mapped_table = db_map.mapped_table("scenario")
+            with self.assertRaisesRegex(SpineDBAPIError, "no such item"):
+                db_map.restore(mapped_table, name="non-existent")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds simplified methods to add, find, update, remove and restore items in `DatabaseMapping`. The old methods remain for backwards compatibility.

Resolves spine-tools/Spine-Toolbox#2754

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
