### PR TITLE
Don't call update callbacks when changes are "trivial"

### DIFF
--- a/spinedb_api/temp_id.py
+++ b/spinedb_api/temp_id.py
@@ -8,35 +8,37 @@
 # Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
+from __future__ import annotations
+from typing import Any, Optional
 
 
 class TempId:
     _next_id = {}
 
-    def __init__(self, id_, item_type, temp_id_lookup=None):
+    def __init__(self, id_: int, item_type: str, temp_id_lookup: Optional[dict[int, TempId]] = None):
         super().__init__()
         self._id = id_
         self._item_type = item_type
         self._temp_id_lookup = temp_id_lookup if temp_id_lookup is not None else {}
-        self._db_id = None
+        self._db_id: Optional[int] = None
         self._temp_id_lookup[self._id] = self
 
     @staticmethod
-    def new_unique(item_type, temp_id_lookup):
+    def new_unique(item_type: str, temp_id_lookup: dict[int, TempId]) -> TempId:
         id_ = TempId._next_id.get(item_type, -1)
         TempId._next_id[item_type] = id_ - 1
         return TempId(id_, item_type, temp_id_lookup)
 
     @property
-    def item_type(self):
+    def item_type(self) -> str:
         return self._item_type
 
     @property
-    def private_id(self):
+    def private_id(self) -> int:
         return self._id
 
     @property
-    def db_id(self):
+    def db_id(self) -> int:
         return self._db_id
 
     def __repr__(self):
@@ -55,12 +57,12 @@ class TempId:
     def __hash__(self):
         return hash((self._item_type, self._id))
 
-    def resolve(self, db_id):
+    def resolve(self, db_id: int) -> None:
         self.unresolve()
         self._db_id = db_id
         self._temp_id_lookup[db_id] = self
 
-    def unresolve(self):
+    def unresolve(self) -> None:
         if self._db_id is None:
             return
         if self._temp_id_lookup[self._db_id] is self:
@@ -68,7 +70,7 @@ class TempId:
         self._db_id = None
 
 
-def resolve(value):
+def resolve(value: Any) -> Any:
     if isinstance(value, tuple):
         return tuple(resolve(v) for v in value)
     if isinstance(value, dict):

--- a/tests/test_DatabaseMapping.py
+++ b/tests/test_DatabaseMapping.py
@@ -93,6 +93,15 @@ class TestDatabaseMappingConstruction(AssertSuccessTestCase):
 
 
 class TestDatabaseMapping(AssertSuccessTestCase):
+    def test_get_item_without_fetching(self):
+        with TemporaryDirectory() as temp_dir:
+            url = "sqlite:///" + os.path.join(temp_dir, "db.sqlite")
+            with DatabaseMapping(url, create=True) as db_map:
+                db_map.add_metadata_item(name="Title", value="The four horsemen")
+                db_map.commit_session("Add test data.")
+            with DatabaseMapping(url) as db_map:
+                self.assertEqual(db_map.get_item("metadata", name="Title", value="The four horsemen", fetch=False), {})
+
     def test_rolling_back_new_item_invalidates_its_id(self):
         with DatabaseMapping("sqlite://", create=True) as db_map:
             mapped_table = db_map.mapped_table("entity_class")
@@ -1049,7 +1058,25 @@ class TestDatabaseMapping(AssertSuccessTestCase):
             self.assertIsNone(error)
             self.assertIsInstance(removed, PublicItem)
 
