### PR TITLE
Fix bug in accessing items in DatabaseMapping

### DIFF
--- a/spinedb_api/db_mapping_base.py
+++ b/spinedb_api/db_mapping_base.py
@@ -265,7 +265,7 @@ class DatabaseMappingBase:
         """Fetches items from the DB and adds them to the mapping."""
         raise NotImplementedError()
 
-    def do_fetch_all(self, mapped_table: MappedTable, commit_count: Optional[int] = None) -> None:
+    def do_fetch_all(self, mapped_table: MappedTable, commit_count: Optional[int] = None) -> list[MappedItemBase]:
         """Fetches all items of given type, but only once for each commit_count.
         In other words, the second time this method is called with the same commit_count, it does nothing.
         If not specified, commit_count defaults to the result of self._get_commit_count().
@@ -274,7 +274,8 @@ class DatabaseMappingBase:
             commit_count = self._get_commit_count()
         if self._fetched.get(mapped_table.item_type, -1) < commit_count:
             self._fetched[mapped_table.item_type] = commit_count
-            self._do_fetch_more(mapped_table, offset=0, limit=None, real_commit_count=commit_count)
+            return self._do_fetch_more(mapped_table, offset=0, limit=None, real_commit_count=commit_count)
+        return []
 
     def item(self, mapped_table: MappedTable, **kwargs) -> PublicItem:
         raise NotImplementedError()

--- a/tests/test_DatabaseMapping.py
+++ b/tests/test_DatabaseMapping.py
@@ -3021,6 +3021,19 @@ class TestDatabaseMapping(AssertSuccessTestCase):
             ):
                 db_map.update_entity(id=relationship["id"], entity_byname=("knife", "anon"))
 
+    def test_find_fetched_entity_classes(self):
+        with TemporaryDirectory() as temp_dir:
+            url = "sqlite:///" + os.path.join(temp_dir, "db.sqlite")
+            with DatabaseMapping(url, create=True) as db_map:
+                db_map.add_entity_class(name="asset")
+                db_map.add_entity_class(name="group")
+                db_map.add_entity_class(dimension_name_list=["asset", "group"])
+                db_map.commit_session("Add test data.")
+            with DatabaseMapping(url) as db_map:
+                classes = db_map.find_entity_classes(name="asset__group")
+                self.assertEqual(len(classes), 1)
+                self.assertEqual(classes[0]["name"], "asset__group")
+
 
 class TestDatabaseMappingLegacy(unittest.TestCase):
     """'Backward compatibility' tests, i.e. pre-entity tests converted to work with the entity structure."""


### PR DESCRIPTION
This PR fixes a Traceback with `item()`, `find()` and their legacy counterparts when using these function on a clean (nothing fetched yet) `DatabaseMapping`.

Reported by @jkiviluo. No associated issue.

## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black & isort
- [ ] Unit tests pass
