### PR TITLE
Fix export_entities()

### DIFF
--- a/spinedb_api/export_functions.py
+++ b/spinedb_api/export_functions.py
@@ -164,7 +164,7 @@ def export_entity_class_display_modes(db_map, ids=Asterisk):
 def export_entities(db_map, ids=Asterisk):
     return sorted(
         (
-            (x.entity_class_name, x.element_name_list or x.name, x.description)
+            (x.entity_class_name, x.entity_byname if x.element_name_list else x.name, x.description)
             for x in _get_items(db_map, "entity", ids)
         ),
         key=lambda x: (0 if isinstance(x[1], str) else len(x[1]), x[0], (x[1],) if isinstance(x[1], str) else x[1]),


### PR DESCRIPTION
`export_entities()` was writing element_name_list to the output while `import_entities()` requires entity_byname instead.

No associated issue.

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [ ] Unit tests pass