-    def test_get_items_with_skip_removed(self):
+    def test_double_remove_does_not_invoke_remove_callbacks(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            scenario = db_map.add_scenario(name="Scenario")
+            remove_callback = mock.MagicMock()
+            scenario.add_remove_callback(remove_callback)
+            scenario.remove()
+            remove_callback.assert_called_once()
+            remove_callback.reset_mock()
+            scenario.remove()
+            remove_callback.assert_not_called()
+
+    def test_get_items_returns_nothing_when_item_is_removed(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            entity_class = db_map.add_entity_class(name="Object")
+            entity_class.remove()
+            classes = db_map.get_items("entity_class")
+            self.assertEqual(len(classes), 0)
+
+    def test_get_items_with_skip_removed_set_to_false(self):
         with DatabaseMapping("sqlite://", create=True) as db_map:
             alternative = db_map.get_alternative_item(name="Base")
             alternative.remove()
@@ -1057,6 +1084,19 @@ class TestDatabaseMapping(AssertSuccessTestCase):
             self.assertEqual(len(alternatives), 1)
             self.assertEqual(alternatives[0]["name"], "Base")
             self.assertFalse(alternatives[0].is_valid())
+
+    def test_get_items_with_existing_item_and_skip_removed_set_to_false(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            alternatives = db_map.get_items("alternative", skip_removed=False)
+            self.assertEqual(len(alternatives), 1)
+            self.assertEqual(alternatives[0]["name"], "Base")
+
+    def test_get_items_with_skip_removed_set_to_true(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            alternative = db_map.get_alternative_item(name="Base")
+            alternative.remove()
+            alternatives = db_map.get_items("alternative", skip_removed=True)
+            self.assertEqual(len(alternatives), 0)
 
     def test_get_items_with_skip_removed_after_readding_item(self):
         with DatabaseMapping("sqlite://", create=True) as db_map:
@@ -1069,6 +1109,40 @@ class TestDatabaseMapping(AssertSuccessTestCase):
             self.assertFalse(alternatives[0].is_valid())
             self.assertEqual(alternatives[1]["name"], "Base")
             self.assertTrue(alternatives[1].is_valid())
+
+    def test_get_item_returns_nothing_when_item_is_removed(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            entity_class = db_map.add_entity_class(name="Object")
+            entity_class.remove()
+            self.assertEqual(db_map.get_item("entity_class", name="Object"), {})
+
+    def test_get_item_with_skip_removed_set_to_false(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            db_map.get_alternative_item(name="Base").remove()
+            alternative = db_map.get_item("alternative", name="Base", skip_removed=False)
+            self.assertEqual(alternative["name"], "Base")
+            self.assertFalse(alternative.is_valid())
+
+    def test_get_item_with_existing_item_and_skip_removed_set_to_false(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            db_map.get_alternative_item(name="Base")
+            alternative = db_map.get_item("alternative", name="Base", skip_removed=True)
+            self.assertEqual(alternative["name"], "Base")
+
+    def test_get_item_with_skip_removed_set_to_true(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            db_map.get_alternative_item(name="Base").remove()
+            alternative = db_map.get_item("alternative", name="Base", skip_removed=True)
+            self.assertEqual(alternative, {})
+
+    def test_get_item_with_skip_removed_after_readding_item(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            alternative = db_map.get_alternative_item(name="Base")
+            alternative.remove()
+            self._assert_success(db_map.add_alternative_item(name="Base"))
+            alternative = db_map.get_item("alternative", name="Base", skip_removed=False)
+            self.assertEqual(alternative["name"], "Base")
+            self.assertTrue(alternative.is_valid())
 
     def test_entity_item_active_in_scenario(self):
         with TemporaryDirectory() as temp_dir:
@@ -5894,6 +5968,53 @@ class TestDatabaseMappingConcurrent(AssertSuccessTestCase):
                 entity_class_item = db_map.get_entity_class_item(name="my_class")
                 self.assertTrue(entity_class_item)
                 self.assertEqual(entity_class_item["name"], "my_class")
+
+    def test_db_items_prevail_with_get_items_if_mapped_items_are_committed(self):
+        with TemporaryDirectory() as temp_dir:
+            url = "sqlite:///" + os.path.join(temp_dir, "db.sqlite")
+            with DatabaseMapping(url, create=True) as db_map:
+                self._assert_success(db_map.add_entity_class_item(name="my_class"))
+                db_map.commit_session("Add some data")
+            with DatabaseMapping(url) as db_map:
+                db_map.purge_items("entity_class")
+                db_map.commit_session("Purge all")
+                with DatabaseMapping(url) as shadow_db_map:
+                    self._assert_success(shadow_db_map.add_entity_class_item(name="my_class"))
+                    shadow_db_map.commit_session("Add same class")
+                entity_class_items = db_map.get_entity_class_items()
+                self.assertEqual(len(entity_class_items), 1)
+                self.assertEqual(entity_class_items[0]["name"], "my_class")
+
+    def test_db_items_prevail_with_item_if_mapped_items_are_committed(self):
+        with TemporaryDirectory() as temp_dir:
+            url = "sqlite:///" + os.path.join(temp_dir, "db.sqlite")
+            with DatabaseMapping(url, create=True) as db_map:
+                db_map.add_entity_class(name="my_class")
+                db_map.commit_session("Add some data")
+            with DatabaseMapping(url) as db_map:
+                db_map.purge_items("entity_class")
+                db_map.commit_session("Purge all")
+                with DatabaseMapping(url) as shadow_db_map:
+                    shadow_db_map.add_entity_class(name="my_class")
+                    shadow_db_map.commit_session("Add same class")
+                entity_class_item = db_map.entity_class(name="my_class")
+                self.assertEqual(entity_class_item["name"], "my_class")
+
+    def test_db_items_prevail_with_find_if_mapped_items_are_committed(self):
+        with TemporaryDirectory() as temp_dir:
+            url = "sqlite:///" + os.path.join(temp_dir, "db.sqlite")
+            with DatabaseMapping(url, create=True) as db_map:
+                db_map.add_entity_class(name="my_class")
+                db_map.commit_session("Add some data")
+            with DatabaseMapping(url) as db_map:
+                db_map.purge_items("entity_class")
+                db_map.commit_session("Purge all")
+                with DatabaseMapping(url) as shadow_db_map:
+                    shadow_db_map.add_entity_class(name="my_class")
+                    shadow_db_map.commit_session("Add same class")
+                entity_class_items = db_map.find_entity_classes(name="my_class")
+                self.assertEqual(len(entity_class_items), 1)
+                self.assertEqual(entity_class_items[0]["name"], "my_class")
 
     def test_remove_items_then_refresh_then_readd(self):
         with TemporaryDirectory() as temp_dir:

--- a/tests/test_db_mapping_interface.py
+++ b/tests/test_db_mapping_interface.py
@@ -22,7 +22,7 @@ class TestItem(unittest.TestCase):
 
     def test_raises_when_find_args_are_wrong(self):
         with DatabaseMapping("sqlite://", create=True) as db_map:
-            with self.assertRaisesRegex(SpineDBAPIError, "no such item"):
+            with self.assertRaisesRegex(SpineDBAPIError, "no alternative matching {'name': 'non-existent'}"):
                 mapped_table = db_map.mapped_table("alternative")
                 db_map.item(mapped_table, name="non-existent")
 
@@ -30,7 +30,7 @@ class TestItem(unittest.TestCase):
         with DatabaseMapping("sqlite://", create=True) as db_map:
             mapped_table = db_map.mapped_table("alternative")
             db_map.item(mapped_table, name="Base").remove()
-            with self.assertRaisesRegex(SpineDBAPIError, "no such item"):
+            with self.assertRaisesRegex(SpineDBAPIError, "no alternative matching {'name': 'Base'}"):
                 db_map.item(mapped_table, name="Base")
 
 
@@ -200,7 +200,7 @@ class TestRemove(unittest.TestCase):
     def test_raises_when_items_doesnt_exist(self):
         with DatabaseMapping("sqlite://", create=True) as db_map:
             mapped_table = db_map.mapped_table("alternative")
-            with self.assertRaisesRegex(SpineDBAPIError, "no such item"):
+            with self.assertRaisesRegex(SpineDBAPIError, "no alternative matching {'name': 'non-existent'}"):
                 db_map.remove(mapped_table, name="non-existent")
 
 
@@ -238,7 +238,7 @@ class TestRestore(unittest.TestCase):
             item.remove()
             self.assertFalse(item.is_valid())
             mapped_table = db_map.mapped_table("scenario")
-            with self.assertRaisesRegex(SpineDBAPIError, "no such item"):
+            with self.assertRaisesRegex(SpineDBAPIError, "no scenario matching {'name': 'non-existent'}"):
                 db_map.restore(mapped_table, name="non-existent")
 
 

--- a/tests/test_db_mapping_interface.py
+++ b/tests/test_db_mapping_interface.py
@@ -30,7 +30,7 @@ class TestItem(unittest.TestCase):
         with DatabaseMapping("sqlite://", create=True) as db_map:
             mapped_table = db_map.mapped_table("alternative")
             db_map.item(mapped_table, name="Base").remove()
-            with self.assertRaisesRegex(SpineDBAPIError, "no alternative matching {'name': 'Base'}"):
+            with self.assertRaisesRegex(SpineDBAPIError, "alternative matching {'name': 'Base'} has been removed"):
                 db_map.item(mapped_table, name="Base")
 
 
@@ -90,6 +90,13 @@ class TestFind(unittest.TestCase):
             found = db_map.find(mapped_table)
             self.assertEqual(len(found), 2)
             self.assertCountEqual([i["name"] for i in found], ["Base", "new"])
+
+    def test_find_doesnt_find_removed_items(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            db_map.add_scenario(name="Scenario").remove()
+            scenario_table = db_map.mapped_table("scenario")
+            found = db_map.find(scenario_table)
+            self.assertEqual(found, [])
 
     def test_asterisk_works_with_bynames(self):
         with DatabaseMapping("sqlite://", create=True) as db_map:

--- a/tests/test_import_functions.py
+++ b/tests/test_import_functions.py
@@ -522,14 +522,14 @@ class TestImportEntity(AssertSuccessTestCase):
             self.assertEqual(
                 errors,
                 [
-                    "non-existent elements in byname ['n1', 'u2', 'n2', 'u2'] for class " "unit_flow__unit_flow",
-                    "non-existent elements in byname ['n2', 'u2', 'n1', 'u2'] for class " "unit_flow__unit_flow",
-                    "non-existent elements in byname ['u1', 'n1', 'u2', 'n1'] for class " "unit_flow__unit_flow",
-                    "non-existent elements in byname ['u1', 'n2', 'u1', 'n1'] for class " "unit_flow__unit_flow",
-                    "non-existent elements in byname ['n1', 'u2', 'u1', 'n2'] for class " "unit_flow__unit_flow",
-                    "non-existent elements in byname ['n1', 'u1', 'u1', 'n1'] for class " "unit_flow__unit_flow",
-                    "non-existent elements in byname ['u1', 'n1', 'n2', 'u2'] for class " "unit_flow__unit_flow",
-                    "non-existent elements in byname ['u2', 'n1', 'n2', 'u1'] for class " "unit_flow__unit_flow",
+                    "non-existent elements in byname ('n1', 'u2', 'n2', 'u2') for class " "unit_flow__unit_flow",
+                    "non-existent elements in byname ('n2', 'u2', 'n1', 'u2') for class " "unit_flow__unit_flow",
+                    "non-existent elements in byname ('u1', 'n1', 'u2', 'n1') for class " "unit_flow__unit_flow",
+                    "non-existent elements in byname ('u1', 'n2', 'u1', 'n1') for class " "unit_flow__unit_flow",
+                    "non-existent elements in byname ('n1', 'u2', 'u1', 'n2') for class " "unit_flow__unit_flow",
+                    "non-existent elements in byname ('n1', 'u1', 'u1', 'n1') for class " "unit_flow__unit_flow",
+                    "non-existent elements in byname ('u1', 'n1', 'n2', 'u2') for class " "unit_flow__unit_flow",
+                    "non-existent elements in byname ('u2', 'n1', 'n2', 'u1') for class " "unit_flow__unit_flow",
                 ],
             )
             classes = {c["name"]: c["dimension_name_list"] for c in db_map.find_entity_classes()}
@@ -1678,6 +1678,12 @@ class TestImportScenarioAlternative(AssertSuccessTestCase):
             self.assertEqual(count, 1)
             scenario_alternatives = self.scenario_alternatives(db_map)
             self.assertEqual(scenario_alternatives, {"scenario": {"alternative": 1}})
+
+    def test_missing_scenario_gets_created(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            count, errors = import_data(db_map, scenario_alternatives=[["scen", "Base"]])
+            self.assertEqual(errors, ["no scenario matching {'name': 'scen'}"])
+            self.assertEqual(count, 0)
 
     def test_scenario_alternative_import_multiple_without_before_alternatives(self):
         with DatabaseMapping("sqlite://", create=True) as db_map:


### PR DESCRIPTION
There is no need to notify e.g. parameter value items if the "description" field of an entity changes.

Re spine-tools/Spine-Toolbox#2975

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
