### PR TITLE
Add entity_location table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `update()` and convenience methods to `DatabaseMapping` that supersede `update_item()`.
 - Added `remove()` and convenience methods to `DatabaseMapping` that supersede `remove_item()`.
 - Added `add_or_update()` and convenience methods to `DatabaseMapping` that supersede `add_update_item()`.
+- Entity's location data and shape polygon (as GEOJSON feature) can now be stored in the `entity_location` table.
+  The main entry point to the data is via `EntityItems`'s `lat`, `lon`, `alt`, `shape_name` and `shape_blob`
+  fields.
 
 ### Changed
 
@@ -35,7 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `export_parameter_values` now correctly exports `entity_byname` for compound classes.
+- `export_functions` now correctly exports `entity_byname` for compound classes.
+  It used to export `element_name_list` which is incompatible with `import_functions`.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `update()` and convenience methods to `DatabaseMapping` that supersede `update_item()`.
 - Added `remove()` and convenience methods to `DatabaseMapping` that supersede `remove_item()`.
 - Added `add_or_update()` and convenience methods to `DatabaseMapping` that supersede `add_update_item()`.
-- Entity's location data and shape polygon (as GEOJSON feature) can now be stored in the `entity_location` table.
+- Entity's location data and shape polygon (as GeoJSON feature) can now be stored in the `entity_location` table.
   The main entry point to the data is via `EntityItems`'s `lat`, `lon`, `alt`, `shape_name` and `shape_blob`
   fields.
 

--- a/spinedb_api/alembic/versions/91f1f55aa972_create_entity_location_table.py
+++ b/spinedb_api/alembic/versions/91f1f55aa972_create_entity_location_table.py
@@ -1,0 +1,36 @@
+"""create entity_location table
+
+Revision ID: 91f1f55aa972
+Revises: 7e2e66ae0f8f
+Create Date: 2025-03-18 15:20:36.616427
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "91f1f55aa972"
+down_revision = "7e2e66ae0f8f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "entity_location",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column(
+            "entity_id", sa.Integer, sa.ForeignKey("entity.id", onupdate="CASCADE", ondelete="CASCADE"), nullable=False
+        ),
+        sa.Column("lat", sa.Float),
+        sa.Column("lon", sa.Float),
+        sa.Column("alt", sa.Float),
+        sa.Column("shape_name", sa.String(155)),
+        sa.Column("shape_blob", sa.Text, server_default=sa.null()),
+        sa.UniqueConstraint("entity_id"),
+    )
+
+
+def downgrade():
+    pass

--- a/spinedb_api/db_mapping.py
+++ b/spinedb_api/db_mapping.py
@@ -1323,7 +1323,7 @@ def _add_convenience_methods(node):
         children.setdefault("get", []).append(child)
         child = astroid.extract_node(
             f'''
-            def find_{item_type}(self, **kwargs):
+            def find_{_pluralize(item_type)}(self, **kwargs):
                 """Finds and returns all `{item_type}` items matching the keyword arguments.
 
                 Args:

--- a/spinedb_api/db_mapping.py
+++ b/spinedb_api/db_mapping.py
@@ -130,6 +130,7 @@ class DatabaseMapping(DatabaseMappingQueryMixin, DatabaseMappingCommitMixin, Dat
         "metadata": "metadata_sq",
         "entity_metadata": "entity_metadata_sq",
         "parameter_value_metadata": "parameter_value_metadata_sq",
+        "entity_location": "entity_location_sq",
         "commit": "commit_sq",
     }
 

--- a/spinedb_api/db_mapping_base.py
+++ b/spinedb_api/db_mapping_base.py
@@ -1144,9 +1144,8 @@ class MappedItemBase(dict):
                         invalidate_ref(id_)
                 else:
                     invalidate_ref(src_val)
-        id_ = dict.__getitem__(self, "id")
+        del other["id"]
         super().update(other)
