### PR TITLE
Remove MappedItemBase.__getattr__()

### DIFF
--- a/spinedb_api/db_mapping_base.py
+++ b/spinedb_api/db_mapping_base.py
@@ -1130,12 +1130,6 @@ class MappedItemBase(dict):
         """Overridden to return a more verbose representation."""
         return f"{self.item_type}{self.extended()}"
 
-    def __getattr__(self, name):
-        """Overridden to return the dictionary key named after the attribute, or None if it doesn't exist."""
-        # FIXME: We should try and get rid of this one
-
-        return self.get(name)
-
     def __getitem__(self, key):
         """Overridden to return references."""
         source_and_target_key = self._external_fields.get(key)

--- a/spinedb_api/mapped_items.py
+++ b/spinedb_api/mapped_items.py
@@ -968,9 +968,9 @@ class ScenarioItem(MappedItemBase):
 
     def __getitem__(self, key):
         if key == "alternative_id_list":
-            return [x["alternative_id"] for x in self.sorted_scenario_alternatives]
+            return [x["alternative_id"] for x in self["sorted_scenario_alternatives"]]
         if key == "alternative_name_list":
-            return [x["alternative_name"] for x in self.sorted_scenario_alternatives]
+            return [x["alternative_name"] for x in self["sorted_scenario_alternatives"]]
         if key == "sorted_scenario_alternatives":
             mapped_table = self._db_map.mapped_table("scenario_alternative")
             self._db_map.do_fetch_all(mapped_table)


### PR DESCRIPTION
This method was implemented for legacy reasons but has proven to be a nuisance.

Curshed a FIXME in code. No associated issue.

## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black & isort
- [ ] Unit tests pass
