### PR TITLE
Fix scenario filter so unrelated alternatives do not matter

### DIFF
--- a/spinedb_api/filters/scenario_filter.py
+++ b/spinedb_api/filters/scenario_filter.py
@@ -201,34 +201,25 @@ def _ext_entity_sq(db_map, state):
             db_map.entity_class_sq.c.active_by_default,
             state.original_scenario_alternative_sq.c.scenario_id,
         )
+        .filter(state.original_entity_sq.c.class_id == db_map.entity_class_sq.c.id)
         .outerjoin(
             state.original_entity_alternative_sq,
             state.original_entity_sq.c.id == state.original_entity_alternative_sq.c.entity_id,
         )
-        .outerjoin(db_map.entity_class_sq, state.original_entity_sq.c.class_id == db_map.entity_class_sq.c.id)
         .outerjoin(
             state.original_scenario_alternative_sq,
             state.original_entity_alternative_sq.c.alternative_id
             == state.original_scenario_alternative_sq.c.alternative_id,
-        )
-        .filter(
-            or_(
-                state.original_scenario_alternative_sq.c.scenario_id == None,
-                state.original_scenario_alternative_sq.c.scenario_id == state.scenario_id,
-            ),
-            or_(
-                state.original_entity_alternative_sq.c.alternative_id == None,
-                state.original_entity_alternative_sq.c.alternative_id
-                == state.original_scenario_alternative_sq.c.alternative_id,
-                db_map.entity_class_sq.c.active_by_default == True,
-            ),
         )
     ).subquery()
     return (
         db_map.query(entity_sq)
         .filter(
             entity_sq.c.desc_rank_row_number == 1,
-            or_(entity_sq.c.active == True, and_(entity_sq.c.active == None, entity_sq.c.active_by_default == True)),
+            or_(
+                and_(entity_sq.c.scenario_id == state.scenario_id, entity_sq.c.active == True),
+                and_(entity_sq.c.scenario_id == None, entity_sq.c.active_by_default == True),
+            ),
         )
         .subquery()
     )

--- a/tests/filters/test_scenario_filter.py
+++ b/tests/filters/test_scenario_filter.py
@@ -53,9 +53,7 @@ class TestScenarioFilterInMemory(AssertSuccessTestCase):
             db_map.add_scenario_alternative(scenario_name="other_scen", alternative_name="alt", rank=2)
             db_map.add_scenario_alternative(scenario_name="other_scen", alternative_name="Base", rank=1)
             db_map.commit_session("Add data.")
-            # Filter by the first scenario
             apply_filter_stack(db_map, [scenario_filter_config("scen")])
-            # The entity should show up
             entities = db_map.query(db_map.wide_entity_sq).all()
             self.assertEqual(len(entities), 1)
             self.assertEqual(entities[0].name, "Felix")

--- a/tests/filters/test_scenario_filter.py
+++ b/tests/filters/test_scenario_filter.py
@@ -33,6 +33,25 @@ from tests.mock_helpers import AssertSuccessTestCase
 
 
 class TestScenarioFilterInMemory(AssertSuccessTestCase):
+    def test_filter_entity_inactive_but_in_unrelated_alternative(self):
+        with DatabaseMapping("sqlite://", create=True) as db_map:
+            db_map.add_entity_class(name="cat", active_by_default=True)
+            db_map.add_entity(name="Felix", entity_class_name="cat")
+            db_map.add_alternative(name="alt")
+            # Disable entity in alt
+            db_map.add_entity_alternative(
+                alternative_name="alt", entity_class_name="cat", entity_byname=("Felix",), active=False
+            )
+            # Create scenario only with Base, not including alt
+            db_map.add_scenario(name="scen")
+            db_map.add_scenario_alternative(scenario_name="scen", alternative_name="Base", rank=1)
+            db_map.commit_session("Add data.")
+            apply_filter_stack(db_map, [scenario_filter_config("scen")])
+            # The entity should show up
+            entities = db_map.query(db_map.wide_entity_sq).all()
+            self.assertEqual(len(entities), 1)
+            self.assertEqual(entities[0].name, "Felix")
+
     def test_filter_entities_with_default_activity_only(self):
         with DatabaseMapping("sqlite://", create=True) as db_map:
             self._assert_success(db_map.add_entity_class_item(name="visible", active_by_default=True))

--- a/tests/filters/test_scenario_filter.py
+++ b/tests/filters/test_scenario_filter.py
@@ -37,15 +37,23 @@ class TestScenarioFilterInMemory(AssertSuccessTestCase):
         with DatabaseMapping("sqlite://", create=True) as db_map:
             db_map.add_entity_class(name="cat", active_by_default=True)
             db_map.add_entity(name="Felix", entity_class_name="cat")
+            db_map.add_entity(name="Tom", entity_class_name="cat")
             db_map.add_alternative(name="alt")
-            # Disable entity in alt
+            db_map.add_alternative(name="other_alt")
             db_map.add_entity_alternative(
                 alternative_name="alt", entity_class_name="cat", entity_byname=("Felix",), active=False
             )
-            # Create scenario only with Base, not including alt
+            db_map.add_entity_alternative(
+                alternative_name="Base", entity_class_name="cat", entity_byname=("Tom",), active=False
+            )
+
             db_map.add_scenario(name="scen")
             db_map.add_scenario_alternative(scenario_name="scen", alternative_name="Base", rank=1)
+            db_map.add_scenario(name="other_scen")
+            db_map.add_scenario_alternative(scenario_name="other_scen", alternative_name="alt", rank=2)
+            db_map.add_scenario_alternative(scenario_name="other_scen", alternative_name="Base", rank=1)
             db_map.commit_session("Add data.")
+            # Filter by the first scenario
             apply_filter_stack(db_map, [scenario_filter_config("scen")])
             # The entity should show up
             entities = db_map.query(db_map.wide_entity_sq).all()


### PR DESCRIPTION
There was a bug where if an entity was disabled in an alternative, and then we filtered by a scenario not including that alternative, somehow the entity was filtered out.

But that alternative shouldn't matter, only active_by_default should matter in this case because the alternative is not in the scenario.

## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black & isort
- [ ] Unit tests pass
