### PR TITLE
Handle broken references in DB

### DIFF
--- a/spinedb_api/db_mapping.py
+++ b/spinedb_api/db_mapping.py
@@ -1054,20 +1054,18 @@ class DatabaseMapping(DatabaseMappingQueryMixin, DatabaseMappingCommitMixin, Dat
         # Add items first
         for x in chunk:
             item, new = mapped_table.add_item_from_db(x, not is_db_dirty)
+            if item is None:
+                continue
             if new:
                 new_items.append(item)
             else:
                 item.handle_refetch()
-                items.append(item)
+            items.append(item)
         # Once all items are added, add the unique key values
         # Otherwise items that refer to other items that come later in the query will be seen as corrupted
         for item in new_items:
             mapped_table.add_unique(item)
-            if not item.become_referrer():
-                mapped_table.remove_item(item)
-                mapped_table.remove_unique(item)
-                continue
-            items.append(item)
+            item.become_referrer()
         return items
 
     def fetch_more(self, item_type, offset=0, limit=None, **kwargs):

--- a/spinedb_api/db_mapping.py
+++ b/spinedb_api/db_mapping.py
@@ -1058,12 +1058,16 @@ class DatabaseMapping(DatabaseMappingQueryMixin, DatabaseMappingCommitMixin, Dat
                 new_items.append(item)
             else:
                 item.handle_refetch()
-            items.append(item)
+                items.append(item)
         # Once all items are added, add the unique key values
         # Otherwise items that refer to other items that come later in the query will be seen as corrupted
         for item in new_items:
             mapped_table.add_unique(item)
-            item.become_referrer()
+            if not item.become_referrer():
+                mapped_table.remove_item(item)
+                mapped_table.remove_unique(item)
+                continue
+            items.append(item)
         return items
 
     def fetch_more(self, item_type, offset=0, limit=None, **kwargs):

--- a/spinedb_api/db_mapping.py
+++ b/spinedb_api/db_mapping.py
@@ -1055,6 +1055,7 @@ class DatabaseMapping(DatabaseMappingQueryMixin, DatabaseMappingCommitMixin, Dat
         for x in chunk:
             item, new = mapped_table.add_item_from_db(x, not is_db_dirty)
             if item is None:
+                # Item has a broken reference from DB
                 continue
             if new:
                 new_items.append(item)

--- a/spinedb_api/db_mapping_base.py
+++ b/spinedb_api/db_mapping_base.py
@@ -927,7 +927,6 @@ class MappedItemBase(dict):
             except KeyError:
                 continue
             ref.add_weak_referrer(self)
-        return True
 
     def cascade_restore(self, source: Optional[object] = None) -> None:
         """Restores this item (if removed) and all its referrers in cascade.

--- a/spinedb_api/db_mapping_base.py
+++ b/spinedb_api/db_mapping_base.py
@@ -434,7 +434,9 @@ class MappedTable(dict):
             except ValueError:
                 pass
 
-    def _make_and_add_item(self, item: Union[dict, MappedItemBase], ignore_polishing_errors: bool) -> MappedItemBase:
+    def _make_and_add_item(
+        self, item: Union[dict, MappedItemBase], ignore_polishing_errors: bool, check_invalid_refs: bool = False
+    ) -> MappedItemBase:
         if not isinstance(item, MappedItemBase):
             item = self._db_map.make_item(self.item_type, **item)
             try:
@@ -442,8 +444,7 @@ class MappedTable(dict):
             except SpineDBAPIError as error:
                 if not ignore_polishing_errors:
                     raise error
-            invalid_key = item.first_invalid_key()
-            if invalid_key is not None:
+            if check_invalid_refs and item.first_invalid_key() is not None:
                 return None
         db_id = item.pop("id", None) if item.has_valid_id else None
         item["id"] = new_id = TempId.new_unique(self.item_type, self._temp_id_lookup)
@@ -462,7 +463,7 @@ class MappedTable(dict):
                 if is_db_clean or self._same_item(mapped_item.db_equivalent(), item):
                     return mapped_item, False
                 mapped_item.handle_id_steal()
-            mapped_item = self._make_and_add_item(item, ignore_polishing_errors=True)
+            mapped_item = self._make_and_add_item(item, ignore_polishing_errors=True, check_invalid_refs=True)
             if mapped_item is None:
                 # Item has a broken reference in the DB, nothing to do here
                 return None, None


### PR DESCRIPTION
Looks like historically we have allowed our DBs to hold broken references - basically a failure to cascade remove in any of our multiple API versions.

The current API raises a RuntimeError when this occurs but to me it seems so common, that we should better handle it. And the way I am handling it here is to just skip the record with the broken reference. The implementation at the moment goes a bit in circles by adding the item and then removing it if a broken ref is found. This is because to be able to check references at the moment we need some side effects that happen when we add the item.

**Edit**: just fixed the implementation so it doesn't go on circles anymore. We validate the references before adding the item to the in-memory mapping - it was possible.


## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black & isort
- [ ] Unit tests pass
