### PR TITLE
Add MacOs to unit test matrix

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -18,6 +18,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        include:
+          - os: macos-latest
+            python-version: "3.13"
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
Added macos_latest to Python 3.13 unit tests.

Re spine-tools/Spine-Toolbox#2273

## Checklist before merging
- [x] Unit tests pass
