### PR TITLE
Make fetch_all() return fetched PublicItems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `DatabaseMapping.fetch_all()` now returns the fetched items as instances of `PublicItem`.
+
 ### Removed
 
 ### Fixed

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -469,11 +469,20 @@ which also fetches multiple items at once::
         for entity in db_map.find_entities(entity_class_name="cutlery"):
             ...
 
-The SQLAlchemy_ queries that are used to fetch the data can be used directly
-if reading the data is all that is needed.
-This is the fastest interface to the database.
-It also lacks the convenience of :class:`.DatabaseMapping`,
-including any kind of documentation.
+:meth:`.DatabaseMapping.find` works nicely if the items need to be restricted somehow
+as was the case above (find entities with specific entity class).
+If all items of certain type need to be processed,
+:meth:`DatabaseMapping.fetch_all` is more performant::
+
+    with api.DatabaseMapping(url) as db_map:
+        for entity in db_map.fetch_all("entity"):
+            ...
+
+Even faster access would be achieved by using the SQLAlchemy_ queries
+that are used to fetch the data directly.
+The queried data is, however, unstructured
+meaning that resolving all references has to be done manually.
+Also, the query interface is currently largely undocumented.
 
 Parameter types
 ---------------

--- a/spinedb_api/db_mapping.py
+++ b/spinedb_api/db_mapping.py
@@ -1085,7 +1085,7 @@ class DatabaseMapping(DatabaseMappingQueryMixin, DatabaseMappingCommitMixin, Dat
             for x in self._do_fetch_more(mapped_table, offset=offset, limit=limit, real_commit_count=None, **kwargs)
         ]
 
-    def fetch_all(self, *item_types):
+    def fetch_all(self, *item_types) -> list[PublicItem]:
         """Fetches items from the DB into the in-memory mapping.
         Unlike :meth:`fetch_more`, this method fetches entire tables.
 
@@ -1094,10 +1094,12 @@ class DatabaseMapping(DatabaseMappingQueryMixin, DatabaseMappingCommitMixin, Dat
         """
         item_types = set(self.item_types()) if not item_types else set(item_types) & set(self.item_types())
         commit_count = self._query_commit_count()
+        items = []
         for item_type in item_types:
             item_type = self.real_item_type(item_type)
             mapped_table = self.mapped_table(item_type)
-            self.do_fetch_all(mapped_table, commit_count)
+            items += [item.public_item for item in self.do_fetch_all(mapped_table, commit_count)]
+        return items
 
     def query(self, *entities, **kwargs):
         """Returns a :class:`~spinedb_api.query.Query` object to execute against the mapped DB.

--- a/tests/test_DatabaseMapping.py
+++ b/tests/test_DatabaseMapping.py
@@ -3034,6 +3034,23 @@ class TestDatabaseMapping(AssertSuccessTestCase):
                 self.assertEqual(len(classes), 1)
                 self.assertEqual(classes[0]["name"], "asset__group")
 
+    def test_fetch_all_returns_public_items(self):
+        with TemporaryDirectory() as temp_dir:
+            url = "sqlite:///" + os.path.join(temp_dir, "db.sqlite")
+            with DatabaseMapping(url, create=True) as db_map:
+                db_map.add_entity_class(name="Object")
+                db_map.add_scenario(name="my scenario")
+                db_map.commit_session("Add test data.")
+            with DatabaseMapping(url) as db_map:
+                classes_and_scenarios = db_map.fetch_all("entity_class", "scenario")
+                self.assertEqual(len(classes_and_scenarios), 2)
+                classes = [item["name"] for item in classes_and_scenarios if item.item_type == "entity_class"]
+                self.assertEqual(len(classes), 1)
+                self.assertEqual(classes[0], "Object")
+                scenarios = [item["name"] for item in classes_and_scenarios if item.item_type == "scenario"]
+                self.assertEqual(len(scenarios), 1)
+                self.assertEqual(scenarios[0], "my scenario")
+
 
 class TestDatabaseMappingLegacy(unittest.TestCase):
     """'Backward compatibility' tests, i.e. pre-entity tests converted to work with the entity structure."""


### PR DESCRIPTION
`DatabaseMapping.fetch_all()` now returns the fetched items as a list of `PublicItem` instances.

No associated issue.

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
