### PR TITLE
Make reader errors optionally non-fatal

### DIFF
--- a/spinedb_api/spine_io/importers/reader.py
+++ b/spinedb_api/spine_io/importers/reader.py
@@ -114,7 +114,7 @@ class Reader:
         data = list(data_iter)
         return data, header
 
-    def resolve_values_for_fixed_position_mappings(self, tables_mappings, table_options):
+    def resolve_values_for_fixed_position_mappings(self, tables_mappings, table_options, reader_error_is_fatal):
         for table, named_mappings in tables_mappings.items():
             parsed_mappings = []
             for mapping_name, root_mapping in named_mappings:
@@ -126,7 +126,12 @@ class Reader:
                     if target_table is None:
                         target_table = table
                     options = table_options.get(target_table, {})
-                    mapping.value = self.get_table_cell(target_table, row, column, options)
+                    try:
+                        mapping.value = self.get_table_cell(target_table, row, column, options)
+                    except ReaderError as error:
+                        if reader_error_is_fatal:
+                            raise error
+                        mapping.value = None
                     mapping.position = Position.hidden
                 parsed_mappings.append((mapping_name, root_mapping))
             tables_mappings[table] = parsed_mappings


### PR DESCRIPTION
It often makes sense to ignore `ReaderError` exceptions in `Reader.resolve_values_for_fixed_position_mapping()`  and set the mapping's value to `None`.

Resolves #503

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
