### PR TITLE
Filter entity location with the alternatives and scenario filter

### DIFF
--- a/spinedb_api/db_mapping_query_mixin.py
+++ b/spinedb_api/db_mapping_query_mixin.py
@@ -392,7 +392,7 @@ class DatabaseMappingQueryMixin:
             :class:`~sqlalchemy.sql.Subquery`
         """
         if self._entity_location_sq is None:
-            self._entity_location_sq = self._subquery("entity_location")
+            self._entity_location_sq = self._make_entity_location_sq()
         return self._entity_location_sq
 
     @property
@@ -1301,6 +1301,15 @@ class DatabaseMappingQueryMixin:
         """
         return self._subquery("entity_element")
 
+    def _make_entity_location_sq(self):
+        """
+        Creates a subquery for entity-locations.
+
+        Returns:
+            Subquery: an entity_location subquery
+        """
+        return self._subquery("entity_location")
+
     def _make_entity_group_sq(self):
         """
         Creates a subquery for entity groups.
@@ -1442,6 +1451,17 @@ class DatabaseMappingQueryMixin:
         self._make_entity_element_sq = MethodType(method, self)
         self._clear_subqueries("entity_element")
 
+    def override_entity_location_sq_maker(self, method):
+        """
+        Overrides the function that creates the ``entity_location_sq`` property.
+
+        Args:
+            method (Callable): a function that accepts a :class:`DatabaseMapping` as its argument and
+                returns entity_location subquery as an :class:`Subquery` object
+        """
+        self._make_entity_location_sq = MethodType(method, self)
+        self._clear_subqueries("entity_location")
+
     def override_entity_group_sq_maker(self, method):
         """
         Overrides the function that creates the ``entity_group_sq`` property.
@@ -1533,6 +1553,11 @@ class DatabaseMappingQueryMixin:
         """Restores the original function that creates the ``entity_element_sq`` property."""
         self._make_entity_element_sq = MethodType(DatabaseMappingQueryMixin._make_entity_element_sq, self)
         self._clear_subqueries("entity_element")
+
+    def restore_entity_location_sq_maker(self):
+        """Restores the original function that creates the ``entity_location_sq`` property."""
+        self._make_entity_location_sq = MethodType(DatabaseMappingQueryMixin._make_entity_location_sq, self)
+        self._clear_subqueries("entity_location")
 
     def restore_parameter_definition_sq_maker(self):
         """Restores the original function that creates the ``parameter_definition_sq`` property."""

--- a/spinedb_api/filters/alternative_filter.py
+++ b/spinedb_api/filters/alternative_filter.py
@@ -44,6 +44,8 @@ def apply_alternative_filter_to_parameter_value_sq(db_map, alternatives):
     db_map.override_scenario_sq_maker(make_scenario_sq)
     make_entity_element_sq = partial(_make_alternative_filtered_entity_element_sq, state=state)
     db_map.override_entity_element_sq_maker(make_entity_element_sq)
+    make_entity_location_sq = partial(_make_alternative_filtered_entity_location_sq, state=state)
+    db_map.override_entity_location_sq_maker(make_entity_location_sq)
     make_entity_sq = partial(_make_alternative_filtered_entity_sq, state=state)
     db_map.override_entity_sq_maker(make_entity_sq)
     make_entity_alternative_sq = partial(_make_alternative_filtered_entity_alternative_sq, state=state)
@@ -130,6 +132,7 @@ class _AlternativeFilterState:
         self.original_entity_element_sq = db_map.entity_element_sq
         self.original_entity_alternative_sq = db_map.entity_alternative_sq
         self.original_entity_group_sq = db_map.entity_group_sq
+        self.original_entity_location_sq = db_map.entity_location_sq
         self.original_parameter_value_sq = db_map.parameter_value_sq
         self.original_scenario_sq = db_map.scenario_sq
         self.original_scenario_alternative_sq = db_map.scenario_alternative_sq
@@ -344,6 +347,26 @@ def _make_alternative_filtered_entity_group_sq(db_map, state):
             state.original_entity_group_sq.c.entity_id == ext_entity_sq1.c.id,
             state.original_entity_group_sq.c.member_id == ext_entity_sq2.c.id,
         )
+        .subquery()
+    )
+
+
+def _make_alternative_filtered_entity_location_sq(db_map, state):
+    """Returns an entity filtering subquery similar to :func:`DatabaseMapping.entity_location_sq`.
+
+    This function can be used as replacement for entity subquery maker in :class:`DatabaseMapping`.
+
+    Args:
+        db_map (DatabaseMapping): a database map
+        state (_AlternativeFilterState): a state bound to ``db_map``
+
+    Returns:
+        Alias: a subquery for entity_location filtered by selected alternatives
+    """
+    ext_entity_sq = _ext_entity_sq(db_map, state)
+    return (
+        db_map.query(state.original_entity_location_sq)
+        .filter(state.original_entity_location_sq.c.entity_id == ext_entity_sq.c.id)
         .subquery()
     )
 

--- a/spinedb_api/filters/scenario_filter.py
+++ b/spinedb_api/filters/scenario_filter.py
@@ -37,6 +37,8 @@ def apply_scenario_filter_to_subqueries(db_map, scenario):
     db_map.override_entity_sq_maker(make_entity_sq)
     make_entity_group_sq = partial(_make_scenario_filtered_entity_group_sq, state=state)
     db_map.override_entity_group_sq_maker(make_entity_group_sq)
+    make_entity_location_sq = partial(_make_scenario_filtered_entity_location_sq, state=state)
+    db_map.override_entity_location_sq_maker(make_entity_location_sq)
     make_entity_alternative_sq = partial(_make_scenario_filtered_entity_alternative_sq, state=state)
     db_map.override_entity_alternative_sq_maker(make_entity_alternative_sq)
     make_parameter_value_sq = partial(_make_scenario_filtered_parameter_value_sq, state=state)
