### PR TITLE
trigger spineopt

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -86,3 +86,14 @@ jobs:
       spinedb-api-ref-name: ${{ github.ref_name }}
       coverage: false
     secrets: inherit
+  call-spine-opt-test:
+    name: SpineOpt.jl test
+    uses: spine-tools/SpineOpt.jl/.github/workflows/ci.yml@master
+    with:
+      host-os: ubuntu-latest
+      julia-version: "1"
+      python-version: "3.13"
+      repository: spine-tools/SpineOpt.jl
+      spinedb-api-ref-name: ${{ github.ref_name }}
+      coverage: false
+    secrets: inherit

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -88,7 +88,7 @@ jobs:
     secrets: inherit
   call-spine-opt-test:
     name: SpineOpt.jl test
-    uses: spine-tools/SpineOpt.jl/.github/workflows/Test.yml@spinedbapitrigger
+    uses: spine-tools/SpineOpt.jl/.github/workflows/Test.yml@21713b7cdda827ec3c5fb8643f42135192dc3060
     with:
       host-os: ubuntu-latest
       julia-version: "1"

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -88,7 +88,7 @@ jobs:
     secrets: inherit
   call-spine-opt-test:
     name: SpineOpt.jl test
-    uses: spine-tools/SpineOpt.jl/.github/workflows/Test.yml@master
+    uses: spine-tools/SpineOpt.jl/.github/workflows/Test.yml@spinedbapitrigger
     with:
       host-os: ubuntu-latest
       julia-version: "1"

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -88,7 +88,7 @@ jobs:
     secrets: inherit
   call-spine-opt-test:
     name: SpineOpt.jl test
-    uses: spine-tools/SpineOpt.jl/.github/workflows/Test.yml@21713b7cdda827ec3c5fb8643f42135192dc3060
+    uses: spine-tools/SpineOpt.jl/.github/workflows/Test.yml@master
     with:
       host-os: ubuntu-latest
       julia-version: "1"

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -88,7 +88,7 @@ jobs:
     secrets: inherit
   call-spine-opt-test:
     name: SpineOpt.jl test
-    uses: spine-tools/SpineOpt.jl/.github/workflows/ci.yml@master
+    uses: spine-tools/SpineOpt.jl/.github/workflows/Test.yml@master
     with:
       host-os: ubuntu-latest
       julia-version: "1"


### PR DESCRIPTION
Changes in spine db api should trigger SpineOpt tests to ensure that SpineOpt remains functional. The trigger in this commit is heavily inspired by the one that was already there for SpineInterface.
