### PR TITLE
Support Asterisk in find()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   supersede the `get_entity_item()` etc. methods.
 - Added `find()` method to `DatabaseMapping` that supersedes `get_items()`.
   Its convenience methods are `find_entities()`, `find_entity_classes()` etc.
+  Also, searching with `Asterisk` is supported.
 - Added `add()` and convenience methods to `DatabaseMapping` that supersede `add_item()`.
 - Added `update()` and convenience methods to `DatabaseMapping` that supersede `update_item()`.
 - Added `remove()` and convenience methods to `DatabaseMapping` that supersede `remove_item()`.

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -172,7 +172,8 @@ whereas their ids are just single entries.
 Finding items
 -------------
 
-The simplest way of getting a specific item out of a :class:`.DatabaseMapping` is to use one of its convenience methods::
+The simplest way of getting a specific item out of a :class:`.DatabaseMapping` is to use one of the convenience methods
+named after the item itself::
 
     with api.DatabaseMapping(url) as db_map:
         spoon = db_map.entity(entity_class_name="utensil", name="spoon")
@@ -201,6 +202,14 @@ It is also possible to search using other fields than unique keys::
         print("Pointy items:")
         for item in pointy_items:
             print(item["name"])
+
+"Anything goes" values inside dimension name lists, entity bynames and other list-like fields
+can be replaced with the ``Asterisk`` placeholder::
+
+    with api.DatabaseMapping(url) as db_map:
+        utensil_relationship_classes = db_map.find_entity_classes(
+            dimension_name_list=[api.helpers.Asterisk, "utensil"]
+        )
 
 Bare :meth:`.DatabaseMapping.find` might be useful when more generic programming is required::
 

--- a/spinedb_api/db_mapping.py
+++ b/spinedb_api/db_mapping.py
@@ -525,10 +525,13 @@ class DatabaseMapping(DatabaseMappingQueryMixin, DatabaseMappingCommitMixin, Dat
                     print(f"{entity['name']}: {entity['description']}")
         """
         mapped_table.check_fields(kwargs, valid_types=(type(None),))
+        fetched = self._fetched.get(mapped_table.item_type, -1) == self._get_commit_count()
         if not kwargs:
-            self.do_fetch_all(mapped_table)
+            if not fetched:
+                self.do_fetch_all(mapped_table)
             return [i.public_item for i in mapped_table.values() if i.is_valid()]
-        self._do_fetch_more(mapped_table, offset=0, limit=None, real_commit_count=None, **kwargs)
+        if not fetched:
+            self._do_fetch_more(mapped_table, offset=0, limit=None, real_commit_count=None, **kwargs)
         return [
             i.public_item
             for i in mapped_table.values()

--- a/spinedb_api/db_mapping_base.py
+++ b/spinedb_api/db_mapping_base.py
@@ -12,22 +12,11 @@
 from __future__ import annotations
 from contextlib import suppress
 from difflib import SequenceMatcher
-from enum import Enum, auto, unique
 from typing import ClassVar, Optional, Set
 from .exception import SpineDBAPIError
 from .helpers import Asterisk
+from .mapped_item_status import Status
 from .temp_id import TempId, resolve
-
-
-@unique
-class Status(Enum):
-    """Mapped item status."""
-
-    committed = auto()
-    to_add = auto()
-    to_update = auto()
-    to_remove = auto()
-    added_and_removed = auto()
 
 
 class DatabaseMappingBase:

--- a/spinedb_api/db_mapping_base.py
+++ b/spinedb_api/db_mapping_base.py
@@ -279,22 +279,7 @@ class DatabaseMappingBase:
             self._do_fetch_more(mapped_table, offset=0, limit=None, real_commit_count=commit_count)
 
     def item(self, mapped_table: MappedTable, **kwargs) -> PublicItem:
-        """Returns an item matching the keyword arguments.
-
-        Example::
-
-            with DatabaseMapping(db_url) as db_map:
-                entity_table = db_map.mapped_table("entity")
-                prince = db_map.get_item(entity_table, entity_class_name="musician", name="Prince")
-
-        """
-        item = mapped_table.find_item(kwargs)
-        if not item:
-            self._do_fetch_more(mapped_table, offset=0, limit=None, real_commit_count=None, **kwargs)
-            item = mapped_table.find_item(kwargs)
-        if not item or not item.is_valid():
-            raise SpineDBAPIError("no such item")
-        return item.public_item
+        raise NotImplementedError()
 
 
 class MappedTable(dict):

--- a/spinedb_api/mapped_item_status.py
+++ b/spinedb_api/mapped_item_status.py
@@ -1,0 +1,23 @@
+######################################################################################################################
+# Copyright (C) 2017-2022 Spine project consortium
+# Copyright Spine Database API contributors
+# This file is part of Spine Database API.
+# Spine Database API is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+# General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+# Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+######################################################################################################################
+from enum import Enum, auto, unique
+
+
+@unique
+class Status(Enum):
+    """Mapped item status."""
+
+    committed = auto()
+    to_add = auto()
+    to_update = auto()
+    to_remove = auto()
+    added_and_removed = auto()

--- a/spinedb_api/mapped_items.py
+++ b/spinedb_api/mapped_items.py
@@ -32,11 +32,6 @@ from .parameter_value import (
 )
 from .temp_id import TempId
 
-
-def item_factory(item_type):
-    return ITEM_CLASS_BY_TYPE.get(item_type, MappedItemBase)
-
-
 _ENTITY_BYNAME_VALUE = (
     "A tuple with the entity name as single element if the entity is 0-dimensional, "
     "or the 0-dimensional element names if it is multi-dimensional."

--- a/spinedb_api/mapped_items.py
+++ b/spinedb_api/mapped_items.py
@@ -195,11 +195,11 @@ class EntityItem(MappedItemBase):
     def resolve_internal_fields(self, skip_keys=()):
         """Overridden to translate byname into element name list."""
         super().resolve_internal_fields(skip_keys=skip_keys)
-        byname = dict.pop(self, "entity_byname", None)
-        if byname is None:
+        try:
+            byname = dict.pop(self, "entity_byname")
+        except KeyError:
             return
-        dim_count = len(self["dimension_id_list"])
-        if not dim_count:
+        if not self["dimension_id_list"]:
             self["name"] = byname[0]
             return
         byname_remainder = list(byname)


### PR DESCRIPTION
`DatabaseMapping.find()` now supports `helpers.Asterisk` as an "anything goes" placeholder inside list-like fields (dimension name list, entity byname,...).

Resolves #310

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
