### PR TITLE
Restore scenario creation with execution filter

### DIFF
--- a/spinedb_api/filters/execution_filter.py
+++ b/spinedb_api/filters/execution_filter.py
@@ -153,5 +153,9 @@ def _create_import_alternative(db_map, state):
     scenarios = state.scenarios
     timestamp = state.timestamp
     sep = "__" if scenarios else ""
-    db_map._import_alternative_name = f"{'_'.join(scenarios)}{sep}{execution_item}@{timestamp}"
-    db_map.add_item("alternative", name=db_map._import_alternative_name)
+    db_map._import_alternative_name = alt_name = f"{'_'.join(scenarios)}{sep}{execution_item}@{timestamp}"
+    db_map.add_alternative(name=alt_name)
+    for scen_name in scenarios:
+        scen = db_map.add_scenario(name=scen_name)
+        rank = len(scen["sorted_scenario_alternatives"]) + 1  # ranks are 1-based
+        db_map.add_scenario_alternative(scenario_name=scen_name, alternative_name=alt_name, rank=rank)

--- a/tests/filters/test_execution_filter.py
+++ b/tests/filters/test_execution_filter.py
@@ -26,6 +26,19 @@ class TestExecutionFilter(unittest.TestCase):
             self.assertEqual(alternative_name, "low_on_steam_wasting_my_time__Importing importer@2023-09-06T01:23:45")
             alternatives = {item["name"] for item in db_map.mapped_table("alternative").valid_values()}
             self.assertIn(alternative_name, alternatives)
+            scenarios = {item["name"] for item in db_map.mapped_table("scenario").valid_values()}
+            self.assertEqual(scenarios, {"low_on_steam", "wasting_my_time"})
+            scenario_alternatives = {
+                (item["scenario_name"], item["alternative_name"], item["rank"])
+                for item in db_map.mapped_table("scenario_alternative").valid_values()
+            }
+            self.assertEqual(
+                scenario_alternatives,
+                {
+                    ("low_on_steam", "low_on_steam_wasting_my_time__Importing importer@2023-09-06T01:23:45", 1),
+                    ("wasting_my_time", "low_on_steam_wasting_my_time__Importing importer@2023-09-06T01:23:45", 1),
+                },
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is to support a use case where the output DB from an execution is sent to another tool to postprocess the results of each execution separately in parallel.
This cannot be achieved as cleanly with the alternatives filter.

No issue related.

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
