### PR TITLE
Fix datapackage reader for files with over 100 rows

### DIFF
--- a/tests/spine_io/importers/test_datapackage_reader.py
+++ b/tests/spine_io/importers/test_datapackage_reader.py
@@ -112,6 +112,16 @@ class TestDatapackageReader(unittest.TestCase):
             with self.assertRaisesRegex(ReaderError, "no such table 'non-table'"):
                 reader.get_table_cell("non-table", 0, 0, {"has_header": False})
 
+    def test_get_large_data_does_not_raise_operation_on_closed_file(self):
+        header = ["header 1 ", "header 2", "header 3"]
+        data = [header] + 1000 * [["21", "22", "23"]]
+        with test_datapackage(data) as package_path:
+            reader = DatapackageReader(None)
+            reader.connect_to_source(str(package_path))
+            data, header = reader.get_data("test_data", {})
+            self.assertEqual(header, ["header 1", "header 2", "header 3"])
+            self.assertEqual(data, 1000 * [[21, 22, 23]])
+
 
 @contextmanager
 def test_datapackage(rows):


### PR DESCRIPTION
This PR fixes a Traceback from `datapackage_reader` when the reader was accessing a resource with over 100 lines of text.

No associated issue.

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
