### PR TITLE
Fix closing_spine_db_server() context manager

### DIFF
--- a/spinedb_api/spine_db_server.py
+++ b/spinedb_api/spine_db_server.py
@@ -706,7 +706,7 @@ def closing_spine_db_server(
     db_url: str,
     upgrade: bool = False,
     memory: bool = False,
-    ordering=Optional[OrderingDict],
+    ordering: Optional[OrderingDict] = None,
     server_manager_queue: Optional[MPQueue] = None,
 ):
     """Creates a Spine DB server.
@@ -728,6 +728,13 @@ def closing_spine_db_server(
         server_manager_queue = mngr.queue
     else:
         mngr = None
+    if ordering is None:
+        ordering = {
+            "id": 0,
+            "current": 0,
+            "precursors": set(),
+            "part_count": 0,
+        }
     server_address = start_spine_db_server(server_manager_queue, db_url, memory=memory, ordering=ordering)
     host, port = server_address
     try:

--- a/tests/filters/test_scenario_filter.py
+++ b/tests/filters/test_scenario_filter.py
@@ -19,7 +19,6 @@ from spinedb_api import (
     append_filter_config,
     apply_filter_stack,
     apply_scenario_filter_to_subqueries,
-    export_data,
     from_database,
     to_database,
 )


### PR DESCRIPTION
We accidentally assigned the type of a function parameter to the parameter.

No associated issue.

## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black & isort
- [ ] Unit tests pass
