### PR TITLE
Add 'ignorable' flag to import mappings

### DIFF
--- a/tests/import_mapping/test_generator.py
+++ b/tests/import_mapping/test_generator.py
@@ -1037,6 +1037,47 @@ class TestGetMappedData(unittest.TestCase):
             },
         )
 
+    def test_missing_entity_alternative_does_not_prevent_importing_of_values(self):
+        data_source = iter(
+            [
+                [None, None, "Whether unit is included", "In MW"],
+                ["alternative", "unit", "Entity Alternative", "existing"],
+                ["Fail", "Wind_plant", None, 150],
+                ["Succeed", "Wind_plant", True, 200],
+            ]
+        )
+
+        mappings = [
+            [
+                {"map_type": "EntityClass", "position": "hidden", "value": "unit"},
+                {"map_type": "Entity", "position": 1},
+                {"map_type": "EntityMetadata", "position": "hidden"},
+                {"map_type": "Alternative", "position": 0},
+                {"map_type": "EntityAlternativeActivity", "position": 2},
+                {"map_type": "ParameterDefinition", "position": -2},
+                {"map_type": "ParameterValueMetadata", "position": "hidden"},
+                {"map_type": "ParameterValue", "position": "hidden"},
+            ]
+        ]
+        convert_function_specs = {0: "string", 1: "string", 2: "boolean", 3: "float"}
+        convert_functions = {column: value_to_convert_spec(spec) for column, spec in convert_function_specs.items()}
+        mapped_data, errors = get_mapped_data(data_source, mappings, column_convert_fns=convert_functions)
+        self.assertEqual(errors, [])
+        self.assertEqual(
+            mapped_data,
+            {
+                "alternatives": {"Succeed", "Fail"},
+                "entities": [("unit", "Wind_plant")],
+                "entity_alternatives": [("unit", ("Wind_plant",), "Succeed", True)],
+                "entity_classes": [("unit",)],
+                "parameter_definitions": [("unit", "existing")],
+                "parameter_values": [
+                    ["unit", "Wind_plant", "existing", 150.0, "Fail"],
+                    ["unit", "Wind_plant", "existing", 200.0, "Succeed"],
+                ],
+            },
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The new flag works analogously to export mappings: if `True`, child mappings will get processed even when the imported value is None. Otherwise we skip the children.

Fixes spine-tools/Spine-Toolbox#3165

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [ ] Unit tests pass