-        self["id"] = id_
         if self._backup is not None:
             backup = self._backup
             as_dict = self._asdict()
@@ -1234,11 +1233,11 @@ class PublicItem:
 
     def update(self, **kwargs) -> Optional[PublicItem]:
         mapped_table = self._mapped_item.db_map.mapped_table(self._mapped_item.item_type)
-        return self._mapped_item.db_map.update(mapped_table, id=self["id"], **kwargs)
+        return self._mapped_item.db_map.update(mapped_table, id=dict.__getitem__(self._mapped_item, "id"), **kwargs)
 
     def remove(self) -> None:
         db_map = self._mapped_item.db_map
-        db_map.remove(db_map.mapped_table(self.item_type), id=self["id"])
+        db_map.remove(db_map.mapped_table(self.item_type), id=dict.__getitem__(self._mapped_item, "id"))
 
     def restore(self) -> PublicItem:
         mapped_table = self._mapped_item.db_map.mapped_table(self.item_type)
@@ -1251,7 +1250,7 @@ class PublicItem:
                 mapped_table.remove_unique(existing_item)
                 self._mapped_item.validate_id()
                 mapped_table.add_unique(self._mapped_item)
-        return self._mapped_item.db_map.restore(mapped_table, id=self["id"])
+        return self._mapped_item.db_map.restore(mapped_table, id=dict.__getitem__(self._mapped_item, "id"))
 
     def add_update_callback(self, callback):
         self._mapped_item.update_callbacks.add(callback)

--- a/spinedb_api/db_mapping_base.py
+++ b/spinedb_api/db_mapping_base.py
@@ -10,9 +10,10 @@
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
 from __future__ import annotations
+from collections.abc import Iterator
 from contextlib import suppress
 from difflib import SequenceMatcher
-from typing import ClassVar, Optional, Set
+from typing import ClassVar, Optional, Set, Union
 from .exception import SpineDBAPIError
 from .helpers import Asterisk
 from .mapped_item_status import Status
@@ -335,7 +336,7 @@ class MappedTable(dict):
             return None
         return mapped_item
 
-    def valid_values(self):
+    def valid_values(self) -> Iterator[MappedItemBase]:
         return (x for x in self.values() if x.is_valid())
 
     def find_item(self, item, skip_keys=(), fetch=True):

--- a/spinedb_api/db_mapping_query_mixin.py
+++ b/spinedb_api/db_mapping_query_mixin.py
@@ -49,6 +49,7 @@ class DatabaseMappingQueryMixin:
         self._superclass_subclass_sq = None
         self._display_mode_sq = None
         self._entity_class_display_mode_sq = None
+        self._entity_location_sq = None
         # Special convenience subqueries that join two or more tables
         self._wide_entity_class_sq = None
         self._wide_entity_sq = None
@@ -378,6 +379,21 @@ class DatabaseMappingQueryMixin:
         if self._entity_class_display_mode_sq is None:
             self._entity_class_display_mode_sq = self._subquery("entity_class_display_mode")
         return self._entity_class_display_mode_sq
+
+    @property
+    def entity_location_sq(self):
+        """A subquery of the form:
+
+        .. code-block:: sql
+
+            SELECT * FROM entity_location
+
+        Returns:
+            :class:`~sqlalchemy.sql.Subquery`
+        """
+        if self._entity_location_sq is None:
+            self._entity_location_sq = self._subquery("entity_location")
+        return self._entity_location_sq
 
     @property
     def alternative_sq(self):

--- a/spinedb_api/export_functions.py
+++ b/spinedb_api/export_functions.py
@@ -161,11 +161,22 @@ def export_entity_class_display_modes(db_map, ids=Asterisk):
 
 
 def export_entities(db_map, ids=Asterisk):