@@ -131,6 +133,7 @@ class _ScenarioFilterState:
         self.original_entity_element_sq = db_map.entity_element_sq
         self.original_entity_alternative_sq = db_map.entity_alternative_sq
         self.original_entity_group_sq = db_map.entity_group_sq
+        self.original_entity_location_sq = db_map.entity_location_sq
         self.original_parameter_value_sq = db_map.parameter_value_sq
         self.original_scenario_sq = db_map.scenario_sq
         self.original_scenario_alternative_sq = db_map.scenario_alternative_sq
@@ -324,6 +327,26 @@ def _make_scenario_filtered_entity_group_sq(db_map, state):
             state.original_entity_group_sq.c.entity_id == ext_entity_sq1.c.id,
             state.original_entity_group_sq.c.member_id == ext_entity_sq2.c.id,
         )
+        .subquery()
+    )
+
+
+def _make_scenario_filtered_entity_location_sq(db_map, state):
+    """Returns an entity filtering subquery similar to :func:`DatabaseMapping.entity_location_sq`.
+
+    This function can be used as replacement for entity subquery maker in :class:`DatabaseMapping`.
+
+    Args:
+        db_map (DatabaseMapping): a database map
+        state (_AlternativeFilterState): a state bound to ``db_map``
+
+    Returns:
+        Alias: a subquery for entity_location filtered by selected scenario
+    """
+    ext_entity_sq = _ext_entity_sq(db_map, state)
+    return (
+        db_map.query(state.original_entity_location_sq)
+        .filter(state.original_entity_location_sq.c.entity_id == ext_entity_sq.c.id)
         .subquery()
     )
 

--- a/spinedb_api/spine_db_server.py
+++ b/spinedb_api/spine_db_server.py
@@ -438,6 +438,7 @@ class _DBWorker:
     def _do_clear_filters(self):
         self._db_map.restore_entity_sq_maker()
         self._db_map.restore_entity_element_sq_maker()
+        self._db_map.restore_entity_location_sq_maker()
         self._db_map.restore_entity_class_sq_maker()
         self._db_map.restore_parameter_definition_sq_maker()
         self._db_map.restore_parameter_value_sq_maker()

--- a/tests/filters/test_alternative_filter.py
+++ b/tests/filters/test_alternative_filter.py
@@ -218,6 +218,28 @@ class TestAlternativeFilter(AssertSuccessTestCase):
             entities = db_map.query(db_map.entity_sq).all()
             self.assertEqual(len(entities), 0)
 
+    def test_filters_entity_location(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            db_map.add_entity_class(name="Cat")
+            db_map.add_entity(name="Felix", entity_class_name="Cat")
+            db_map.add_entity_location(
+                entity_class_name="Cat",
+                entity_byname=("Felix",),
+                lat=0.0,
+                lon=0.0,
+                alt=0.0,
+                shape_name="foo",
+                shape_blob="bar",
+            )
+            db_map.add_entity_alternative(
+                entity_class_name="Cat", entity_byname=("Felix",), alternative_name="Base", active=False
+            )
+            db_map.commit_session("Add stuff.")
+            config = alternative_filter_config(["Base"])
+            alternative_filter_from_dict(db_map, config)
+            entity_locations = db_map.query(db_map.entity_location_sq).all()
+            self.assertEqual(len(entity_locations), 0)
+
     def test_filters_entities_in_class_thats_active_by_default(self):
         with DatabaseMapping("sqlite://", create=True) as db_map:
             self._assert_success(db_map.add_entity_class_item(name="ActiveByDefault", active_by_default=True))

--- a/tests/filters/test_scenario_filter.py
+++ b/tests/filters/test_scenario_filter.py
@@ -317,7 +317,6 @@ class DataBuilderTestCase(AssertSuccessTestCase):
 
 
 class TestScenarioFilter(DataBuilderTestCase):
-
     def test_scenario_filter(self):
         with TemporaryDirectory() as temp_dir:
             url = "sqlite:///" + str(Path(temp_dir, "db.sqlite"))
@@ -1276,6 +1275,30 @@ class TestScenarioFilter(DataBuilderTestCase):
                 self.assertEqual(len(entities), 1)
                 self.assertEqual(entities[0]["name"], "cube")
             db_map.engine.dispose()
+
+    def test_filters_entity_location(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            db_map.add_entity_class(name="Cat")
+            db_map.add_entity(name="Felix", entity_class_name="Cat")
+            db_map.add_entity_location(
+                entity_class_name="Cat",
+                entity_byname=("Felix",),
+                lat=0.0,
+                lon=0.0,
+                alt=0.0,
+                shape_name="foo",
+                shape_blob="bar",
+            )
+            db_map.add_entity_alternative(
+                entity_class_name="Cat", entity_byname=("Felix",), alternative_name="Base", active=False
+            )
+            db_map.add_scenario(name="scen")
+            db_map.add_scenario_alternative(scenario_name="scen", alternative_name="Base", rank=1)
+            db_map.commit_session("Add stuff.")
+            config = scenario_filter_config("scen")
+            scenario_filter_from_dict(db_map, config)
+            entity_locations = db_map.query(db_map.entity_location_sq).all()
+            self.assertEqual(len(entity_locations), 0)
 
 
 class TestScenarioFilterUtils(DataBuilderTestCase):


### PR DESCRIPTION
No issue related. We just missed filtering the entity_location table when introducing it. There's so much stuff to do when introducing a new table that we can easily miss this kind of stuff - perhaps it is a good idea to create a checklist for this purposes?

## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black & isort
- [ ] Unit tests pass
