### PR TITLE
Require value's type more strictly

### DIFF
--- a/spinedb_api/mapped_items.py
+++ b/spinedb_api/mapped_items.py
@@ -1003,7 +1003,7 @@ class ParameterValueItem(ParameterItemBase):
             "value": _ENTITY_BYNAME_VALUE,
         },
         "value": {"type": bytes, "value": "The value's database representation."},
-        "type": {"type": str, "value": "The value's type.", "optional": True},
+        "type": {"type": str, "value": "The value's type. Optional only when value is null.", "optional": True},
         "parsed_value": {"type": ParameterValue, "value": "The value.", "optional": True},
         "alternative_name": {"type": str, "value": "The alternative name - defaults to 'Base'.", "optional": True},
     }
@@ -1064,6 +1064,13 @@ class ParameterValueItem(ParameterItemBase):
             f"value {parsed_value} of {self['parameter_definition_name']} for {self['entity_byname']} "
             f"is not in {list_name}"
         )
+
+    def check_mutability(self):
+        if (
+            dict.__getitem__(self, self.type_key) is None
+            and dict.__getitem__(self, self.value_key) != UNPARSED_NULL_VALUE
+        ):
+            raise SpineDBAPIError("'type' is missing")
 
 
 class ParameterValueListItem(MappedItemBase):

--- a/tests/test_DatabaseMapping.py
+++ b/tests/test_DatabaseMapping.py
@@ -1523,7 +1523,7 @@ class TestDatabaseMapping(AssertSuccessTestCase):
                 value=value,
                 type=None,
             )
-            self.assertEqual(error, "invalid type for parameter_value")
+            self.assertEqual(error, "'type' is missing")
             self.assertIsNone(value_item)
 
     def test_parameter_definition_callbacks_get_called_on_default_value_update(self):
@@ -3872,13 +3872,13 @@ class TestDatabaseMappingAdd(AssertSuccessTestCase):
             import_functions.import_relationship_parameters(db_map, [("fish_dog", "rel_speed")])
             _, errors = db_map.add_items(
                 "parameter_value",
-                {"parameter_definition_id": 1, "object_id": 3, "value": b'"orange"', "alternative_id": 1},
+                {"parameter_definition_id": 1, "object_id": 3, "parsed_value": "orange", "alternative_id": 1},
                 strict=False,
             )
             self.assertEqual([str(e) for e in errors], ["invalid entity_class_id for parameter_value"])
             _, errors = db_map.add_items(
                 "parameter_value",
-                {"parameter_definition_id": 2, "relationship_id": 2, "value": b"125", "alternative_id": 1},
+                {"parameter_definition_id": 2, "relationship_id": 2, "parsed_value": 125, "alternative_id": 1},
                 strict=False,
             )
             self.assertEqual([str(e) for e in errors], ["invalid entity_class_id for parameter_value"])


### PR DESCRIPTION
This changes parameter value semantics such that it is not possible to add a parameter value without 'type' unless the value is null.

## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black & isort
- [ ] Unit tests pass