+    data = []
+    if ids is Asterisk:
+        db_map.fetch_all("entity_location")
+    for entity in _get_items(db_map, "entity", ids):
+        exported = (
+            entity["entity_class_name"],
+            entity["entity_byname"] if entity["element_name_list"] else entity["name"],
+            entity["description"],
+        )
+        if entity["entity_location_id"] is not None:
+            exported = exported + (
+                (entity["lat"], entity["lon"], entity["alt"], entity["shape_name"], entity["shape_blob"]),
+            )
+        data.append(exported)
     return sorted(
-        (
-            (x["entity_class_name"], x["entity_byname"] if x["element_name_list"] else x["name"], x["description"])
-            for x in _get_items(db_map, "entity", ids)
-        ),
+        data,
         key=lambda x: (0 if isinstance(x[1], str) else len(x[1]), x[0], (x[1],) if isinstance(x[1], str) else x[1]),
     )
 

--- a/spinedb_api/helpers.py
+++ b/spinedb_api/helpers.py
@@ -636,6 +636,18 @@ def create_spine_metadata():
         UniqueConstraint("entity_id", "metadata_id"),
     )
     Table(
+        "entity_location",
+        meta,
+        Column("id", Integer, primary_key=True),
+        Column("entity_id", Integer, ForeignKey("entity.id", onupdate="CASCADE", ondelete="CASCADE"), nullable=False),
+        Column("lat", Float),
+        Column("lon", Float),
+        Column("alt", Float),
+        Column("shape_name", String(155)),
+        Column("shape_blob", Text, server_default=null()),
+        UniqueConstraint("entity_id"),
+    )
+    Table(
         "alembic_version",
         meta,
         Column("version_num", String(32), nullable=False),

--- a/tests/test_DatabaseMapping.py
+++ b/tests/test_DatabaseMapping.py
@@ -2618,7 +2618,32 @@ class TestDatabaseMapping(AssertSuccessTestCase):
             self.assertEqual(sphere["lat"], 2.3)
             self.assertEqual(sphere["lon"], 3.2)
 
-
+    def test_purge_entity_location_sets_entitys_location_data_to_none(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            db_map.add_entity_class(name="Object")
+            entity = db_map.add_entity(entity_class_name="Object", name="mouse", lat=2.3, lon=3.2)
+            db_map.purge_items("entity_location")
+            self.assertIsNone(entity["lat"])
+            self.assertIsNone(entity["lon"])
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            db_map.add_entity_class(name="Object")
+            entity = db_map.add_entity(entity_class_name="Object", name="mouse", lat=2.3, lon=3.2)
+            self.assertEqual(entity["lat"], 2.3)
+            self.assertEqual(entity["lon"], 3.2)
+            db_map.purge_items("entity_location")
+            self.assertIsNone(entity["lat"])
+            self.assertIsNone(entity["lon"])
+        with TemporaryDirectory() as temp_dir:
+            url = "sqlite:///" + os.path.join(temp_dir, "db.sqlite")
+            with DatabaseMapping(url, create=True) as db_map:
+                db_map.add_entity_class(name="Object")
+                db_map.add_entity(entity_class_name="Object", name="mouse", lat=2.3, lon=3.2)
+                db_map.commit_session("Add test data.")
+            with DatabaseMapping(url) as db_map:
+                db_map.purge_items("entity_location")
+                entity = db_map.entity(entity_class_name="Object", name="mouse")
+                self.assertIsNone(entity["lat"])
+                self.assertIsNone(entity["lon"])
 
 
 class TestDatabaseMappingLegacy(unittest.TestCase):

--- a/tests/test_DatabaseMapping.py
+++ b/tests/test_DatabaseMapping.py
@@ -2347,6 +2347,279 @@ class TestDatabaseMapping(AssertSuccessTestCase):
                 self.assertEqual(db_map.query(db_map.list_value_sq).all(), [])
                 self.assertEqual(db_map.query(db_map.parameter_definition_sq).all(), [])
 
+    def test_add_entity_with_location_data(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            db_map.add_entity_class(name="Object")
+            lat_lon_entity = db_map.add_entity(entity_class_name="Object", name="lat_lon", lat=2.3, lon=3.2)
+            self.assertEqual(lat_lon_entity["lat"], 2.3)
+            self.assertEqual(lat_lon_entity["lon"], 3.2)
+            self.assertEqual(lat_lon_entity["alt"], None)
+            self.assertIsNone(lat_lon_entity["shape_name"])
+            self.assertIsNone(lat_lon_entity["shape_blob"])
+            lat_lon_alt_entity = db_map.add_entity(
+                entity_class_name="Object", name="lat_lon_alt", lat=2.3, lon=3.2, alt=55.0
+            )
+            self.assertEqual(lat_lon_alt_entity["lat"], 2.3)
+            self.assertEqual(lat_lon_alt_entity["lon"], 3.2)
+            self.assertEqual(lat_lon_alt_entity["alt"], 55.0)
+            self.assertIsNone(lat_lon_alt_entity["shape_name"])
+            self.assertIsNone(lat_lon_alt_entity["shape_blob"])
+            shape_blob_and_name_entity = db_map.add_entity(
+                entity_class_name="Object", name="name_shape_blob", shape_name="island", shape_blob="{}"
+            )
+            self.assertIsNone(shape_blob_and_name_entity["lat"])
+            self.assertIsNone(shape_blob_and_name_entity["lon"])
+            self.assertIsNone(shape_blob_and_name_entity["alt"])
+            self.assertEqual(shape_blob_and_name_entity["shape_name"], "island")
+            self.assertEqual(shape_blob_and_name_entity["shape_blob"], "{}")
+            entity = db_map.add_entity(
+                entity_class_name="Object",
+                name="all_data",
+                lat=2.3,
+                lon=-3.2,
+                alt=55.0,
+                shape_name="island",
+                shape_blob="{}",
+            )
+            self.assertEqual(entity["lat"], 2.3)
+            self.assertEqual(entity["lon"], -3.2)
+            self.assertEqual(entity["alt"], 55.0)
+            self.assertEqual(entity["shape_name"], "island")
+            self.assertEqual(entity["shape_blob"], "{}")
+
+    def test_add_entity_with_incomplete_location_data_raises(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            db_map.add_entity_class(name="Object")
+            with self.assertRaisesRegex(SpineDBAPIError, "cannot set latitude without longitude"):
+                db_map.add_entity(entity_class_name="Object", name="gadget", lat=2.3)
+            with self.assertRaisesRegex(SpineDBAPIError, "cannot set longitude without latitude"):
+                db_map.add_entity(entity_class_name="Object", name="gadget", lon=3.2)
+            with self.assertRaisesRegex(SpineDBAPIError, "cannot set altitude without latitude and longitude"):
+                db_map.add_entity(entity_class_name="Object", name="gadget", alt=55.0)
+            with self.assertRaisesRegex(SpineDBAPIError, "cannot set shape_name without shape_blob"):
+                db_map.add_entity(entity_class_name="Object", name="gadget", shape_name="island")
+            with self.assertRaisesRegex(SpineDBAPIError, "cannot set shape_blob without shape_name"):
+                db_map.add_entity(entity_class_name="Object", name="gadget", shape_blob="{}}")
+
+    def test_location_data_available_from_database(self):
+        with TemporaryDirectory() as temp_dir:
+            url = "sqlite:///" + os.path.join(temp_dir, "db.sqlite")
+            with DatabaseMapping(url, create=True) as db_map:
+                db_map.add_entity_class(name="Object")
+                db_map.add_entity(entity_class_name="Object", name="no_location")
+                db_map.add_entity(
+                    entity_class_name="Object",
+                    name="locations_and_shapes",
+                    lat=2.3,
+                    lon=3.2,
+                    alt=55.0,
+                    shape_name="hexagon",
+                    shape_blob="{}",
+                )
+                db_map.commit_session("Add test data.")
+            with DatabaseMapping(url) as db_map:
+                no_location = db_map.entity(entity_class_name="Object", name="no_location")
+                self.assertIsNone(no_location["lat"])
+                self.assertIsNone(no_location["lon"])
+                self.assertIsNone(no_location["alt"])
+                self.assertIsNone(no_location["shape_name"])
+                self.assertIsNone(no_location["shape_blob"])
+                with_location = db_map.entity(entity_class_name="Object", name="locations_and_shapes")
+                self.assertEqual(with_location["lat"], 2.3)
+                self.assertEqual(with_location["lon"], 3.2)
+                self.assertEqual(with_location["alt"], 55.0)
+                self.assertEqual(with_location["shape_name"], "hexagon")
+                self.assertEqual(with_location["shape_blob"], "{}")
+
+    def test_entity_location_data_available_in_asdict(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            entity_class = db_map.add_entity_class(name="Object")
+            no_location = db_map.add_entity(entity_class_name="Object", name="no_location")
+            yes_location = db_map.add_entity(
+                entity_class_name="Object",
+                name="yes_location",
+                lat=2.3,
+                lon=3.2,
+                alt=55.0,
+                shape_name="hexagon",
+                shape_blob="{}",
+            )
+            self.assertEqual(
+                no_location._asdict(),
+                {
+                    "class_id": entity_class["id"],
+                    "id": no_location["id"],
+                    "name": "no_location",
+                    "element_id_list": (),
+                    "description": None,
+                    "lat": None,
+                    "lon": None,
+                    "alt": None,
+                    "shape_name": None,
+                    "shape_blob": None,
+                },
+            )
+            self.assertEqual(
+                yes_location._asdict(),
+                {
+                    "class_id": entity_class["id"],
+                    "id": yes_location["id"],
+                    "name": "yes_location",
+                    "element_id_list": (),
+                    "description": None,
+                    "lat": 2.3,
+                    "lon": 3.2,
+                    "alt": 55.0,
+                    "shape_name": "hexagon",
+                    "shape_blob": "{}",
+                },
+            )
+
+    def test_entity_location_is_removed_in_cascade_with_entity(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            db_map.add_entity_class(name="Object")
+            entity = db_map.add_entity(entity_class_name="Object", name="cube", lat=2.3, lon=3.2)
+            locations = db_map.find_entity_locations(lat=2.3, lon=3.2)
+            self.assertEqual(len(locations), 1)
+            self.assertTrue(locations[0].is_valid())
+            entity.remove()
+            self.assertFalse(locations[0].is_valid())
+
+    def test_entity_location_is_removed_when_all_its_data_is_set_to_none(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            db_map.add_entity_class(name="Object")
+            lat_lon_entity = db_map.add_entity(entity_class_name="Object", name="point", lat=2.3, lon=3.2)
+            locations = db_map.find_entity_locations(lat=2.3, lon=3.2)
+            self.assertEqual(len(locations), 1)
+            self.assertTrue(locations[0].is_valid())
+            lat_lon_entity.update(lat=None, lon=None)
+            self.assertFalse(locations[0].is_valid())
+            shape_entity = db_map.add_entity(
+                entity_class_name="Object", name="polygon", shape_name="hexagon", shape_blob="{}"
+            )
+            locations = db_map.find_entity_locations(shape_name="hexagon", shape_blob="{}")
+            self.assertEqual(len(locations), 1)
+            self.assertTrue(locations[0].is_valid())
+            shape_entity.update(shape_name=None, shape_blob=None)
+            self.assertFalse(locations[0].is_valid())
+
+    def test_entity_location_is_not_removed_when_some_of_its_data_is_set_to_none(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            db_map.add_entity_class(name="Object")
+            locationed_entity1 = db_map.add_entity(
+                entity_class_name="Object", name="soon_polygon", lat=2.3, lon=3.2, shape_name="hexagon", shape_blob="{}"
+            )
+            locations = db_map.find_entity_locations(lat=2.3, lon=3.2)
+            self.assertEqual(len(locations), 1)
+            self.assertTrue(locations[0].is_valid())
+            locationed_entity1.update(lat=None, lon=None)
+            self.assertTrue(locations[0].is_valid())
+            self.assertEqual(locations[0]["entity_byname"], ("soon_polygon",))
+            self.assertIsNone(locations[0]["lat"])
+            self.assertIsNone(locations[0]["lon"])
+            self.assertIsNone(locations[0]["alt"])
+            self.assertEqual(locations[0]["shape_name"], "hexagon")
+            self.assertEqual(locations[0]["shape_blob"], "{}")
+            locationed_entity2 = db_map.add_entity(
+                entity_class_name="Object",
+                name="soon_point",
+                lat=2.3,
+                lon=3.2,
+                alt=55.0,
+                shape_name="hexagon",
+                shape_blob="{}",
+            )
+            locations = db_map.find_entity_locations(lat=2.3, lon=3.2)
+            self.assertEqual(len(locations), 1)
+            self.assertTrue(locations[0].is_valid())
+            locationed_entity2.update(shape_name=None, shape_blob=None)
+            self.assertTrue(locations[0].is_valid())
+            self.assertEqual(locations[0]["entity_byname"], ("soon_point",))
+            self.assertEqual(locations[0]["lat"], 2.3)
+            self.assertEqual(locations[0]["lon"], 3.2)
+            self.assertEqual(locations[0]["alt"], 55.0)
+            self.assertIsNone(locations[0]["shape_name"])
+            self.assertIsNone(locations[0]["shape_blob"])
+
+    def test_updating_entitys_location_data_adds_location_item(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            db_map.add_entity_class(name="Object")
+            entity = db_map.add_entity(entity_class_name="Object", name="soon_to_have_location")
+            self.assertEqual(db_map.find_entity_locations(), [])
+            entity.update(lat=2.3, lon=3.2)
+            locations = db_map.find_entity_locations()
+            self.assertEqual(len(locations), 1)
+            self.assertEqual(locations[0]["entity_byname"], ("soon_to_have_location",))
+            self.assertEqual(locations[0]["lat"], 2.3)
+            self.assertEqual(locations[0]["lon"], 3.2)
+            self.assertIsNone(locations[0]["alt"])
+            self.assertIsNone(locations[0]["shape_name"])
+            self.assertIsNone(locations[0]["shape_blob"])
+            entity.update(lat=None, lon=None)
+            self.assertEqual(db_map.find_entity_locations(), [])
+            entity.update(shape_name="polygon", shape_blob="{}")
+            locations = db_map.find_entity_locations()
+            self.assertEqual(len(locations), 1)
+            self.assertEqual(locations[0]["entity_byname"], ("soon_to_have_location",))
+            self.assertIsNone(locations[0]["lat"])
+            self.assertIsNone(locations[0]["lon"])
+            self.assertIsNone(locations[0]["alt"])
+            self.assertEqual(locations[0]["shape_name"], "polygon")
+            self.assertEqual(locations[0]["shape_blob"], "{}")
+
+    def test_updating_entitys_location_data_with_missing_data_raises_exception(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            db_map.add_entity_class(name="Object")
+            entity = db_map.add_entity(entity_class_name="Object", name="soon_to_have_location")
+            with self.assertRaisesRegex(SpineDBAPIError, "latitude cannot be set if longitude is None"):
+                entity.update(lat=2.3)
+            with self.assertRaisesRegex(SpineDBAPIError, "longitude cannot be set if latitude is None"):
+                entity.update(lon=3.2)
+            with self.assertRaisesRegex(SpineDBAPIError, "altitude cannot be set if latitude and longitude are None"):
+                entity.update(alt=55.0)
+            with self.assertRaisesRegex(SpineDBAPIError, "shape_name cannot be set if shape_blob is None"):
+                entity.update(shape_name="monogon")
+            with self.assertRaisesRegex(SpineDBAPIError, "shape_blob cannot be set if shape_name is None"):
+                entity.update(shape_blob="{}}")
+
+    def test_removing_entity_location_sets_entitys_location_id_to_none(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            db_map.add_entity_class(name="Object")
+            sphere = db_map.add_entity(entity_class_name="Object", name="sphere", lat=2.3, lon=3.2)
+            location = db_map.entity_location(entity_class_name="Object", entity_byname=("sphere",))
+            location.remove()
+            self.assertIsNone(sphere["lat"])
+            self.assertIsNone(sphere["lon"])
+
+    def test_updating_manually_removed_entity_location_via_entity_restores_location(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            db_map.add_entity_class(name="Object")
+            sphere = db_map.add_entity(entity_class_name="Object", name="sphere", lat=2.3, lon=3.2)
+            location = db_map.entity_location(entity_class_name="Object", entity_byname=("sphere",))
+            location.remove()
+            self.assertFalse(location.is_valid())
+            sphere.update(shape_name="metagon", shape_blob="{}")
+            self.assertTrue(location.is_valid())
+            self.assertIsNone(location["lat"])
+            self.assertIsNone(location["lon"])
+            self.assertIsNone(location["alt"])
+            self.assertEqual(location["shape_name"], "metagon")
+            self.assertEqual(location["shape_blob"], "{}")
+
+    def test_restoring_entity_restores_its_location(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            db_map.add_entity_class(name="Object")
+            sphere = db_map.add_entity(entity_class_name="Object", name="sphere", lat=2.3, lon=3.2)
+            location = db_map.entity_location(entity_class_name="Object", entity_byname=("sphere",))
+            sphere.remove()
+            self.assertFalse(location.is_valid())
+            sphere.restore()
+            self.assertTrue(location.is_valid())
+            self.assertEqual(sphere["lat"], 2.3)
+            self.assertEqual(sphere["lon"], 3.2)
+
+
+
 
 class TestDatabaseMappingLegacy(unittest.TestCase):
     """'Backward compatibility' tests, i.e. pre-entity tests converted to work with the entity structure."""

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -80,7 +80,7 @@ class TestRemoveCredentialsFromUrl(unittest.TestCase):
 class TestGetHeadAlembicVersion(unittest.TestCase):
     def test_returns_latest_version(self):
         # This test must be updated each time new migration script is added.
-        self.assertEqual(get_head_alembic_version(), "7e2e66ae0f8f")
+        self.assertEqual(get_head_alembic_version(), "91f1f55aa972")
 
 
 class TestStringToBool(unittest.TestCase):

--- a/tests/test_import_functions.py
+++ b/tests/test_import_functions.py
@@ -592,6 +592,19 @@ class TestImportEntity(AssertSuccessTestCase):
             self.assertEqual(entities[0]["entity_class_name"], "flow__flow")
             self.assertEqual(entities[0]["dimension_name_list"], ("flow", "flow"))
 
+    def test_entity_location(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_imports(import_entity_classes(db_map, [("Object",)]))
+            self._assert_imports(
+                import_entities(db_map, [("Object", "shape", None, (2.3, 3.2, 55.0, "polyhedron", "{}"))])
+            )
+            shape = db_map.entity(entity_class_name="Object", name="shape")
+            self.assertEqual(shape["lat"], 2.3)
+            self.assertEqual(shape["lon"], 3.2)
+            self.assertEqual(shape["alt"], 55.0)
+            self.assertEqual(shape["shape_name"], "polyhedron")
+            self.assertEqual(shape["shape_blob"], "{}")
+
 
 class TestImportRelationship(AssertSuccessTestCase):
     def populate(self, db_map):


### PR DESCRIPTION
This PR adds `entity_location` table to the database including migrations, support for locations in `DatabaseMapping`, import and export functions as well as comprehensive documentation.

Re spine-tools/Spine-Toolbox#2975

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass (Toolbox tests fixed in spine-tools/Spine-Toolbox#3069
