### PR TITLE
Fix alternatives filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Things should work as before, except
   if you are using a SQLite database backed by temporary file/in temporary directory,
   you may need to call `db_map.engine.dispose()` before the SQLite file gets removed.
+- The 'alternatives' filter now assumes the alternatives in the filter are given in ascending rank order,
+  and then follows a similar logic as the 'scenario' filter where alternatives with higher ranks are prioritized.
+  This is to disambiguate a case where one entity was active in, say, alternative A, and inactive in alternative B,
+  and the user specified an 'alternatives' filter that included both A and B.
 
 ### Deprecated
 

--- a/spinedb_api/filters/alternative_filter.py
+++ b/spinedb_api/filters/alternative_filter.py
@@ -17,7 +17,7 @@ It lets everything depending on the selected alternatives through and filters ou
 """
 from collections.abc import Iterable
 from functools import partial
-from sqlalchemy import and_, or_
+from sqlalchemy import and_, or_, select, literal, cast, Integer, union_all, func, desc
 from ..exception import SpineDBAPIError
 from .query_utils import filter_by_active_elements
 
@@ -192,9 +192,36 @@ class _AlternativeFilterState:
 
 
 def _ext_entity_sq(db_map, state):
-    return (
+    """Filter entities in given `db_map` by the alternatives defined by given `state`."""
+    # NOTE: the 'alternatives' filter is pretty much like the 'scenario' filter,
+    # except that here the alternatives are explicitly given in a list by the user (in increasing rank order)
+    # (whereas in the 'scenario' filter, they are given by a scenario
+    # and fetched from the scenario_alternative table...)
+    # For the implementation we create a literal subquery with alternatives and their ranks
+    # that we join to the entity subquery (in the same fashion as we join the scenario_alternative table
+    # in the scenario filter).
+    if state.alternatives:
+        rank_alt_rows = list(enumerate(reversed(state.alternatives)))
+        selects = [
+            # NOTE: optimization to reduce the size of the statement:
+            # make type cast only for first row, for other rows DB engine will infer
+            select(cast(literal(rank), Integer).label("rank"), cast(literal(alt_id), Integer).label("alternative_id"))
+            if i == 0
+            else select(literal(rank), literal(alt_id))  # no type cast
+            for i, (rank, alt_id) in enumerate(rank_alt_rows)
+        ]
+        rank_alt_sq = union_all(*selects).alias(name="rank_alternative")
+    else:
+        rank_alt_sq = select(literal(None).label("rank"), literal(None).label("alternative_id"))
+    entity_sq = (
         db_map.query(
             state.original_entity_sq,
+            func.row_number()
+            .over(
+                partition_by=[state.original_entity_sq.c.id],
+                order_by=desc(rank_alt_sq.c.rank),
+            )
+            .label("desc_rank_row_number"),
             state.original_entity_alternative_sq.c.active,
             db_map.entity_class_sq.c.active_by_default,
         )
@@ -203,13 +230,23 @@ def _ext_entity_sq(db_map, state):
             state.original_entity_sq.c.id == state.original_entity_alternative_sq.c.entity_id,
         )
         .outerjoin(db_map.entity_class_sq, state.original_entity_sq.c.class_id == db_map.entity_class_sq.c.id)
+        .outerjoin(rank_alt_sq, state.original_entity_alternative_sq.c.alternative_id == rank_alt_sq.c.alternative_id)
         .filter(
             or_(
                 state.original_entity_alternative_sq.c.alternative_id == None,
-                state.original_entity_alternative_sq.c.alternative_id.in_(state.alternatives),
-            )
+                state.original_entity_alternative_sq.c.alternative_id == rank_alt_sq.c.alternative_id,
+                db_map.entity_class_sq.c.active_by_default == True,
+            ),
         )
     ).subquery()
+    return (
+        db_map.query(entity_sq)
+        .filter(
+            entity_sq.c.desc_rank_row_number == 1,
+            or_(entity_sq.c.active == True, and_(entity_sq.c.active == None, entity_sq.c.active_by_default == True)),
+        )
+        .subquery()
+    )
 
 
 def _make_alternative_filtered_entity_alternative_sq(db_map, state):
@@ -228,9 +265,9 @@ def _make_alternative_filtered_entity_alternative_sq(db_map, state):
     ext_entity_sq = _ext_entity_sq(db_map, state)
     return (
         db_map.query(state.original_entity_alternative_sq)
-        .filter(state.original_entity_alternative_sq.c.entity_id == ext_entity_sq.c.id)
         .filter(
-            or_(ext_entity_sq.c.active == True, ext_entity_sq.c.active == None),
+            state.original_entity_alternative_sq.c.alternative_id.in_(state.alternatives),
+            state.original_entity_alternative_sq.c.entity_id == ext_entity_sq.c.id,
         )
         .subquery()
     )
@@ -253,13 +290,9 @@ def _make_alternative_filtered_entity_element_sq(db_map, state):
     element_sq = ext_entity_sq.alias()
     return (
         db_map.query(state.original_entity_element_sq)
-        .filter(state.original_entity_element_sq.c.entity_id == entity_sq.c.id)
-        .filter(state.original_entity_element_sq.c.element_id == element_sq.c.id)
         .filter(
-            or_(entity_sq.c.active == True, entity_sq.c.active == None),
-        )
-        .filter(
-            or_(element_sq.c.active == True, and_(element_sq.c.active == None, element_sq.c.active_by_default == True)),
+            state.original_entity_element_sq.c.entity_id == entity_sq.c.id,
+            state.original_entity_element_sq.c.element_id == element_sq.c.id,
         )
         .subquery()
     )
@@ -284,11 +317,6 @@ def _make_alternative_filtered_entity_sq(db_map, state):
         ext_entity_sq.c.name,
         ext_entity_sq.c.description,
         ext_entity_sq.c.commit_id,
-    ).filter(
-        or_(
-            ext_entity_sq.c.active == True,
-            and_(ext_entity_sq.c.active == None, ext_entity_sq.c.active_by_default == True),
-        ),
     )
     return filter_by_active_elements(db_map, filtered_by_activity, ext_entity_sq).subquery()
 
@@ -310,22 +338,8 @@ def _make_alternative_filtered_entity_group_sq(db_map, state):
     return (
         db_map.query(state.original_entity_group_sq)
         .filter(
-            and_(
-                state.original_entity_group_sq.c.entity_id == ext_entity_sq1.c.id,
-                or_(
-                    ext_entity_sq1.c.active == True,
-                    and_(ext_entity_sq1.c.active == None, ext_entity_sq1.c.active_by_default == True),
-                ),
-            )
-        )
-        .filter(
-            and_(
-                state.original_entity_group_sq.c.member_id == ext_entity_sq2.c.id,
-                or_(
-                    ext_entity_sq2.c.active == True,
-                    and_(ext_entity_sq2.c.active == None, ext_entity_sq2.c.active_by_default == True),
-                ),
-            )
+            state.original_entity_group_sq.c.entity_id == ext_entity_sq1.c.id,
+            state.original_entity_group_sq.c.member_id == ext_entity_sq2.c.id,
         )
         .subquery()
     )

--- a/tests/filters/test_alternative_filter.py
+++ b/tests/filters/test_alternative_filter.py
@@ -179,6 +179,26 @@ class TestAlternativeFilter(AssertSuccessTestCase):
             scenario_alternatives = db_map.query(db_map.scenario_alternative_sq).all()
             self.assertEqual(len(scenario_alternatives), 0)
 
+    def test_filters_entity_by_another_alternative_than_its_entity_alternative(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(db_map.add_entity_class_item(name="Cat", active_by_default=True))
+            self._assert_success(db_map.add_entity_item(name="Felix", entity_class_name="Cat"))
+            self._assert_success(db_map.add_alternative_item(name="Other"))
+            self._assert_success(
+                db_map.add_entity_alternative_item(
+                    entity_class_name="Cat",
+                    entity_byname=("Felix",),
+                    alternative_name="Base",
+                    active=True,
+                )
+            )
+            db_map.commit_session("Add stuff.")
+            config = alternative_filter_config(["Other"])
+            alternative_filter_from_dict(db_map, config)
+            entities = db_map.query(db_map.entity_sq).all()
+            self.assertEqual(len(entities), 1)
+            self.assertCountEqual([e.name for e in entities], ["Felix"])
+
     def test_filters_entities_in_class_thats_active_by_default(self):
         with DatabaseMapping("sqlite://", create=True) as db_map:
             self._assert_success(db_map.add_entity_class_item(name="ActiveByDefault", active_by_default=True))

--- a/tests/filters/test_alternative_filter.py
+++ b/tests/filters/test_alternative_filter.py
@@ -119,9 +119,9 @@ class TestAlternativeFilter(AssertSuccessTestCase):
             config = alternative_filter_config(["new@2005-05-05T22:23:24", "new@2023-23-23T11:12:13"])
             alternative_filter_from_dict(db_map, config)
             parameters = db_map.query(db_map.parameter_value_sq).all()
-            self.assertEqual(len(parameters), 2)
+            self.assertEqual(len(parameters), 1)
             values = {from_database(p.value, p.type) for p in parameters}
-            self.assertEqual(values, {23.0, 101.1})
+            self.assertEqual(values, {101.1})
 
     def test_filters_alternatives(self):
         with DatabaseMapping("sqlite://", create=True) as db_map:
@@ -179,7 +179,7 @@ class TestAlternativeFilter(AssertSuccessTestCase):
             scenario_alternatives = db_map.query(db_map.scenario_alternative_sq).all()
             self.assertEqual(len(scenario_alternatives), 0)
 
-    def test_filters_entity_by_another_alternative_than_its_entity_alternative(self):
+    def test_filters_active_by_default_entity_by_another_alternative_than_its_entity_alternative(self):
         with DatabaseMapping("sqlite://", create=True) as db_map:
             self._assert_success(db_map.add_entity_class_item(name="Cat", active_by_default=True))
             self._assert_success(db_map.add_entity_item(name="Felix", entity_class_name="Cat"))
@@ -198,6 +198,25 @@ class TestAlternativeFilter(AssertSuccessTestCase):
             entities = db_map.query(db_map.entity_sq).all()
             self.assertEqual(len(entities), 1)
             self.assertCountEqual([e.name for e in entities], ["Felix"])
+
+    def test_filters_inactive_by_default_entity_by_another_alternative_than_its_entity_alternative_not(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            self._assert_success(db_map.add_entity_class_item(name="Cat", active_by_default=False))
+            self._assert_success(db_map.add_entity_item(name="Felix", entity_class_name="Cat"))
+            self._assert_success(db_map.add_alternative_item(name="Other"))
+            self._assert_success(
+                db_map.add_entity_alternative_item(
+                    entity_class_name="Cat",
+                    entity_byname=("Felix",),
+                    alternative_name="Base",
+                    active=True,
+                )
+            )
+            db_map.commit_session("Add stuff.")
+            config = alternative_filter_config(["Other"])
+            alternative_filter_from_dict(db_map, config)
+            entities = db_map.query(db_map.entity_sq).all()
+            self.assertEqual(len(entities), 0)
 
     def test_filters_entities_in_class_thats_active_by_default(self):
         with DatabaseMapping("sqlite://", create=True) as db_map:


### PR DESCRIPTION
We had two issues:
- If an entity had an entry in entity_alternative and we filtered by another alternative, the entity was dropped by the filter regardless!
- We didn't handle the case where an entity is active in, say, alternative A, and inactive in alternative B, and the alternatives filter list included both alternatives. Here we solve it by assuming the alternatives in the list are sorted by increasing rank and apply the same logic as the scenario filter.

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
