### PR TITLE
Add unique constraints to entity_class and entity tables

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "GDX2py >=2.2.0",
     "ijson >=3.1.4",
     "chardet >=4.0.0",
-    "PyMySQL >=1.0.2",
+    "PyMySQL[rsa] >=1.0.2",
     "psycopg2-binary",
     "pyarrow >= 19.0",
     "pandas >= 2.2.3",

--- a/spinedb_api/alembic/versions/e9f2c2330cf8_fix_unique_constraints_in_entity_and_.py
+++ b/spinedb_api/alembic/versions/e9f2c2330cf8_fix_unique_constraints_in_entity_and_.py
@@ -1,0 +1,26 @@
+"""fix unique constraints in entity and entity_class tables
+
+Revision ID: e9f2c2330cf8
+Revises: 91f1f55aa972
+Create Date: 2025-10-06 10:11:27.100719
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "e9f2c2330cf8"
+down_revision = "91f1f55aa972"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("entity_class") as batch_op:
+        batch_op.create_unique_constraint(None, ["name"])
+    with op.batch_alter_table("entity") as batch_op:
+        batch_op.create_unique_constraint(None, ["id", "class_id"])
+
+
+def downgrade():
+    pass

--- a/tests/test_DatabaseMapping.py
+++ b/tests/test_DatabaseMapping.py
@@ -5976,8 +5976,12 @@ class TestDatabaseMappingConcurrent(AssertSuccessTestCase):
                     widget_class = shadow_db_map.get_entity_class_item(name="Widget")
                     widget_class.update(name="NotAWidget")
                     gadget_class = shadow_db_map.get_entity_class_item(name="Gadget")
-                    gadget_class.update(name="Widget")
+                    gadget_class.update(name="NotAGadget")
+                    shadow_db_map.commit_session(
+                        "Rename Widget and Gadget to something else to circumvent unique constraints."
+                    )
                     widget_class.update(name="Gadget")
+                    gadget_class.update(name="Widget")
                     shadow_db_map.commit_session("Swap Widget and Gadget to cause mayhem.")
                 shadow_db_map.engine.dispose()
                 db_map.refresh_session()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -82,7 +82,7 @@ class TestRemoveCredentialsFromUrl(unittest.TestCase):
 class TestGetHeadAlembicVersion(unittest.TestCase):
     def test_returns_latest_version(self):
         # This test must be updated each time new migration script is added.
-        self.assertEqual(get_head_alembic_version(), "91f1f55aa972")
+        self.assertEqual(get_head_alembic_version(), "e9f2c2330cf8")
 
 
 class TestStringToBool(unittest.TestCase):


### PR DESCRIPTION
`entity_element`'s `entity_class_id` column has a foreign key constraint referring to `class_id` in `entity` table. However, `class_id` did not have unique constraint which, according to recent MySQL versions, is non-standard and not supported. This adds the required unique constraint to `entity` table.

Additionally, `entity_class` table was missing a unique constraint for the `name` column. This PR adds that constraint as well.

Corresponding Alembic migration has been implemented, too.

Resolves #586, #548

## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black & isort
- [ ] Unit tests pass
