### PR TITLE
Restore returning multiple parameter values for alternatives filter

### DIFF
--- a/spinedb_api/filters/alternative_filter.py
+++ b/spinedb_api/filters/alternative_filter.py
@@ -420,7 +420,7 @@ def _make_alternative_filtered_parameter_value_sq(db_map, state):
     ext_entity_sq = _ext_entity_sq(db_map, state)
     filtered_by_activity = (
         db_map.query(subquery)
-        .outerjoin(ext_entity_sq, subquery.c.entity_id == ext_entity_sq.c.id)
-        .filter(subquery.c.alternative_id.in_(state.alternatives), ext_entity_sq.c.id != None)
+        .join(ext_entity_sq, subquery.c.entity_id == ext_entity_sq.c.id)
+        .filter(subquery.c.alternative_id.in_(state.alternatives))
     )
     return filter_by_active_elements(db_map, filtered_by_activity, ext_entity_sq).subquery()

--- a/spinedb_api/filters/alternative_filter.py
+++ b/spinedb_api/filters/alternative_filter.py
@@ -416,28 +416,11 @@ def _make_alternative_filtered_parameter_value_sq(db_map, state):
     Returns:
         Alias: a subquery for parameter value filtered by selected alternatives
     """
+    subquery = state.original_parameter_value_sq
     ext_entity_sq = _ext_entity_sq(db_map, state)
-    rank_alt_sq = _rank_alternative_sq(state.alternatives)
-    ext_parameter_value_sq = (
-        db_map.query(
-            state.original_parameter_value_sq,
-            func.row_number()
-            .over(
-                partition_by=[
-                    state.original_parameter_value_sq.c.parameter_definition_id,
-                    state.original_parameter_value_sq.c.entity_id,
-                ],
-                order_by=desc(rank_alt_sq.c.rank),
-            )  # the one with the highest rank will have row_number equal to 1, so it will 'win' in the filter below
-            .label("desc_rank_row_number"),
-        ).filter(
-            state.original_parameter_value_sq.c.entity_id == ext_entity_sq.c.id,
-            state.original_parameter_value_sq.c.alternative_id == rank_alt_sq.c.alternative_id,
-        )
-    ).subquery()
-    filtered_by_entity_activity = (
-        db_map.query(ext_parameter_value_sq)
-        .filter(ext_parameter_value_sq.c.desc_rank_row_number == 1)
-        .outerjoin(ext_entity_sq, ext_parameter_value_sq.c.entity_id == ext_entity_sq.c.id)
+    filtered_by_activity = (
+        db_map.query(subquery)
+        .outerjoin(ext_entity_sq, subquery.c.entity_id == ext_entity_sq.c.id)
+        .filter(subquery.c.alternative_id.in_(state.alternatives), ext_entity_sq.c.id != None)
     )
-    return filter_by_active_elements(db_map, filtered_by_entity_activity, ext_entity_sq).subquery()
+    return filter_by_active_elements(db_map, filtered_by_activity, ext_entity_sq).subquery()

--- a/tests/filters/test_alternative_filter.py
+++ b/tests/filters/test_alternative_filter.py
@@ -119,9 +119,9 @@ class TestAlternativeFilter(AssertSuccessTestCase):
             config = alternative_filter_config(["new@2005-05-05T22:23:24", "new@2023-23-23T11:12:13"])
             alternative_filter_from_dict(db_map, config)
             parameters = db_map.query(db_map.parameter_value_sq).all()
-            self.assertEqual(len(parameters), 1)
+            self.assertEqual(len(parameters), 2)
             values = {from_database(p.value, p.type) for p in parameters}
-            self.assertEqual(values, {101.1})
+            self.assertEqual(values, {23.0, 101.1})
 
     def test_filters_alternatives(self):
         with DatabaseMapping("sqlite://", create=True) as db_map:


### PR DESCRIPTION
We can't filter the parameter_value subquery by only the winning alternative because there are some use cases where the user effectively wants multiple values returned


## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black & isort
- [ ] Unit tests pass
