### PR TITLE
Fix EntityItem._asdict()

### DIFF
--- a/spinedb_api/mapped_items.py
+++ b/spinedb_api/mapped_items.py
@@ -189,6 +189,8 @@ class EntityItem(MappedItemBase):
         kwargs["element_id_list"] = tuple(element_id_list)
         self._location_id = _unfetched
         self._init_location = self._pop_location_data(kwargs)
+        if not self._init_location and "commit_id" in kwargs:
+            self._init_location = None
         super().__init__(*args, **kwargs)
 
     @classmethod


### PR DESCRIPTION
Location data was not always included in the dict.

Re spine-tools/Spine-Toolbox#2975

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [ ] Unit tests pass
