### PR TITLE
Fix database mapping reset

### DIFF
--- a/spinedb_api/db_mapping.py
+++ b/spinedb_api/db_mapping.py
@@ -36,7 +36,7 @@ from .compatibility import compatibility_transformations
 from .db_mapping_base import DatabaseMappingBase, MappedItemBase, MappedTable, PublicItem, Status
 from .db_mapping_commit_mixin import DatabaseMappingCommitMixin
 from .db_mapping_query_mixin import DatabaseMappingQueryMixin
-from .exception import NothingToCommit, SpineDBAPIError, SpineDBVersionError, SpineIntegrityError
+from .exception import NothingToCommit, NothingToRollback, SpineDBAPIError, SpineDBVersionError, SpineIntegrityError
 from .filters.tools import apply_filter_stack, load_filters, pop_filter_configs
 from .helpers import (
     Asterisk,
@@ -1138,7 +1138,7 @@ class DatabaseMapping(DatabaseMappingQueryMixin, DatabaseMappingCommitMixin, Dat
     def rollback_session(self):
         """Discards all the changes from the in-memory mapping."""
         if not self._rollback():
-            raise SpineDBAPIError("Nothing to rollback.")
+            raise NothingToRollback()
         if self._memory:
             self._memory_dirty = False
 

--- a/spinedb_api/db_mapping_base.py
+++ b/spinedb_api/db_mapping_base.py
@@ -235,10 +235,9 @@ class DatabaseMappingBase:
         item_types = set(self.item_types()) if not item_types else set(item_types) & set(self.item_types())
         self._add_descendants(item_types)
         for item_type in item_types:
+            self._mapped_tables[item_type].reset()
             with suppress(KeyError):
-                self._mapped_tables[item_type].clear()
-            with suppress(KeyError):
-                del self._fetched[item_type]
+                self._fetched.clear()
 
     def reset_purging(self):
         """Resets purging status for all item types.
@@ -640,6 +639,11 @@ class MappedTable(dict):
         if current_item:
             current_item.cascade_restore()
         return current_item
+
+    def reset(self):
+        self._ids_by_unique_key_value.clear()
+        self._temp_id_lookup.clear()
+        self.clear()
 
 
 class MappedItemBase(dict):

--- a/spinedb_api/exception.py
+++ b/spinedb_api/exception.py
@@ -87,3 +87,10 @@ class NothingToCommit(SpineDBAPIError):
 
     def __init__(self):
         super().__init__("Nothing to commit.")
+
+
+class NothingToRollback(SpineDBAPIError):
+    """A notification that the session contains no changes."""
+
+    def __init__(self):
+        super().__init__("Nothing to rollback.")


### PR DESCRIPTION
We need to reset mapped tables properly, not just clear them.

No associated issue.

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
