### PR TITLE
Do not sort pivot table when exporting

### DIFF
--- a/spinedb_api/export_mapping/pivot.py
+++ b/spinedb_api/export_mapping/pivot.py
@@ -9,10 +9,7 @@
 # Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
-"""
-Contains functions and methods to turn a regular export table into a pivot table
-
-"""
+""" Contains functions and methods to turn a regular export table into a pivot table """
 from copy import deepcopy
 from ..mapping import Position, is_pivoted, is_regular, unflatten, value_index
 from .export_mapping import EntityMapping
@@ -167,11 +164,11 @@ def make_pivot(
         values = value_tree()
         if not any(regular_rows.values()) and pivot_header and table:
             # Need a padding column for pivot header.
-            for row_key in sorted(regular_rows.keys()):
+            for row_key in regular_rows.keys():
                 pivot_branch = leaf(values, row_key)
                 yield [None] + [group_fn(leaf(pivot_branch, column_key)) for column_key in pivot_keys]
         else:
-            for row_key in sorted(regular_rows.keys(), key=_convert_elements_to_strings):
+            for row_key in regular_rows.keys():
                 pivot_branch = leaf(values, row_key)
                 row = regular_rows[row_key]
                 row += [group_fn(leaf(pivot_branch, column_key)) for column_key in pivot_keys]

--- a/tests/export_mapping/test_pivot.py
+++ b/tests/export_mapping/test_pivot.py
@@ -200,11 +200,11 @@ class TestPivot(unittest.TestCase):
         pivot_table = list(make_pivot(table, None, 3, [0], [1], [2]))
         expected = [
             [None, "1", "2", "3"],
+            ["A", -1.1, -2.2, None],
+            ["A", -3.3, -4.4, -5.5],
             [None, None, -6.6, None],
             [None, None, -7.7, None],
             [None, None, None, -8.8],
-            ["A", -1.1, -2.2, None],
-            ["A", -3.3, -4.4, -5.5],
             ["C", -9.9, None, None],
         ]
         self.assertEqual(pivot_table, expected)

--- a/tests/spine_io/exporters/test_excel_writer.py
+++ b/tests/spine_io/exporters/test_excel_writer.py
@@ -10,12 +10,13 @@
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
 """ Unit tests for Excel writer. """
+from itertools import zip_longest
 import os.path
 from tempfile import TemporaryDirectory
 import unittest
 from openpyxl import load_workbook
-from spinedb_api import DatabaseMapping, import_object_classes, import_objects
-from spinedb_api.export_mapping import entity_export
+from spinedb_api import DatabaseMapping, Map, import_object_classes, import_objects
+from spinedb_api.export_mapping import entity_export, entity_parameter_value_export
 from spinedb_api.mapping import Position
 from spinedb_api.spine_io.exporters.excel_writer import ExcelWriter
 from spinedb_api.spine_io.exporters.writer import write
@@ -120,6 +121,37 @@ class TestExcelWriter(AssertSuccessTestCase):
                 self.check_sheet(workbook, "oc", expected)
                 workbook.close()
 
+    def test_value_indexes_remain_unsorted(self):
+        with TemporaryDirectory() as temp_dir:
+            with DatabaseMapping("sqlite://", create=True) as db_map:
+                db_map.add_entity_class(name="Sheet1")
+                db_map.add_parameter_definition(entity_class_name="Sheet1", name="z")
+                db_map.add_entity(entity_class_name="Sheet1", name="o1")
+                db_map.add_parameter_value(
+                    entity_class_name="Sheet1",
+                    entity_byname=("o1",),
+                    parameter_definition_name="z",
+                    alternative_name="Base",
+                    parsed_value=Map(["T02", "T01"], [1.1, 1.2]),
+                )
+                db_map.commit_session("Add test data.")
+                root_mapping = entity_parameter_value_export(
+                    Position.table_name, 0, Position.hidden, 1, None, None, 2, 3, 6, [4], [5]
+                )
+                path = os.path.join(temp_dir, "test.xlsx")
+                writer = ExcelWriter(path)
+                write(db_map, writer, root_mapping)
+                workbook = load_workbook(path, read_only=True)
+                try:
+                    self.assertEqual(workbook.sheetnames, ["Sheet1"])
+                    expected = [
+                        ["z", "o1", "Base", "1d_map", "x", "T02", 1.1],
+                        ["z", "o1", "Base", "1d_map", "x", "T01", 1.2],
+                    ]
+                    self.check_sheet(workbook, "Sheet1", expected)
+                finally:
+                    workbook.close()
+
     def check_sheet(self, workbook, sheet_name, expected):
         """
         Args:
@@ -128,7 +160,7 @@ class TestExcelWriter(AssertSuccessTestCase):
             expected (list): expected rows
         """
         sheet = workbook[sheet_name]
-        for row, expected_row in zip(sheet.iter_rows(), expected):
+        for row, expected_row in zip_longest(sheet.iter_rows(), expected):
             values = [cell.value for cell in row]
             self.assertEqual(values, expected_row)
 


### PR DESCRIPTION
We must to keep parameter value indexes in their original order.

No associated issue.

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
