### PR TITLE
Dispose engine in DatabaseMapping.close()

### DIFF
--- a/spinedb_api/db_mapping.py
+++ b/spinedb_api/db_mapping.py
@@ -1251,6 +1251,12 @@ class DatabaseMapping(DatabaseMappingQueryMixin, DatabaseMappingCommitMixin, Dat
         """Returns the config dicts of filters applied to this database mapping."""
         return self._filter_configs
 
+    def close(self):
+        self._original_engine.dispose()
+        self._original_engine = None
+        self.engine = None
+        super().close()
+
 
 def _fields_equal(item: MappedItemBase, required: dict) -> bool:
     for key, required_value in required.items():

--- a/spinedb_api/db_mapping_base.py
+++ b/spinedb_api/db_mapping_base.py
@@ -44,9 +44,6 @@ class DatabaseMappingBase:
             else:
                 self._sorted_item_types.append(item_type)
 
-    def __del__(self):
-        self.close()
-
     @property
     def closed(self) -> bool:
         return self._closed


### PR DESCRIPTION
This is mostly useful in unit tests that utilize SQLite files in temporary directories.

No associated issue.

## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black & isort
- [ ] Unit tests pass
