### PR TITLE
Fix unchecked item update

### DIFF
--- a/spinedb_api/db_mapping.py
+++ b/spinedb_api/db_mapping.py
@@ -809,7 +809,9 @@ class DatabaseMapping(DatabaseMappingQueryMixin, DatabaseMappingCommitMixin, Dat
         merged_item, updated_fields = target_item.merge(kwargs)
         if merged_item is None:
             return None, ""
-        mapped_table.update_item(merged_item, target_item, updated_fields)
+        candidate_item = self.make_item(item_type, **merged_item)
+        candidate_item.polish()
+        mapped_table.update_item(candidate_item, target_item, updated_fields)
         return target_item.public_item, ""
 
     def update_items(self, item_type, *items, check=True, strict=False):

--- a/tests/test_DatabaseMapping.py
+++ b/tests/test_DatabaseMapping.py
@@ -3051,6 +3051,32 @@ class TestDatabaseMapping(AssertSuccessTestCase):
                 self.assertEqual(len(scenarios), 1)
                 self.assertEqual(scenarios[0], "my scenario")
 
+    def test_set_parameter_definitions_list_value_to_none(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            db_map.add_parameter_value_list(name="Choices")
+            db_map.add_list_value(parameter_value_list_name="Choices", parsed_value="yes", index=0)
+            db_map.add_entity_class(name="Object")
+            definition = db_map.add_parameter_definition(
+                entity_class_name="Object", name="y", parameter_value_list_name="Choices", parsed_value="yes"
+            )
+            db_map.update_parameter_definition(id=definition["id"], default_type=None, default_value=None)
+            self.assertIsNone(definition["default_type"])
+            self.assertIsNone(definition["default_value"])
+
+    def test_set_parameter_definitions_list_value_to_none_unchecked(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            db_map.add_parameter_value_list(name="Choices")
+            db_map.add_list_value(parameter_value_list_name="Choices", parsed_value="yes", index=0)
+            db_map.add_entity_class(name="Object")
+            definition = db_map.add_parameter_definition(
+                entity_class_name="Object", name="y", parameter_value_list_name="Choices", parsed_value="yes"
+            )
+            db_map.update_parameter_definition_item(
+                id=definition["id"], default_type=None, default_value=None, check=False
+            )
+            self.assertIsNone(definition["default_type"])
+            self.assertIsNone(definition["default_value"])
+
 
 class TestDatabaseMappingLegacy(unittest.TestCase):
     """'Backward compatibility' tests, i.e. pre-entity tests converted to work with the entity structure."""


### PR DESCRIPTION
This fixes a bug where parameter definition's updates could leave the definition unchanged if the definition was using a parameter value list.

Fixes spine-tools/Spine-Toolbox#3094

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
