### PR TITLE
512 database import export broken for compound class parameter values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `export_parameter_values` now correctly exports `entity_byname` for compound classes.
+
 ### Security
 
 ## [0.33.0]

--- a/spinedb_api/export_functions.py
+++ b/spinedb_api/export_functions.py
@@ -9,7 +9,7 @@
 # Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
-""" Functions for exporting data from a Spine database in a standard format. """
+"""Functions for exporting data from a Spine database in a standard format."""
 from collections import namedtuple
 from operator import itemgetter
 from .helpers import Asterisk

--- a/spinedb_api/export_functions.py
+++ b/spinedb_api/export_functions.py
@@ -207,7 +207,7 @@ def export_parameter_values(db_map, ids=Asterisk, parse_value=from_database):
         (
             (
                 x.entity_class_name,
-                x.entity_byname if x.element_name_list else x.name,
+                x.entity_byname if x.element_name_list else x.entity_name,
                 x.parameter_name,
                 parse_value(x.value, x.type),
                 x.alternative_name,

--- a/spinedb_api/export_functions.py
+++ b/spinedb_api/export_functions.py
@@ -207,7 +207,7 @@ def export_parameter_values(db_map, ids=Asterisk, parse_value=from_database):
         (
             (
                 x.entity_class_name,
-                x.element_name_list or x.entity_name,
+                x.entity_byname if x.element_name_list else x.name,
                 x.parameter_name,
                 parse_value(x.value, x.type),
                 x.alternative_name,

--- a/tests/test_export_functions.py
+++ b/tests/test_export_functions.py
@@ -159,13 +159,23 @@ class TestExportFunctions(unittest.TestCase):
                 import_object_parameter_values(db_map, [("object_class", "object", "object_parameter", 2.3)])
             )
             self._assert_import_success(import_relationship_classes(db_map, [("relationship_class", ["object_class"])]))
+            self._assert_import_success(import_relationship_classes(db_map, [("compound_class", ["relationship_class", "relationship_class"])]))
             self._assert_import_success(
                 import_relationship_parameters(db_map, [("relationship_class", "relationship_parameter")])
             )
+            self._assert_import_success(
+                import_relationship_parameters(db_map, [("compound_class", "compound_parameter")])
+            )
             self._assert_import_success(import_relationships(db_map, [("relationship_class", ["object"])]))
+            self._assert_import_success(import_relationships(db_map, [("compound_class", ["object", "object"])]))
             self._assert_import_success(
                 import_relationship_parameter_values(
                     db_map, [("relationship_class", ["object"], "relationship_parameter", 3.14)]
+                )
+            )
+            self._assert_import_success(
+                import_relationship_parameter_values(
+                    db_map, [("compound_class", ["object", "object"], "compound_parameter", 2.71)]
                 )
             )
             self._assert_import_success(
@@ -185,24 +195,34 @@ class TestExportFunctions(unittest.TestCase):
             self.assertIn("entity_classes", exported)
             self.assertEqual(
                 exported["entity_classes"],
-                [("object_class", (), None, None, True), ("relationship_class", ("object_class",), None, None, True)],
+                [
+                    ("object_class", (), None, None, True),
+                    ("relationship_class", ("object_class",), None, None, True),
+                    ("compound_class", ("relationship_class", "relationship_class"), None, None, True)
+                ],
             )
             self.assertIn("parameter_definitions", exported)
             self.assertEqual(
                 exported["parameter_definitions"],
                 [
+                    ("compound_class", "compound_parameter", None, None, None),
                     ("object_class", "object_parameter", None, None, None),
                     ("relationship_class", "relationship_parameter", None, None, None),
                 ],
             )
             self.assertIn("entities", exported)
             self.assertEqual(
-                exported["entities"], [("object_class", "object", None), ("relationship_class", ("object",), None)]
+                exported["entities"], [
+                    ("object_class", "object", None),
+                    ("relationship_class", ("object",), None),
+                    ("compound_class", ("object", "object"), None),
+                ]
             )
             self.assertIn("parameter_values", exported)
             self.assertEqual(
                 exported["parameter_values"],
                 [
+                    ("compound_class", ("object", "object"), "compound_parameter", 2.71, "Base"),
                     ("object_class", "object", "object_parameter", 2.3, "Base"),
                     ("relationship_class", ("object",), "relationship_parameter", 3.14, "Base"),
                 ],

--- a/tests/test_export_functions.py
+++ b/tests/test_export_functions.py
@@ -9,7 +9,7 @@
 # Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
-""" Unit tests for export_functions. """
+"""Unit tests for export_functions."""
 
 import unittest
 from spinedb_api import (
@@ -159,7 +159,9 @@ class TestExportFunctions(unittest.TestCase):
                 import_object_parameter_values(db_map, [("object_class", "object", "object_parameter", 2.3)])
             )
             self._assert_import_success(import_relationship_classes(db_map, [("relationship_class", ["object_class"])]))
-            self._assert_import_success(import_relationship_classes(db_map, [("compound_class", ["relationship_class", "relationship_class"])]))
+            self._assert_import_success(
+                import_relationship_classes(db_map, [("compound_class", ["relationship_class", "relationship_class"])])
+            )
             self._assert_import_success(
                 import_relationship_parameters(db_map, [("relationship_class", "relationship_parameter")])
             )
@@ -198,7 +200,7 @@ class TestExportFunctions(unittest.TestCase):
                 [
                     ("object_class", (), None, None, True),
                     ("relationship_class", ("object_class",), None, None, True),
-                    ("compound_class", ("relationship_class", "relationship_class"), None, None, True)
+                    ("compound_class", ("relationship_class", "relationship_class"), None, None, True),
                 ],
             )
             self.assertIn("parameter_definitions", exported)
@@ -212,11 +214,12 @@ class TestExportFunctions(unittest.TestCase):
             )
             self.assertIn("entities", exported)
             self.assertEqual(
-                exported["entities"], [
+                exported["entities"],
+                [
                     ("object_class", "object", None),
                     ("relationship_class", ("object",), None),
                     ("compound_class", ("object", "object"), None),
-                ]
+                ],
             )
             self.assertIn("parameter_values", exported)
             self.assertEqual(


### PR DESCRIPTION
Fixed `export_parameter_values` to correctly export byentities for compound classes.

Fixes #512 

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date _(No need?)_
- [x] Release notes have been updated _(Added a line under "Fixed")_
- [x] Unit tests have been added/updated accordingly _(As far as I knew how)_
- [x] Code has been formatted by black & isort _(I think so? Nor completely sure if I have them correctly formatted or not though)_
- [x] Unit tests pass
